### PR TITLE
fix(shared): pointer l’entrée de @mesh/shared vers `./src/index.ts` pour Vitest

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,8 +2,11 @@
   "name": "@mesh/shared",
   "version": "0.1.0",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./src/index.ts",
+  "module": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run"


### PR DESCRIPTION
### Motivation
- Vitest (via Vite) ne pouvait pas résoudre l’entrée de `@mesh/shared` car `package.json` pointait vers `dist/` non généré en CI, ce qui empêche Vite/Vitest d’entrer dans le package.

### Description
- Mise à jour de `packages/shared/package.json` pour définir `main` et `module` sur `./src/index.ts` et ajout d’un champ `exports` pointant vers `./src/index.ts`.
- Suppression de la référence `types` vers `dist/index.d.ts` afin d’éviter des résolutions TypeScript cassées tant que `dist/` n’est pas produit.

### Testing
- Exécution de la suite de tests via `pnpm test`, qui a réussi (Vitest: `Test Files 1 passed`, `Tests 1 passed | 5 todo`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990bfe6311c83218e877b6abc5565e3)