### PR TITLE
chore: switch mesh packages back to dist ESM outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "version": "0.1.0",
   "scripts": {
     "build": "pnpm -r build",
-    "test": "pnpm --filter @mesh/conformance-tests test",
-    "test:all": "pnpm -r test"
+    "test": "pnpm -r build && pnpm --filter @mesh/conformance-tests test",
+    "test:all": "pnpm -r test",
+    "smoke:node": "node ./scripts/smoke-node.mjs"
   },
   "devDependencies": {
     "typescript": "^5.6.3",

--- a/packages/conformance-harness/package.json
+++ b/packages/conformance-harness/package.json
@@ -2,8 +2,8 @@
   "name": "@mesh/conformance-harness",
   "version": "0.1.0",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run --passWithNoTests"
@@ -11,5 +11,12 @@
   "dependencies": {
     "@mesh/shared": "workspace:*",
     "@mesh/eventstore-local": "workspace:*"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   }
 }

--- a/packages/conformance-harness/tsconfig.json
+++ b/packages/conformance-harness/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  }
 }

--- a/packages/conformance-tests/package.json
+++ b/packages/conformance-tests/package.json
@@ -2,8 +2,8 @@
   "name": "@mesh/conformance-tests",
   "version": "0.1.0",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run"
@@ -11,5 +11,12 @@
   "dependencies": {
     "@mesh/conformance-harness": "workspace:*",
     "@mesh/shared": "workspace:*"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   }
 }

--- a/packages/conformance-tests/tsconfig.json
+++ b/packages/conformance-tests/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  }
 }

--- a/packages/eventstore-local/package.json
+++ b/packages/eventstore-local/package.json
@@ -2,13 +2,20 @@
   "name": "@mesh/eventstore-local",
   "version": "0.1.0",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "@mesh/shared": "workspace:*"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   }
 }

--- a/packages/eventstore-local/tsconfig.json
+++ b/packages/eventstore-local/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  }
 }

--- a/packages/kernel-minimal/package.json
+++ b/packages/kernel-minimal/package.json
@@ -2,8 +2,8 @@
   "name": "@mesh/kernel-minimal",
   "version": "0.1.0",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run --passWithNoTests"
@@ -11,5 +11,12 @@
   "dependencies": {
     "@mesh/shared": "workspace:*",
     "@mesh/eventstore-local": "workspace:*"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   }
 }

--- a/packages/kernel-minimal/tsconfig.json
+++ b/packages/kernel-minimal/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,13 +2,17 @@
   "name": "@mesh/shared",
   "version": "0.1.0",
   "type": "module",
-  "main": "./src/index.ts",
-  "module": "./src/index.ts",
+  "main": "./dist/index.js",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run"
-  }
+  },
+  "types": "./dist/index.d.ts"
 }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  }
 }

--- a/scripts/smoke-node.mjs
+++ b/scripts/smoke-node.mjs
@@ -1,0 +1,12 @@
+const modules = [
+  '../packages/shared/dist/index.js',
+  '../packages/eventstore-local/dist/index.js',
+  '../packages/kernel-minimal/dist/index.js',
+  '../packages/conformance-harness/dist/index.js'
+];
+
+for (const spec of modules) {
+  const mod = await import(new URL(spec, import.meta.url));
+  if (!mod || typeof mod !== 'object') throw new Error(`Failed to import ${spec}`);
+  console.log(`ok: ${spec}`);
+}


### PR DESCRIPTION
### Motivation
- Restore packages from a "test-only" state so runtime Node imports resolve against compiled ESM outputs in `./dist` instead of `src`.
- Make the monorepo build-first so conformance tests run against real compiled artifacts.
- Add a lightweight runtime smoke check to catch packaging/exports issues early.

### Description
- Updated every `@mesh/*` package manifest to expose ESM entrypoints from `./dist/*` via `main`, `types`, and `exports` and removed any `src/*.ts` entries.
- Ensured each package has a `build` script (`tsc -p tsconfig.json`) and added `rootDir: "src"` / `outDir: "dist"` to each package `tsconfig.json`.
- Updated the root `package.json` `test` script to run `pnpm -r build` before running the conformance tests and added a `smoke:node` script plus `scripts/smoke-node.mjs` to perform a simple runtime import check.
- Did not add `paths` to `tsconfig.base.json` because the workspace build succeeds without it.

### Testing
- Ran `pnpm install` and the install completed successfully.
- Ran `pnpm -r build` and all packages compiled successfully.
- Ran `pnpm test` (which runs the repo build first) and the conformance test suite passed.
- Ran `pnpm smoke:node` and the smoke imports succeeded for all built package entrypoints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990c327b5248321b0a7c1b409bd57e2)