### PR TITLE
ci: align conformance workflow to pnpm 10

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -14,7 +14,7 @@ jobs:
           node-version: lts/*
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
       - name: Install
         run: pnpm install --frozen-lockfile
       - name: Enforce conformance test hygiene


### PR DESCRIPTION
### Motivation
- Corriger l’échec CI provoqué par `Cannot find module @rollup/rollup-linux-x64-gnu` au démarrage de Vitest en alignant l’outil `pnpm` utilisé en CI avec la version attendue par le lockfile; la dépendance racine qui tirait Rollup est `vitest -> vite -> rollup` (et `vitest -> vite -> rollup -> @rollup/rollup-linux-x64-gnu`).

### Description
- Met à jour `.github/workflows/conformance.yml` pour utiliser `pnpm/action-setup@v4` avec `version: 10` au lieu de `9` afin que `pnpm install --frozen-lockfile` en CI résolve correctement les dépendances optionnelles natives (ex. `@rollup/rollup-linux-x64-gnu`).

### Testing
- Exécuté `pnpm why rollup` et `pnpm why @rollup/rollup-linux-x64-gnu` pour diagnostiquer la chaîne de dépendances, puis validé `pnpm install --frozen-lockfile`, `pnpm -r build` et `pnpm test` qui ont tous réussi (les suites Vitest sont passées).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990dea326988321b57890e8fbe35603)