### PR TITLE
Rendre les artefacts de conformance déterministes

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -32,6 +32,7 @@ jobs:
           path: |
             artifacts/conformance-evidence.md
             artifacts/conformance-evidence.json
+            artifacts/conformance-evidence.runtime.json
             **/*.log
             **/*dump*.json
             **/vitest*.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+artifacts/conformance-evidence.runtime.*

--- a/artifacts/conformance-evidence.json
+++ b/artifacts/conformance-evidence.json
@@ -1,9 +1,5 @@
 {
   "metadata": {
-    "commitSha": "26420de122117256610a9a3e79278a020b3085af",
-    "generatedAt": "2026-02-14T21:59:54.086Z",
-    "nodeVersion": "v22.21.1",
-    "pnpmVersion": "10.13.1",
     "vitestVersion": "^2.1.8",
     "suites": [
       "CT-C-* Cursor semantics per principal",

--- a/artifacts/conformance-evidence.md
+++ b/artifacts/conformance-evidence.md
@@ -1,9 +1,5 @@
 # Conformance Evidence
 
-- Commit SHA: 26420de122117256610a9a3e79278a020b3085af
-- Generated at (UTC): 2026-02-14T21:59:54.086Z
-- Node: v22.21.1
-- pnpm: 10.13.1
 - Vitest: ^2.1.8
 - Suites: CT-C-* Cursor semantics per principal, CT-K-* Kernel command semantics, CT-L-* Core Local, CT-P-* Projection determinism, CT-S-* Security masking and indistinguishability, CT-SYNC-* Local sync harness
 

--- a/packages/conformance-tests/scripts/check-artifacts-clean.mjs
+++ b/packages/conformance-tests/scripts/check-artifacts-clean.mjs
@@ -12,6 +12,7 @@ function run(command) {
 
 try {
   run("pnpm --filter @mesh/conformance-tests test");
+  // Runtime diagnostics are intentionally excluded: they contain non-deterministic metadata.
   run("git diff --exit-code -- artifacts/conformance-evidence.md artifacts/conformance-evidence.json");
 } catch {
   console.error("Conformance artifacts are not up to date. Re-run tests and commit updated artifacts.");

--- a/packages/conformance-tests/scripts/generate-evidence.mjs
+++ b/packages/conformance-tests/scripts/generate-evidence.mjs
@@ -242,10 +242,6 @@ async function main() {
   const markdown = [
     "# Conformance Evidence",
     "",
-    `- Commit SHA: ${commitSha}`,
-    `- Generated at (UTC): ${generatedAt}`,
-    `- Node: ${nodeVersion}`,
-    `- pnpm: ${pnpmVersion}`,
     `- Vitest: ${vitestVersion}`,
     `- Suites: ${[...new Set(suiteNames)].join(", ")}`,
     "",
@@ -267,10 +263,6 @@ async function main() {
 
   const jsonPayload = {
     metadata: {
-      commitSha,
-      generatedAt,
-      nodeVersion,
-      pnpmVersion,
       vitestVersion,
       suites: [...new Set(suiteNames)].sort()
     },
@@ -280,12 +272,29 @@ async function main() {
     coverageGaps: missingInvariants
   };
 
+  const runtimePayload = {
+    metadata: {
+      commitSha,
+      generatedAt,
+      nodeVersion,
+      pnpmVersion,
+      vitestVersion,
+      suites: [...new Set(suiteNames)].sort(),
+      runner: {
+        platform: process.platform,
+        arch: process.arch
+      }
+    }
+  };
+
   const mdPath = path.resolve(artifactsDir, "conformance-evidence.md");
   const jsonPath = path.resolve(artifactsDir, "conformance-evidence.json");
+  const runtimeJsonPath = path.resolve(artifactsDir, "conformance-evidence.runtime.json");
   await fs.writeFile(mdPath, markdown, "utf8");
   await fs.writeFile(jsonPath, `${JSON.stringify(jsonPayload, null, 2)}\n`, "utf8");
+  await fs.writeFile(runtimeJsonPath, `${JSON.stringify(runtimePayload, null, 2)}\n`, "utf8");
 
-  console.log(`Generated evidence:\n- ${mdPath}\n- ${jsonPath}`);
+  console.log(`Generated evidence:\n- ${mdPath}\n- ${jsonPath}\n- ${runtimeJsonPath}`);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
### Motivation
- Le check CI `check:artifacts-clean` échoue parce que les artefacts générés contiennent des métadonnées non déterministes (`commitSha`, `generatedAt`, `nodeVersion`, `pnpmVersion`) qui changent à chaque exécution et produisent des diffs inutiles.
- Il faut conserver la génération et l'upload des preuves tout en gardant un contrôle utile « artefacts à jour » et sans hacks CI.

### Description
- `packages/conformance-tests/scripts/generate-evidence.mjs` est modifié pour produire deux sorties distinctes : `artifacts/conformance-evidence.{md,json}` (métadonnées stables : seulement `vitestVersion` et `suites`) et `artifacts/conformance-evidence.runtime.json` (métadonnées d'exécution volatiles : `commitSha`, `generatedAt`, versions, infos runner).
- `packages/conformance-tests/scripts/check-artifacts-clean.mjs` a été ajusté pour n'exiger le diff que des fichiers déterministes `artifacts/conformance-evidence.md` et `artifacts/conformance-evidence.json` et documente l'exclusion des diagnostics runtime.
- Le workflow CI `.github/workflows/conformance.yml` inclut maintenant `artifacts/conformance-evidence.runtime.json` dans les artefacts uploadés pour permettre le debug sans casser le check.
- Ajout d'une règle `.gitignore` pour `artifacts/conformance-evidence.runtime.*` afin d'empêcher l'ajout accidentel des fichiers runtime au contrôle de source.

### Testing
- J'ai lancé `pnpm --filter @mesh/conformance-tests test` (qui exécute la génération) mais l'exécution locale est bloquée par un échec d'installation d'une dépendance optionnelle (`@rollup/rollup-linux-x64-gnu`) qui a renvoyé 403, donc le test n'a pas pu terminer (échec).
- J'ai lancé `pnpm --filter @mesh/conformance-tests check:artifacts-clean` et il a échoué pour la même raison (il appelle `test` en amont), donc le check n'a pas pu être validé dans cet environnement (échec).
- `pnpm install` a été tenté et a échoué en raison du 403 lors du téléchargement de l'optional dependency, empêchant une validation complète (échec).
- Les changements ont néanmoins été appliqués et les artefacts de sortie ont été réécrits localement au nouveau format déterministe et sont prêts pour vérification dans un environnement CI où les dépendances peuvent être installées correctement (non vérifié ici).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990f39121a48321ab7420696cb47b02)