### PR TITLE
Harden conformance evidence generation invariant checks

### DIFF
--- a/packages/conformance-tests/scripts/generate-evidence.mjs
+++ b/packages/conformance-tests/scripts/generate-evidence.mjs
@@ -10,7 +10,7 @@ const testsRoot = path.resolve(repoRoot, "packages/conformance-tests/src");
 const artifactsDir = path.resolve(repoRoot, "artifacts");
 const expectedInvariantsPath = path.resolve(repoRoot, "packages/conformance-tests/expected-invariants.json");
 const evidenceReporterPath = path.resolve(repoRoot, "packages/conformance-tests/scripts/evidence-meta-reporter.mjs");
-const runtimeMetaPath = path.resolve(artifactsDir, "conformance-runtime-meta.json");
+const runtimeMetaPath = path.resolve(artifactsDir, "conformance-evidence.runtime.meta.json");
 
 const testPattern = /it\(\s*"([^"\n]+)"\s*,/g;
 const conformanceIdPattern = /CT-[A-Z0-9-]+/;
@@ -83,6 +83,10 @@ function escapeCell(value) {
   return value.replace(/\|/g, "\\|");
 }
 
+function sortByInvariantId(left, right) {
+  return left.invariantId.localeCompare(right.invariantId);
+}
+
 async function main() {
   const testFiles = await listTestFiles(testsRoot);
   const expectedInvariants = await readJson(expectedInvariantsPath);
@@ -101,6 +105,13 @@ async function main() {
       throw new Error(`expected-invariants.json has invalid criticality for ${expected.invariantId}`);
     }
     expectedById.set(expected.invariantId, expected);
+  }
+
+  const expectedSorted = [...expectedInvariants].sort(sortByInvariantId);
+  for (let index = 0; index < expectedInvariants.length; index += 1) {
+    if (expectedInvariants[index].invariantId !== expectedSorted[index].invariantId) {
+      throw new Error("expected-invariants.json must be sorted by invariantId");
+    }
   }
 
   const runtimeTests = await collectRuntimeMeta();
@@ -204,13 +215,13 @@ async function main() {
   }
 
   const observed = new Set(evidenceRows.map((row) => row.invariantId));
-  const missingInvariants = [...expectedById.keys()].filter((id) => !observed.has(id));
+  const missingInvariants = [...expectedById.keys()].filter((id) => !observed.has(id)).sort();
 
   if (missingInvariants.length > 0) {
     throw new Error(`Expected invariants without tests: ${missingInvariants.join(", ")}`);
   }
 
-  evidenceRows.sort((a, b) => a.invariantId.localeCompare(b.invariantId));
+  evidenceRows.sort(sortByInvariantId);
 
   const criticalitySummary = {
     Critical: evidenceRows.filter((row) => row.criticality === "Critical").length,
@@ -293,6 +304,7 @@ async function main() {
   await fs.writeFile(mdPath, markdown, "utf8");
   await fs.writeFile(jsonPath, `${JSON.stringify(jsonPayload, null, 2)}\n`, "utf8");
   await fs.writeFile(runtimeJsonPath, `${JSON.stringify(runtimePayload, null, 2)}\n`, "utf8");
+  await fs.rm(runtimeMetaPath, { force: true });
 
   console.log(`Generated evidence:\n- ${mdPath}\n- ${jsonPath}\n- ${runtimeJsonPath}`);
 }


### PR DESCRIPTION
### Motivation
- Ensure the conformance evidence generation cannot produce inconsistent coverage by introducing a canonical, versioned list of expected invariants and making the generator fail on mismatches. 
- Make the deterministic artifacts stable by enforcing ordering and deterministic gap reporting so `coverageGaps` is reproducible and empty when all expected invariants are covered.

### Description
- Tighten `packages/conformance-tests/scripts/generate-evidence.mjs` to require `expected-invariants.json` to be sorted by `invariantId` and to fail if not. 
- Make missing invariant IDs deterministic by sorting `missingInvariants`, sort generated evidence rows with a shared comparator, and remove the temporary runtime-meta file after generation. 
- Validate presence/uniqueness of `invariantId` entries and detect `surface` / `criticality` mismatches and missing/empty `oracle` (existing checks retained and enforced). 
- Changes are minimal and confined to the evidence generator script (`packages/conformance-tests/scripts/generate-evidence.mjs`).

### Testing
- `pnpm -r build` succeeded. 
- `pnpm --filter @mesh/conformance-tests test` failed due to a network/registry issue fetching an optional native Rollup binary (`@rollup/rollup-linux-x64-gnu` returning 403), which prevents running Vitest in this environment. 
- `pnpm --filter @mesh/conformance-tests check:artifacts-clean` failed transitively because the Vitest run could not complete for the same missing optional dependency. 
- `pnpm test` failed for the same reason after build completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990f542c8948321b7b393e88db7a8bd)