### PR TITLE
Add explicit conformance critical gate and critical-only evidence artifact

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -22,6 +22,8 @@ jobs:
           ! rg -n "TODO|skip\(" packages/conformance-tests/src
       - name: Test
         run: pnpm test
+      - name: Critical gate
+        run: pnpm --filter @mesh/conformance-tests check:critical
       - name: Artifacts up-to-date
         run: pnpm --filter @mesh/conformance-tests check:artifacts-clean
       - name: Upload conformance evidence artifacts
@@ -31,6 +33,7 @@ jobs:
           name: conformance-artifacts
           path: |
             artifacts/conformance-evidence.md
+            artifacts/conformance-evidence.critical.md
             artifacts/conformance-evidence.json
             artifacts/conformance-evidence.runtime.json
             **/*.log

--- a/artifacts/conformance-evidence.critical.md
+++ b/artifacts/conformance-evidence.critical.md
@@ -1,0 +1,28 @@
+# Conformance Evidence (Critical)
+
+- Vitest: ^2.1.8
+- Suites: CT-C-* Cursor semantics per principal, CT-K-* Kernel command semantics, CT-L-* Core Local, CT-P-* Projection determinism, CT-S-* Security masking and indistinguishability, CT-SYNC-* Local sync harness
+
+## Invariant Coverage
+| InvariantID | Surface | Test(s) | Oracle | Criticality | Preconditions / Setup | Limitations connues |
+|---|---|---|---|---|---|---|
+| CT-K-2 | Kernel | packages/conformance-tests/src/ct_k_semantics.test.ts::[INV:CT-K-2][SURF:Kernel] CT-K-2: idempotent resubmission with same key returns same receipt | Replaying same actorId+idempotencyKey+payload returns the exact original committed receipt. | Critical | const kernel = new KernelMinimalImpl(new InMemoryLocalEventStore()); const first = await kernel.execute({ |  |
+| CT-K-3 | Kernel | packages/conformance-tests/src/ct_k_semantics.test.ts::[INV:CT-K-3][SURF:Kernel] CT-K-3: idempotency key reuse with payload mismatch is rejected | Reusing idempotency key with different payload must reject with CONFLICT/IDEMPOTENCY_PAYLOAD_MISMATCH. | Critical | const kernel = new KernelMinimalImpl(new InMemoryLocalEventStore()); const accepted = await kernel.execute({ |  |
+| CT-K-4 | Kernel | packages/conformance-tests/src/ct_k_semantics.test.ts::[INV:CT-K-4][SURF:Kernel] CT-K-4: commit invariants preserve appendTx + base revision preconditions | Append-layer precondition failures must be propagated as PRECONDITION/REVISION_MISMATCH. | Critical | const fakeStore = new RevisionMismatchStore(); const kernel = new KernelMinimalImpl(fakeStore) |  |
+| CT-L-1 | EventStore | packages/conformance-tests/src/ct_l_core.test.ts::[INV:CT-L-1][SURF:EventStore] CT-L-1 Append-only immutability (Critical) | Appended transaction envelopes are immutable in canonical form across repeated reads. | Critical | const store = new InMemoryLocalEventStore(); const graphSpaceId = "space-l1" |  |
+| CT-L-2 | EventStore | packages/conformance-tests/src/ct_l_core.test.ts::[INV:CT-L-2][SURF:EventStore] CT-L-2 tx-closed readRange extension (Critical) | Extending read ranges preserves tx-closed boundaries and stable event ordering. | Critical | const store = new InMemoryLocalEventStore(); const graphSpaceId = "space-l2" |  |
+| CT-L-3 | EventStore | packages/conformance-tests/src/ct_l_core.test.ts::[INV:CT-L-3][SURF:EventStore] CT-L-3 tx_index monotonicity and two-stream ordering (Critical) | txIndex increases monotonically and stream sequence ordering stays consistent across tx boundaries. | Critical | const store = new InMemoryLocalEventStore(); const graphSpaceId = "space-l3" |  |
+| CT-L-4 | EventStore | packages/conformance-tests/src/ct_l_core.test.ts::[INV:CT-L-4][SURF:EventStore] CT-L-4 Tx boundary integrity + idempotence (Critical) | A transaction is atomically persisted once and idempotent replay returns the original committed receipt. | Critical | const store = new InMemoryLocalEventStore(); const graphSpaceId = "space-l4" |  |
+| CT-L-5 | EventStore | packages/conformance-tests/src/ct_l_core.test.ts::[INV:CT-L-5][SURF:EventStore] CT-L-5 Fault Injection: crash before commit keeps store atomic | Crash before commit must leave no partial transaction state (neither events nor idempotency entry). | Critical | const store = new InMemoryLocalEventStore(); const graphSpaceId = "space-l5" |  |
+| CT-S-1 | Security | packages/conformance-tests/src/ct_s_security.test.ts::[INV:CT-S-1][SURF:Security] CT-S-1: absent and masked tx are indistinguishable | Masked and absent transaction reads must return identical normalized NOT_FOUND_OR_MASKED rejections. | Critical | const store = new InMemoryLocalEventStore(); const graphSpaceId = "space-s1" |  |
+| CT-S-2 | Security | packages/conformance-tests/src/ct_s_security.test.ts::[INV:CT-S-2][SURF:Security] CT-S-2: masked event hides full transaction without observable holes | Masked event visibility removes entire transaction from principal range without cursor holes. | Critical | const store = new InMemoryLocalEventStore(); const graphSpaceId = "space-s2" |  |
+| CT-SYNC-3 | Sync | packages/conformance-tests/src/ct_sync_harness.test.ts::[INV:CT-SYNC-3][SURF:Sync] CT-SYNC-3: end-to-end submit -> poll -> receipt -> replay | submit->poll->receipt->replay remain coherent: committed tx is seen once then replay is empty. | Critical | const store = new InMemoryLocalEventStore(); const graphSpaceId = "space-sync3" |  |
+
+## Criticality summary
+- Critical: 11
+- Structural: 0
+- Regression: 0
+- Critical IDs: CT-K-2, CT-K-3, CT-K-4, CT-L-1, CT-L-2, CT-L-3, CT-L-4, CT-L-5, CT-S-1, CT-S-2, CT-SYNC-3
+
+## Coverage gaps
+Coverage gaps: none.

--- a/packages/conformance-tests/package.json
+++ b/packages/conformance-tests/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "check:artifacts-clean": "node ./scripts/check-artifacts-clean.mjs",
+    "check:critical": "node ./scripts/check-critical-gate.mjs",
     "test": "vitest run",
     "pretest": "node ./scripts/check-no-todo.mjs",
     "posttest": "node ./scripts/generate-evidence.mjs"

--- a/packages/conformance-tests/scripts/check-artifacts-clean.mjs
+++ b/packages/conformance-tests/scripts/check-artifacts-clean.mjs
@@ -13,7 +13,7 @@ function run(command) {
 try {
   run("pnpm --filter @mesh/conformance-tests test");
   // Runtime diagnostics are intentionally excluded: they contain non-deterministic metadata.
-  run("git diff --exit-code -- artifacts/conformance-evidence.md artifacts/conformance-evidence.json");
+  run("git diff --exit-code -- artifacts/conformance-evidence.md artifacts/conformance-evidence.critical.md artifacts/conformance-evidence.json");
 } catch {
   console.error("Conformance artifacts are not up to date. Re-run tests and commit updated artifacts.");
   process.exit(1);

--- a/packages/conformance-tests/scripts/check-critical-gate.mjs
+++ b/packages/conformance-tests/scripts/check-critical-gate.mjs
@@ -1,0 +1,61 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "../../..");
+const evidencePath = path.resolve(repoRoot, "artifacts/conformance-evidence.json");
+const expectedInvariantsPath = path.resolve(repoRoot, "packages/conformance-tests/expected-invariants.json");
+
+const MIN_EXPECTED_CRITICAL = 1;
+
+async function readJson(filePath) {
+  const raw = await fs.readFile(filePath, "utf8");
+  return JSON.parse(raw);
+}
+
+async function main() {
+  const [evidence, expectedInvariants] = await Promise.all([readJson(evidencePath), readJson(expectedInvariantsPath)]);
+
+  const criticalCount = Number(evidence?.criticalitySummary?.Critical ?? 0);
+  const criticalIds = Array.isArray(evidence?.criticalInvariantIds)
+    ? evidence.criticalInvariantIds.filter((id) => typeof id === "string")
+    : [];
+  const coverageGaps = Array.isArray(evidence?.coverageGaps)
+    ? evidence.coverageGaps.filter((id) => typeof id === "string")
+    : [];
+
+  const expectedCriticalIds = expectedInvariants
+    .filter((item) => item?.criticality === "Critical" && typeof item?.invariantId === "string")
+    .map((item) => item.invariantId)
+    .sort();
+
+  const missingCriticalCoverage = coverageGaps.filter((id) => expectedCriticalIds.includes(id));
+
+  const violations = [];
+  if (criticalCount <= 0) violations.push("criticalitySummary.Critical must be > 0");
+  if (criticalIds.length === 0) violations.push("criticalInvariantIds must not be empty");
+  if (expectedCriticalIds.length < MIN_EXPECTED_CRITICAL) {
+    violations.push(`expected-invariants.json must contain at least ${MIN_EXPECTED_CRITICAL} Critical invariant(s)`);
+  }
+  if (missingCriticalCoverage.length > 0) {
+    violations.push(`coverageGaps includes Critical invariant(s): ${missingCriticalCoverage.join(", ")}`);
+  }
+
+  console.log(`Critical invariants: ${criticalCount}`);
+  console.log(`Critical IDs: ${criticalIds.join(", ") || "none"}`);
+  console.log(`Status: ${violations.length === 0 ? "PASS" : "FAIL"}`);
+
+  if (violations.length > 0) {
+    for (const violation of violations) {
+      console.error(`- ${violation}`);
+    }
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/packages/conformance-tests/scripts/generate-evidence.mjs
+++ b/packages/conformance-tests/scripts/generate-evidence.mjs
@@ -79,6 +79,28 @@ function markdownTable(rows) {
   return [header, sep, body].join("\n");
 }
 
+function buildMarkdown(title, suiteNames, vitestVersion, rows, criticalitySummary, criticalInvariantIds, gapsSection) {
+  return [
+    `# ${title}`,
+    "",
+    `- Vitest: ${vitestVersion}`,
+    `- Suites: ${[...new Set(suiteNames)].join(", ")}`,
+    "",
+    "## Invariant Coverage",
+    markdownTable(rows),
+    "",
+    "## Criticality summary",
+    `- Critical: ${criticalitySummary.Critical}`,
+    `- Structural: ${criticalitySummary.Structural}`,
+    `- Regression: ${criticalitySummary.Regression}`,
+    `- Critical IDs: ${criticalInvariantIds.join(", ") || "none"}`,
+    "",
+    "## Coverage gaps",
+    gapsSection,
+    ""
+  ].join("\n");
+}
+
 function escapeCell(value) {
   return value.replace(/\|/g, "\\|");
 }
@@ -250,25 +272,30 @@ async function main() {
       ? "Coverage gaps: none."
       : `Coverage gaps:\n${missingInvariants.map((id) => `- ${id}`).join("\n")}`;
 
-  const markdown = [
-    "# Conformance Evidence",
-    "",
-    `- Vitest: ${vitestVersion}`,
-    `- Suites: ${[...new Set(suiteNames)].join(", ")}`,
-    "",
-    "## Invariant Coverage",
-    markdownTable(escapedRows),
-    "",
-    "## Criticality summary",
-    `- Critical: ${criticalitySummary.Critical}`,
-    `- Structural: ${criticalitySummary.Structural}`,
-    `- Regression: ${criticalitySummary.Regression}`,
-    `- Critical IDs: ${criticalInvariantIds.join(", ") || "none"}`,
-    "",
-    "## Coverage gaps",
-    gapsSection,
-    ""
-  ].join("\n");
+  const markdown = buildMarkdown(
+    "Conformance Evidence",
+    suiteNames,
+    vitestVersion,
+    escapedRows,
+    criticalitySummary,
+    criticalInvariantIds,
+    gapsSection
+  );
+
+  const criticalRows = escapedRows.filter((row) => row.criticality === "Critical");
+  const criticalMarkdown = buildMarkdown(
+    "Conformance Evidence (Critical)",
+    suiteNames,
+    vitestVersion,
+    criticalRows,
+    {
+      Critical: criticalRows.length,
+      Structural: 0,
+      Regression: 0
+    },
+    criticalInvariantIds,
+    "Coverage gaps: none."
+  );
 
   await fs.mkdir(artifactsDir, { recursive: true });
 
@@ -299,14 +326,16 @@ async function main() {
   };
 
   const mdPath = path.resolve(artifactsDir, "conformance-evidence.md");
+  const criticalMdPath = path.resolve(artifactsDir, "conformance-evidence.critical.md");
   const jsonPath = path.resolve(artifactsDir, "conformance-evidence.json");
   const runtimeJsonPath = path.resolve(artifactsDir, "conformance-evidence.runtime.json");
   await fs.writeFile(mdPath, markdown, "utf8");
+  await fs.writeFile(criticalMdPath, criticalMarkdown, "utf8");
   await fs.writeFile(jsonPath, `${JSON.stringify(jsonPayload, null, 2)}\n`, "utf8");
   await fs.writeFile(runtimeJsonPath, `${JSON.stringify(runtimePayload, null, 2)}\n`, "utf8");
   await fs.rm(runtimeMetaPath, { force: true });
 
-  console.log(`Generated evidence:\n- ${mdPath}\n- ${jsonPath}\n- ${runtimeJsonPath}`);
+  console.log(`Generated evidence:\n- ${mdPath}\n- ${criticalMdPath}\n- ${jsonPath}\n- ${runtimeJsonPath}`);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
### Motivation
- Make CI able to fail explicitly when a Critical invariant is missing or uncovered so the team can block merges on Critical regressions.
- Improve CI readability by printing a short Critical summary to the console and uploading a dedicated `conformance-evidence.critical.md` artifact.
- Keep the change minimal, dependency-free, and deterministic so existing `pnpm` build/test flows remain intact.

### Description
- Add a new gate script `packages/conformance-tests/scripts/check-critical-gate.mjs` that reads `artifacts/conformance-evidence.json` and fails if `criticalitySummary.Critical <= 0`, `criticalInvariantIds` is empty, or any `coverageGaps` contains an expected Critical invariant, and prints a concise summary (`Critical invariants`, `Critical IDs`, `Status`).
- Extend `packages/conformance-tests/scripts/generate-evidence.mjs` to factor markdown rendering into `buildMarkdown(...)` and emit a deterministic critical-only artifact at `artifacts/conformance-evidence.critical.md` (subset table with oracle/tests/surface).
- Add `check:critical` script to `packages/conformance-tests/package.json`, update `check-artifacts-clean.mjs` to include the new critical MD, and update `.github/workflows/conformance.yml` to run the critical gate after tests and upload `artifacts/conformance-evidence.critical.md`.

### Testing
- Ran `pnpm --filter @mesh/conformance-tests check:critical` which printed the Critical summary and returned success (PASS).
- Ran `pnpm -r build` which completed successfully (build step preserved).
- Attempted `pnpm --filter @mesh/conformance-tests test` and `pnpm test` but the local environment failed on an unrelated optional native dependency (`@rollup/rollup-linux-x64-gnu`), preventing full Vitest execution in this environment (environmental failure, not caused by these changes).
- Verified `artifacts/conformance-evidence.critical.md` is deterministically generated by checking its SHA256 before/after rewrite and observed no change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990f88b6a4883218cb9c5065348f531)