### PR TITLE
Add deterministic API v1 contract manifest, generation tooling and CI gate

### DIFF
--- a/.github/workflows/conformance-nightly.yml
+++ b/.github/workflows/conformance-nightly.yml
@@ -26,6 +26,8 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build
         run: pnpm -r build
+      - name: Check API contract v1
+        run: pnpm check:api-contract
       - name: Test (nightly soak)
         run: pnpm test
       - name: Critical gate

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -44,6 +44,8 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build
         run: pnpm -r build
+      - name: Check API contract v1
+        run: pnpm check:api-contract
       - name: Enforce conformance test hygiene
         if: matrix.mesh_backend == 'inmemory'
         run: node tools/ci/check-patterns.mjs --root packages/conformance-tests/src --no-default-patterns --pattern "TODO" --pattern "skip\("

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Phase 14: ajout d'un contrat API v1 canonique (`contracts/v1`) avec génération/contrôle bloquant en CI.

--- a/contracts/v1/README.md
+++ b/contracts/v1/README.md
@@ -1,0 +1,26 @@
+# API Contract v1
+
+Cette arborescence fige la surface **Public API v1** consommable par une application.
+
+## Packages Public API v1
+
+La liste canonique est définie dans `contracts/v1/manifest.json` :
+
+- `@mesh/shared` (types, reasonCodes, cursor/receipt primitives)
+- `@mesh/eventstore-local` (signature API event store)
+- `@mesh/sync-local` (sync receipts côté app)
+- `@mesh/snapshot-minimal` (snapshot envelope/store)
+- `@mesh/projection-minimal` (projection + cursor app-facing)
+
+## Règles SemVer
+
+- **Pas de diff** entre `generated` et `golden` : pas de changement d'API publique.
+- **Diff additive compatible** (nouveaux exports/types non cassants) : bump **minor**.
+- **Diff cassante** (suppression/changement incompatible de signatures/types) : bump **major**.
+
+## Commandes
+
+- Mettre à jour les golden files (après décision de versioning):
+  - `pnpm api:contract:update`
+- Vérifier la compatibilité (bloquant CI):
+  - `pnpm check:api-contract`

--- a/contracts/v1/golden/INDEX.txt
+++ b/contracts/v1/golden/INDEX.txt
@@ -1,0 +1,25 @@
+[@mesh/shared] mesh__shared.d.ts
+  export * from "./types.js";
+  export * from "./reasonCodes.js";
+  export * from "./normalizer.js";
+[@mesh/eventstore-local] mesh__eventstore-local.d.ts
+  export * from "./LocalEventStore.js";
+  export * from "./InMemoryLocalEventStore.js";
+  export * from "./FileBackedLocalEventStore.js";
+[@mesh/sync-local] mesh__sync-local.d.ts
+  export interface SyncPollReceipt {
+  export declare class LocalSyncHarness {
+[@mesh/snapshot-minimal] mesh__snapshot-minimal.d.ts
+  export type SnapshotId = string;
+  export type SnapshotVersion = number;
+  export declare const SNAPSHOT_VERSION_V1 = 1;
+  export interface SnapshotEnvelope<TPayload = unknown> {
+  export interface SnapshotStore<TPayload = unknown> {
+  export declare class SnapshotValidationError extends Error {
+  export declare class InMemorySnapshotStore<TPayload = unknown> implements SnapshotStore<TPayload> {
+  export declare class FileBackedSnapshotStore<TPayload = unknown> implements SnapshotStore<TPayload> {
+[@mesh/projection-minimal] mesh__projection-minimal.d.ts
+  export interface ProjectionSnapshot {
+  export interface RebuildStats {
+  export type ProjectionSnapshotEnvelope = SnapshotEnvelope<ProjectionSnapshot>;
+  export declare class PrincipalProjectionEngine {

--- a/contracts/v1/golden/mesh__eventstore-local.d.ts
+++ b/contracts/v1/golden/mesh__eventstore-local.d.ts
@@ -1,0 +1,3 @@
+export * from "./LocalEventStore.js";
+export * from "./InMemoryLocalEventStore.js";
+export * from "./FileBackedLocalEventStore.js";

--- a/contracts/v1/golden/mesh__projection-minimal.d.ts
+++ b/contracts/v1/golden/mesh__projection-minimal.d.ts
@@ -1,0 +1,31 @@
+import type { LocalEventStore } from "@mesh/eventstore-local";
+import type { SnapshotEnvelope, SnapshotStore } from "@mesh/snapshot-minimal";
+import type { PrincipalContext } from "@mesh/shared";
+export interface ProjectionSnapshot {
+    principalId: string;
+    cursor: number;
+    nodeCount: number;
+    txIds: string[];
+}
+export interface RebuildStats {
+    appliedTxCount: number;
+}
+export type ProjectionSnapshotEnvelope = SnapshotEnvelope<ProjectionSnapshot>;
+export declare class PrincipalProjectionEngine {
+    private readonly eventStore;
+    private readonly graphSpaceId;
+    private readonly cache;
+    constructor(eventStore: LocalEventStore, graphSpaceId: string);
+    rebuild(principal: PrincipalContext): Promise<ProjectionSnapshot>;
+    rebuildWithSnapshot(params: {
+        principal: PrincipalContext;
+        snapshotStore: SnapshotStore<ProjectionSnapshot>;
+    }): Promise<{
+        snapshot: ProjectionSnapshot;
+        replayStats: RebuildStats;
+    }>;
+    incremental(principal: PrincipalContext): Promise<ProjectionSnapshot>;
+    invalidate(graphSpaceId: string): void;
+    private rebuildInternal;
+    private compute;
+}

--- a/contracts/v1/golden/mesh__shared.d.ts
+++ b/contracts/v1/golden/mesh__shared.d.ts
@@ -1,0 +1,3 @@
+export * from "./types.js";
+export * from "./reasonCodes.js";
+export * from "./normalizer.js";

--- a/contracts/v1/golden/mesh__snapshot-minimal.d.ts
+++ b/contracts/v1/golden/mesh__snapshot-minimal.d.ts
@@ -1,0 +1,46 @@
+import { type CommandErrorCategory, type GraphSpaceId, type PrincipalId } from "@mesh/shared";
+export type SnapshotId = string;
+export type SnapshotVersion = number;
+export declare const SNAPSHOT_VERSION_V1 = 1;
+export interface SnapshotEnvelope<TPayload = unknown> {
+    snapshotId: SnapshotId;
+    snapshotVersion: SnapshotVersion;
+    graphSpaceId: GraphSpaceId;
+    principalId: PrincipalId;
+    cursorAt: number;
+    stateHash?: string;
+    payload: TPayload;
+    createdAt?: string;
+}
+export interface SnapshotStore<TPayload = unknown> {
+    saveSnapshot(snapshotEnvelope: SnapshotEnvelope<TPayload>): Promise<void>;
+    loadLatestSnapshot(scope: {
+        graphSpaceId: GraphSpaceId;
+        principalId: PrincipalId;
+    }): Promise<SnapshotEnvelope<TPayload> | null>;
+}
+export declare class SnapshotValidationError extends Error {
+    readonly category: CommandErrorCategory;
+    readonly reasonCode: "CMD.VALIDATION.SNAPSHOT.UNSUPPORTED_VERSION";
+    constructor(snapshotVersion: number);
+}
+export declare class InMemorySnapshotStore<TPayload = unknown> implements SnapshotStore<TPayload> {
+    private readonly byScope;
+    saveSnapshot(snapshotEnvelope: SnapshotEnvelope<TPayload>): Promise<void>;
+    loadLatestSnapshot(scope: {
+        graphSpaceId: GraphSpaceId;
+        principalId: PrincipalId;
+    }): Promise<SnapshotEnvelope<TPayload> | null>;
+}
+export declare class FileBackedSnapshotStore<TPayload = unknown> implements SnapshotStore<TPayload> {
+    private readonly filePath;
+    private state;
+    constructor(filePath: string);
+    saveSnapshot(snapshotEnvelope: SnapshotEnvelope<TPayload>): Promise<void>;
+    loadLatestSnapshot(scope: {
+        graphSpaceId: GraphSpaceId;
+        principalId: PrincipalId;
+    }): Promise<SnapshotEnvelope<TPayload> | null>;
+    private loadState;
+    private persistState;
+}

--- a/contracts/v1/golden/mesh__sync-local.d.ts
+++ b/contracts/v1/golden/mesh__sync-local.d.ts
@@ -1,0 +1,13 @@
+import type { LocalEventStore } from "@mesh/eventstore-local";
+import type { PrincipalContext } from "@mesh/shared";
+export interface SyncPollReceipt {
+    principalCursorAfter: number;
+    txIds: string[];
+}
+export declare class LocalSyncHarness {
+    private readonly eventStore;
+    private readonly graphSpaceId;
+    constructor(eventStore: LocalEventStore, graphSpaceId: string);
+    poll(principal: PrincipalContext, fromCursorExclusive: number, limit: number): Promise<SyncPollReceipt>;
+    subscribeOnce(principal: PrincipalContext, fromCursorExclusive: number, limit: number): Promise<SyncPollReceipt>;
+}

--- a/contracts/v1/manifest.json
+++ b/contracts/v1/manifest.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "@mesh/shared",
+    "entry": "src/index.ts",
+    "kind": "public"
+  },
+  {
+    "name": "@mesh/eventstore-local",
+    "entry": "src/index.ts",
+    "kind": "public"
+  },
+  {
+    "name": "@mesh/sync-local",
+    "entry": "src/index.ts",
+    "kind": "public"
+  },
+  {
+    "name": "@mesh/snapshot-minimal",
+    "entry": "src/index.ts",
+    "kind": "public"
+  },
+  {
+    "name": "@mesh/projection-minimal",
+    "entry": "src/index.ts",
+    "kind": "public"
+  }
+]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "test": "pnpm -r build && pnpm --filter @mesh/conformance-tests test",
     "test:all": "pnpm -r test",
     "smoke:node": "node ./scripts/smoke-node.mjs",
-    "ci:validate-workflows": "node scripts/ci/validate-conformance-workflow.mjs"
+    "ci:validate-workflows": "node scripts/ci/validate-conformance-workflow.mjs",
+    "api:contract:update": "node tools/ci/dump-api.mjs --mode=golden",
+    "check:api-contract": "node tools/ci/check-api-contract.mjs"
   },
   "devDependencies": {
     "typescript": "^5.6.3",

--- a/tools/ci/check-api-contract.mjs
+++ b/tools/ci/check-api-contract.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "../..");
+const goldenDir = path.resolve(repoRoot, "contracts/v1/golden");
+const generatedDir = path.resolve(repoRoot, "contracts/v1/generated");
+
+async function run(cmd, args, cwd = repoRoot) {
+  await new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { cwd, stdio: "inherit", env: process.env });
+    child.on("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`Command failed: ${cmd} ${args.join(" ")} (exit ${code ?? "null"})`));
+    });
+  });
+}
+
+async function readText(filePath) {
+  return fs.readFile(filePath, "utf8");
+}
+
+function simpleDiff(expected, actual, maxChanges = 20) {
+  const exp = expected.split("\n");
+  const act = actual.split("\n");
+  const max = Math.max(exp.length, act.length);
+  const chunks = [];
+  for (let i = 0; i < max; i += 1) {
+    if (exp[i] !== act[i]) {
+      chunks.push(`L${i + 1}\n  - ${exp[i] ?? "<EOF>"}\n  + ${act[i] ?? "<EOF>"}`);
+      if (chunks.length >= maxChanges) break;
+    }
+  }
+  return chunks.join("\n");
+}
+
+async function main() {
+  await run("node", ["tools/ci/dump-api.mjs", "--mode=generated", "--skip-build"]);
+
+  const goldenEntries = (await fs.readdir(goldenDir)).filter((name) => name.endsWith(".d.ts") || name === "INDEX.txt").sort();
+  const generatedEntries = (await fs.readdir(generatedDir)).filter((name) => name.endsWith(".d.ts") || name === "INDEX.txt").sort();
+
+  const missingInGenerated = goldenEntries.filter((name) => !generatedEntries.includes(name));
+  const extraInGenerated = generatedEntries.filter((name) => !goldenEntries.includes(name));
+
+  if (missingInGenerated.length > 0 || extraInGenerated.length > 0) {
+    if (missingInGenerated.length > 0) {
+      console.error(`Missing generated contract files: ${missingInGenerated.join(", ")}`);
+    }
+    if (extraInGenerated.length > 0) {
+      console.error(`Unexpected generated contract files: ${extraInGenerated.join(", ")}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  for (const name of goldenEntries) {
+    const goldenPath = path.join(goldenDir, name);
+    const generatedPath = path.join(generatedDir, name);
+    const [goldenText, generatedText] = await Promise.all([readText(goldenPath), readText(generatedPath)]);
+    if (goldenText !== generatedText) {
+      console.error(`API contract mismatch: ${name}`);
+      console.error(simpleDiff(goldenText, generatedText));
+      process.exitCode = 1;
+      return;
+    }
+  }
+
+  console.log("API contract check passed.");
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/tools/ci/dump-api.mjs
+++ b/tools/ci/dump-api.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "../..");
+const manifestPath = path.resolve(repoRoot, "contracts/v1/manifest.json");
+
+function parseArgs(argv) {
+  const options = { mode: "golden", skipBuild: false };
+  for (const arg of argv) {
+    if (arg === "--skip-build") options.skipBuild = true;
+    else if (arg.startsWith("--mode=")) options.mode = arg.slice("--mode=".length);
+  }
+  if (options.mode !== "golden" && options.mode !== "generated") {
+    throw new Error(`Invalid --mode, expected golden|generated but got: ${options.mode}`);
+  }
+  return options;
+}
+
+async function run(cmd, args, cwd = repoRoot) {
+  await new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { cwd, stdio: "inherit", env: process.env });
+    child.on("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`Command failed: ${cmd} ${args.join(" ")} (exit ${code ?? "null"})`));
+    });
+  });
+}
+
+function pkgDirFromName(name) {
+  const shortName = name.replace("@mesh/", "");
+  return path.resolve(repoRoot, "packages", shortName);
+}
+
+function normalizeDts(text) {
+  return text
+    .replaceAll("\r\n", "\n")
+    .replaceAll(process.cwd().replaceAll("\\", "/"), "<REPO_ROOT>")
+    .replace(/\/\/[#@] sourceMappingURL=.*$/gm, "")
+    .replace(/\/\*\s*eslint[^*]*\*\//g, "")
+    .replace(/[ \t]+$/gm, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trimEnd()
+    .concat("\n");
+}
+
+function pkgOutputName(name) {
+  return name.replace(/^@/, "").replace(/\//g, "__");
+}
+
+function collectExportLines(text) {
+  const lines = text.split("\n");
+  const exports = lines
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("export "));
+  return exports;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const manifestRaw = await fs.readFile(manifestPath, "utf8");
+  const manifest = JSON.parse(manifestRaw);
+
+  if (!Array.isArray(manifest) || manifest.length === 0) {
+    throw new Error("contracts/v1/manifest.json must be a non-empty array");
+  }
+
+  const outRoot = path.resolve(repoRoot, `contracts/v1/${options.mode}`);
+  const buildRoot = path.resolve(repoRoot, ".tmp/api-contract");
+
+  if (!options.skipBuild) {
+    await run("pnpm", ["-r", "build"]);
+  }
+
+  await fs.rm(outRoot, { recursive: true, force: true });
+  await fs.mkdir(outRoot, { recursive: true });
+  await fs.rm(buildRoot, { recursive: true, force: true });
+  await fs.mkdir(buildRoot, { recursive: true });
+
+  const indexRows = [];
+
+  for (const item of manifest) {
+    if (item?.kind !== "public") continue;
+    if (typeof item.name !== "string" || typeof item.entry !== "string") {
+      throw new Error(`Invalid manifest item: ${JSON.stringify(item)}`);
+    }
+
+    const pkgDir = pkgDirFromName(item.name);
+    const tsconfigPath = path.join(pkgDir, "tsconfig.json");
+    const pkgBuildOut = path.join(buildRoot, pkgOutputName(item.name));
+    await fs.mkdir(pkgBuildOut, { recursive: true });
+
+    await run("pnpm", ["exec", "tsc", "-p", tsconfigPath, "--emitDeclarationOnly", "--declarationMap", "false", "--outDir", pkgBuildOut]);
+
+    const entryDts = `${item.entry.replace(/^src\//, "").replace(/\.ts$/, ".d.ts")}`;
+    const entryPath = path.join(pkgBuildOut, entryDts);
+
+    const dtsRaw = await fs.readFile(entryPath, "utf8");
+    const dtsNormalized = normalizeDts(dtsRaw);
+    const outName = `${pkgOutputName(item.name)}.d.ts`;
+    const outPath = path.join(outRoot, outName);
+    await fs.writeFile(outPath, dtsNormalized, "utf8");
+
+    const exports = collectExportLines(dtsNormalized);
+    indexRows.push(`[${item.name}] ${outName}`);
+    if (exports.length === 0) {
+      indexRows.push("  (no direct export statements)");
+    } else {
+      for (const line of exports) {
+        indexRows.push(`  ${line}`);
+      }
+    }
+  }
+
+  await fs.writeFile(path.join(outRoot, "INDEX.txt"), `${indexRows.join("\n")}\n`, "utf8");
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
### Motivation

- Freeze a minimal, app-facing Public API surface (v1) so downstream apps can depend on stable types without architectural refactors. 
- Produce canonical, deterministic declaration artifacts (golden files) to detect accidental or breaking API changes reliably. 
- Provide a fast, reproducible check that can run in PR/nightly CI to block regressions to the public surface. 

### Description

- Add `contracts/v1/manifest.json` listing public packages and their entrypoints for the API v1 surface (`@mesh/shared`, `@mesh/eventstore-local`, `@mesh/sync-local`, `@mesh/snapshot-minimal`, `@mesh/projection-minimal`).
- Implement `tools/ci/dump-api.mjs` which compiles declaration-only outputs per manifest item, normalizes unstable content (paths, headers, spacing) and emits deterministic `.d.ts` files and an `INDEX.txt` diagnostic; it supports `--mode=golden|generated` and `--skip-build` flags. 
- Implement `tools/ci/check-api-contract.mjs` which regenerates into `contracts/v1/generated`, compares byte-for-byte with `contracts/v1/golden`, and prints a minimal line diff on mismatch; add root scripts `api:contract:update` and `check:api-contract` to `package.json` to run these flows. 
- Commit canonical golden artifacts under `contracts/v1/golden/` and add `contracts/v1/README.md` and a minimal `CHANGELOG.md` documenting the v1 surface and update rules. 
- Integrate the API contract check into CI workflows so `pnpm check:api-contract` runs after the `Build` step and before tests in both PR and nightly pipelines. 

### Testing

- Ran `pnpm api:contract:update` (invokes `tools/ci/dump-api.mjs`) to produce canonical golden files successfully. 
- Ran `pnpm check:api-contract` (invokes `tools/ci/check-api-contract.mjs`) which regenerated contracts and reported `API contract check passed.`. 
- Ran full verification `pnpm -r build` and `pnpm test` (conformance suite) and all builds and tests completed successfully (`12 test files, 51 tests passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991fdbc61cc8321bb3abf8a978757c9)