### PR TITLE
ci: add guardrail to ensure public package dist exports exist

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -44,6 +44,8 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build
         run: pnpm -r build
+      - name: Check public exports exist in dist
+        run: pnpm check:public-exports-exist
       - name: Check API contract v1
         run: pnpm check:api-contract
       - name: Check reasonCodes policy

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "ci:validate-workflows": "node scripts/ci/validate-conformance-workflow.mjs",
     "api:contract:update": "node tools/ci/update-api-contract.mjs",
     "check:api-contract": "node tools/ci/check-api-contract.mjs",
-    "check:reasoncodes-policy": "node tools/ci/check-reasoncodes-policy.mjs"
+    "check:reasoncodes-policy": "node tools/ci/check-reasoncodes-policy.mjs",
+    "check:public-exports-exist": "node tools/ci/check-public-exports-exist.mjs"
   },
   "devDependencies": {
     "typescript": "^5.6.3",

--- a/tools/ci/check-public-exports-exist.mjs
+++ b/tools/ci/check-public-exports-exist.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "../..");
+const manifestPath = path.join(repoRoot, "contracts/v1/manifest.json");
+const goldenDir = path.join(repoRoot, "contracts/v1/golden");
+
+function pkgOutputName(name) {
+  return name.replace(/^@/, "").replace(/\//g, "__");
+}
+
+function pkgDirFromName(name) {
+  return path.join(repoRoot, "packages", name.replace("@mesh/", ""));
+}
+
+function collectStarExports(goldenText) {
+  const exports = new Set();
+  const re = /^export\s+\*\s+from\s+["'](\.\/[^"']+\.js)["'];?\s*$/gm;
+  for (const match of goldenText.matchAll(re)) {
+    exports.add(match[1]);
+  }
+  return [...exports].sort();
+}
+
+async function exists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+  if (!Array.isArray(manifest)) {
+    throw new Error("contracts/v1/manifest.json must contain an array");
+  }
+
+  const missing = [];
+
+  for (const item of manifest) {
+    if (item?.kind !== "public") continue;
+    if (typeof item.name !== "string") {
+      throw new Error(`Invalid public item in manifest: ${JSON.stringify(item)}`);
+    }
+
+    const pkgDir = pkgDirFromName(item.name);
+    const distDir = path.join(pkgDir, "dist");
+    const goldenPath = path.join(goldenDir, `${pkgOutputName(item.name)}.d.ts`);
+
+    if (!(await exists(path.join(distDir, "index.js")))) {
+      missing.push(path.relative(repoRoot, path.join(distDir, "index.js")));
+    }
+
+    if (!(await exists(path.join(distDir, "index.d.ts")))) {
+      missing.push(path.relative(repoRoot, path.join(distDir, "index.d.ts")));
+    }
+
+    if (!(await exists(goldenPath))) {
+      missing.push(path.relative(repoRoot, goldenPath));
+      continue;
+    }
+
+    const goldenText = await fs.readFile(goldenPath, "utf8");
+    const starExports = collectStarExports(goldenText);
+    for (const exportPath of starExports) {
+      const rel = exportPath.replace(/^\.\//, "");
+      const distExportPath = path.join(distDir, rel);
+      if (!(await exists(distExportPath))) {
+        missing.push(path.relative(repoRoot, distExportPath));
+      }
+    }
+  }
+
+  if (missing.length > 0) {
+    console.error("Public export artifact check failed. Missing files:");
+    for (const file of [...new Set(missing)].sort()) {
+      console.error(`- ${file}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log("Public export artifact check passed.");
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
### Motivation
- Prevent inconsistent API contract artifacts by ensuring public package entrypoints and their referenced export files are present in `dist/` after build.
- Avoid runtime confusion where golden `.d.ts` references (e.g. `./reasonCodes.js`) do not exist in package `dist/`.

### Description
- Add a Node ESM-only CI check `tools/ci/check-public-exports-exist.mjs` that reads `contracts/v1/manifest.json`, targets items with `kind: public`, and verifies `dist/index.js` and `dist/index.d.ts` exist and that every `export * from "./X.js"` in `contracts/v1/golden/<pkg>.d.ts` maps to an existing `packages/<pkgName>/dist/X.js` file.
- Wire a root npm script `check:public-exports-exist` in `package.json` to run the new script.
- Invoke the new check in the PR workflow `.github/workflows/conformance.yml` immediately after `pnpm -r build`.

### Testing
- Ran `pnpm install --frozen-lockfile` which completed successfully.
- Ran `pnpm -r build` (re-run after install) which completed successfully in this environment.
- Ran `pnpm check:public-exports-exist` which printed success (`Public export artifact check passed.`) and exited 0.
- Ran `pnpm check:api-contract`, `pnpm check:reasoncodes-policy`, and `pnpm ci:validate-workflows`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992211740508321bff9e8fbb8b92122)