### PR TITLE
Make API contract scripts cross-platform and support .d golden files

### DIFF
--- a/contracts/v1/README.md
+++ b/contracts/v1/README.md
@@ -22,9 +22,14 @@ La liste canonique est définie dans `contracts/v1/manifest.json` :
   - `pnpm api:contract:update`
 - Script utilisé: `tools/ci/update-api-contract.mjs`
   - lit `contracts/v1/manifest.json`
-  - régénère les `.d.ts` des packages `kind: "public"`
+  - régénère les déclarations des packages `kind: "public"` (`.d` ou `.d.ts`)
   - normalise le contenu (timestamps/chemins absolus/en-têtes variables)
-  - écrase `contracts/v1/golden/*.d.ts`
+  - écrase `contracts/v1/golden/*.d` ou `contracts/v1/golden/*.d.ts` en conservant le format déjà présent
   - affiche la liste des fichiers écrasés
 - Vérifier la compatibilité (bloquant CI):
   - `pnpm check:api-contract`
+
+## Notes d'implémentation
+
+- Les scripts API contract sont **cross-platform** (Windows/POSIX) et utilisent `node:path` (`path.join`, `path.normalize`, `path.resolve`) pour éviter les séparateurs hardcodés.
+- Le fichier `INDEX` est traité comme un fichier texte, avec tolérance pour `INDEX` ou `INDEX.txt`.

--- a/tools/ci/api-contract-paths.mjs
+++ b/tools/ci/api-contract-paths.mjs
@@ -1,0 +1,54 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const GOLDEN_DECLARATION_RE = /^mesh__.+\.d(?:\.ts)?$/;
+
+export function normalizeConfigPath(value) {
+  return path.normalize(value);
+}
+
+export function packageSlug(name) {
+  return name.replace(/^@/, "").replace(/\//g, "__");
+}
+
+export function generatedNameForPackage(name) {
+  return `${packageSlug(name)}.d.ts`;
+}
+
+export async function goldenNameForPackage(name, goldenDir) {
+  const normalizedGoldenDir = normalizeConfigPath(goldenDir);
+  const slug = packageSlug(name);
+  const dName = `${slug}.d`;
+  const dTsName = `${slug}.d.ts`;
+
+  if (await pathExists(path.join(normalizedGoldenDir, dName))) {
+    return dName;
+  }
+
+  if (await pathExists(path.join(normalizedGoldenDir, dTsName))) {
+    return dTsName;
+  }
+
+  return dTsName;
+}
+
+export function isGoldenDeclarationFile(name) {
+  return GOLDEN_DECLARATION_RE.test(name);
+}
+
+export function isIndexTextFile(name) {
+  return name === "INDEX" || name === "INDEX.txt";
+}
+
+export function stripIndexExtension(name) {
+  return isIndexTextFile(name) ? "INDEX" : name;
+}
+
+async function pathExists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/tools/ci/check-api-contract.mjs
+++ b/tools/ci/check-api-contract.mjs
@@ -3,12 +3,14 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
+import { generatedNameForPackage, goldenNameForPackage, isGoldenDeclarationFile, isIndexTextFile, normalizeConfigPath, stripIndexExtension } from "./api-contract-paths.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "../..");
-const goldenDir = path.resolve(repoRoot, "contracts/v1/golden");
-const generatedDir = path.resolve(repoRoot, "contracts/v1/generated");
+const manifestPath = path.resolve(repoRoot, "contracts", "v1", "manifest.json");
+const goldenDir = path.resolve(repoRoot, "contracts", "v1", "golden");
+const generatedDir = path.resolve(repoRoot, "contracts", "v1", "generated");
 
 async function run(cmd, args, cwd = repoRoot) {
   await new Promise((resolve, reject) => {
@@ -77,20 +79,51 @@ function validateNoInternalLeaks(fileName, text) {
 }
 
 async function main() {
-  await run("node", ["tools/ci/dump-api.mjs", "--mode=generated", "--skip-build"]);
+  await run("node", [path.join("tools", "ci", "dump-api.mjs"), "--mode=generated", "--skip-build"]);
 
-  const goldenEntries = (await fs.readdir(goldenDir)).filter((name) => name.endsWith(".d.ts") || name === "INDEX.txt").sort();
-  const generatedEntries = (await fs.readdir(generatedDir)).filter((name) => name.endsWith(".d.ts") || name === "INDEX.txt").sort();
+  const manifest = JSON.parse(await fs.readFile(normalizeConfigPath(manifestPath), "utf8"));
+  const publicItems = manifest.filter((item) => item?.kind === "public" && typeof item?.name === "string");
 
-  const missingInGenerated = goldenEntries.filter((name) => !generatedEntries.includes(name));
-  const extraInGenerated = generatedEntries.filter((name) => !goldenEntries.includes(name));
+  const goldenEntries = (await fs.readdir(goldenDir)).filter((name) => isGoldenDeclarationFile(name) || isIndexTextFile(name)).sort();
+  const generatedEntries = (await fs.readdir(generatedDir)).filter((name) => name.endsWith(".d.ts") || isIndexTextFile(name)).sort();
 
-  if (missingInGenerated.length > 0 || extraInGenerated.length > 0) {
+  const expectedPairs = [];
+  for (const item of publicItems) {
+    const goldenName = await goldenNameForPackage(item.name, goldenDir);
+    expectedPairs.push({
+      generatedName: generatedNameForPackage(item.name),
+      goldenName
+    });
+  }
+
+  const missingInGenerated = expectedPairs.filter(({ generatedName }) => !generatedEntries.includes(generatedName)).map(({ generatedName }) => generatedName);
+  const missingInGolden = expectedPairs.filter(({ goldenName }) => !goldenEntries.includes(goldenName)).map(({ goldenName }) => goldenName);
+  const expectedGeneratedSet = new Set(expectedPairs.map(({ generatedName }) => generatedName));
+  const expectedGoldenSet = new Set(expectedPairs.map(({ goldenName }) => goldenName));
+  const extraInGenerated = generatedEntries.filter((name) => !isIndexTextFile(name) && !expectedGeneratedSet.has(name));
+  const extraInGolden = goldenEntries.filter((name) => !isIndexTextFile(name) && !expectedGoldenSet.has(name));
+
+  const goldenIndexName = goldenEntries.find((name) => stripIndexExtension(name) === "INDEX");
+  const generatedIndexName = generatedEntries.find((name) => stripIndexExtension(name) === "INDEX");
+
+  if (missingInGenerated.length > 0 || missingInGolden.length > 0 || extraInGenerated.length > 0 || extraInGolden.length > 0 || !goldenIndexName || !generatedIndexName) {
     if (missingInGenerated.length > 0) {
       console.error(`Missing generated contract files: ${missingInGenerated.join(", ")}`);
     }
+    if (missingInGolden.length > 0) {
+      console.error(`Missing golden contract files: ${missingInGolden.join(", ")}`);
+    }
     if (extraInGenerated.length > 0) {
       console.error(`Unexpected generated contract files: ${extraInGenerated.join(", ")}`);
+    }
+    if (extraInGolden.length > 0) {
+      console.error(`Unexpected golden contract files: ${extraInGolden.join(", ")}`);
+    }
+    if (!goldenIndexName) {
+      console.error("Missing golden contract index file: expected INDEX or INDEX.txt");
+    }
+    if (!generatedIndexName) {
+      console.error("Missing generated contract index file: expected INDEX or INDEX.txt");
     }
     process.exitCode = 1;
     return;
@@ -103,13 +136,26 @@ async function main() {
     validateNoInternalLeaks(name, generatedText);
   }
 
-  for (const name of goldenEntries) {
-    const goldenPath = path.join(goldenDir, name);
-    const generatedPath = path.join(generatedDir, name);
+  for (const { goldenName, generatedName } of expectedPairs) {
+    const goldenPath = path.join(normalizeConfigPath(goldenDir), goldenName);
+    const generatedPath = path.join(normalizeConfigPath(generatedDir), generatedName);
     const [goldenText, generatedText] = await Promise.all([readText(goldenPath), readText(generatedPath)]);
     if (goldenText !== generatedText) {
-      console.error(`API contract mismatch: ${name}`);
+      console.error(`API contract mismatch: golden=${goldenName}, generated=${generatedName}`);
       console.error(simpleDiff(goldenText, generatedText));
+      process.exitCode = 1;
+      return;
+    }
+  }
+
+  if (goldenIndexName && generatedIndexName) {
+    const [goldenIndex, generatedIndex] = await Promise.all([
+      readText(path.join(normalizeConfigPath(goldenDir), goldenIndexName)),
+      readText(path.join(normalizeConfigPath(generatedDir), generatedIndexName))
+    ]);
+    if (goldenIndex !== generatedIndex) {
+      console.error(`API contract INDEX mismatch: golden=${goldenIndexName}, generated=${generatedIndexName}`);
+      console.error(simpleDiff(goldenIndex, generatedIndex));
       process.exitCode = 1;
       return;
     }

--- a/tools/ci/check-public-exports-exist.mjs
+++ b/tools/ci/check-public-exports-exist.mjs
@@ -2,16 +2,14 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { goldenNameForPackage, normalizeConfigPath } from "./api-contract-paths.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "../..");
-const manifestPath = path.join(repoRoot, "contracts/v1/manifest.json");
-const goldenDir = path.join(repoRoot, "contracts/v1/golden");
+const manifestPath = path.join(repoRoot, "contracts", "v1", "manifest.json");
+const goldenDir = path.join(repoRoot, "contracts", "v1", "golden");
 
-function pkgOutputName(name) {
-  return name.replace(/^@/, "").replace(/\//g, "__");
-}
 
 function pkgDirFromName(name) {
   return path.join(repoRoot, "packages", name.replace("@mesh/", ""));
@@ -36,7 +34,7 @@ async function exists(filePath) {
 }
 
 async function main() {
-  const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+  const manifest = JSON.parse(await fs.readFile(normalizeConfigPath(manifestPath), "utf8"));
   if (!Array.isArray(manifest)) {
     throw new Error("contracts/v1/manifest.json must contain an array");
   }
@@ -51,7 +49,7 @@ async function main() {
 
     const pkgDir = pkgDirFromName(item.name);
     const distDir = path.join(pkgDir, "dist");
-    const goldenPath = path.join(goldenDir, `${pkgOutputName(item.name)}.d.ts`);
+    const goldenPath = path.join(goldenDir, await goldenNameForPackage(item.name, goldenDir));
 
     if (!(await exists(path.join(distDir, "index.js")))) {
       missing.push(path.relative(repoRoot, path.join(distDir, "index.js")));

--- a/tools/ci/check-reasoncodes-policy.mjs
+++ b/tools/ci/check-reasoncodes-policy.mjs
@@ -2,17 +2,14 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { goldenNameForPackage, normalizeConfigPath } from "./api-contract-paths.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "../..");
 
-const manifestPath = path.join(repoRoot, "contracts/v1/manifest.json");
-const policyPath = path.join(repoRoot, "contracts/v1/reasonCodes-policy.md");
-
-function pkgOutputName(name) {
-  return name.replace(/^@/, "").replace(/\//g, "__");
-}
+const manifestPath = path.join(repoRoot, "contracts", "v1", "manifest.json");
+const policyPath = path.join(repoRoot, "contracts", "v1", "reasonCodes-policy.md");
 
 function uniq(values) {
   return [...new Set(values)];
@@ -57,28 +54,30 @@ function parseReasonCodesFromPolicy(text) {
 }
 
 async function resolveReasonCodesSourcePath() {
-  const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+  const manifest = JSON.parse(await fs.readFile(normalizeConfigPath(manifestPath), "utf8"));
   const shared = manifest.find((item) => item?.kind === "public" && item?.name === "@mesh/shared");
   if (!shared || typeof shared.entry !== "string") {
     throw new Error("Unable to resolve @mesh/shared entry from contracts/v1/manifest.json");
   }
 
-  const goldenEntry = path.join(repoRoot, "contracts/v1/golden", `${pkgOutputName(shared.name)}.d.ts`);
+  const goldenDir = path.join(repoRoot, "contracts", "v1", "golden");
+  const goldenName = await goldenNameForPackage(shared.name, goldenDir);
+  const goldenEntry = path.join(goldenDir, goldenName);
   const goldenText = await fs.readFile(goldenEntry, "utf8");
   const exportMatch = goldenText.match(/^export\s+\*\s+from\s+["'](\.\/reasonCodes\.js)["'];\s*$/m);
   if (!exportMatch) {
     throw new Error(`Could not find reasonCodes export in ${path.relative(repoRoot, goldenEntry)}`);
   }
 
-  const entryDir = path.dirname(shared.entry);
+  const entryDir = path.dirname(normalizeConfigPath(shared.entry));
   const reasonCodesRelTs = exportMatch[1].replace(/^\.\//, "").replace(/\.js$/, ".ts");
-  return path.join(repoRoot, "packages/shared", entryDir, reasonCodesRelTs);
+  return path.join(repoRoot, "packages", "shared", entryDir, reasonCodesRelTs);
 }
 
 async function main() {
   const [reasonCodesSourcePath, policyText] = await Promise.all([
     resolveReasonCodesSourcePath(),
-    fs.readFile(policyPath, "utf8")
+    fs.readFile(normalizeConfigPath(policyPath), "utf8")
   ]);
 
   const contractText = await fs.readFile(reasonCodesSourcePath, "utf8");

--- a/tools/ci/dump-api.mjs
+++ b/tools/ci/dump-api.mjs
@@ -3,11 +3,12 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
+import { generatedNameForPackage, normalizeConfigPath, packageSlug } from "./api-contract-paths.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "../..");
-const manifestPath = path.resolve(repoRoot, "contracts/v1/manifest.json");
+const manifestPath = path.resolve(repoRoot, "contracts", "v1", "manifest.json");
 
 function parseArgs(argv) {
   const options = { mode: "golden", skipBuild: false };
@@ -48,9 +49,6 @@ function normalizeDts(text) {
     .concat("\n");
 }
 
-function pkgOutputName(name) {
-  return name.replace(/^@/, "").replace(/\//g, "__");
-}
 
 function collectExportLines(text) {
   const lines = text.split("\n");
@@ -62,14 +60,14 @@ function collectExportLines(text) {
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
-  const manifestRaw = await fs.readFile(manifestPath, "utf8");
+  const manifestRaw = await fs.readFile(normalizeConfigPath(manifestPath), "utf8");
   const manifest = JSON.parse(manifestRaw);
 
   if (!Array.isArray(manifest) || manifest.length === 0) {
     throw new Error("contracts/v1/manifest.json must be a non-empty array");
   }
 
-  const outRoot = path.resolve(repoRoot, `contracts/v1/${options.mode}`);
+  const outRoot = path.resolve(repoRoot, "contracts", "v1", options.mode);
   const buildRoot = path.resolve(repoRoot, ".tmp/api-contract");
 
   if (!options.skipBuild) {
@@ -91,17 +89,17 @@ async function main() {
 
     const pkgDir = pkgDirFromName(item.name);
     const tsconfigPath = path.join(pkgDir, "tsconfig.json");
-    const pkgBuildOut = path.join(buildRoot, pkgOutputName(item.name));
+    const pkgBuildOut = path.join(buildRoot, packageSlug(item.name));
     await fs.mkdir(pkgBuildOut, { recursive: true });
 
     await run("pnpm", ["exec", "tsc", "-p", tsconfigPath, "--emitDeclarationOnly", "--declarationMap", "false", "--outDir", pkgBuildOut]);
 
-    const entryDts = `${item.entry.replace(/^src\//, "").replace(/\.ts$/, ".d.ts")}`;
+    const entryDts = normalizeConfigPath(item.entry).replace(/^src[\\/]/, "").replace(/\.ts$/, ".d.ts");
     const entryPath = path.join(pkgBuildOut, entryDts);
 
     const dtsRaw = await fs.readFile(entryPath, "utf8");
     const dtsNormalized = normalizeDts(dtsRaw);
-    const outName = `${pkgOutputName(item.name)}.d.ts`;
+    const outName = generatedNameForPackage(item.name);
     const outPath = path.join(outRoot, outName);
     await fs.writeFile(outPath, dtsNormalized, "utf8");
 
@@ -116,7 +114,7 @@ async function main() {
     }
   }
 
-  await fs.writeFile(path.join(outRoot, "INDEX.txt"), `${indexRows.join("\n")}\n`, "utf8");
+  await fs.writeFile(path.join(outRoot, "INDEX"), `${indexRows.join("\n")}\n`, "utf8");
 }
 
 main().catch((error) => {

--- a/tools/ci/update-api-contract.mjs
+++ b/tools/ci/update-api-contract.mjs
@@ -3,12 +3,13 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
+import { goldenNameForPackage, normalizeConfigPath, packageSlug } from "./api-contract-paths.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "../..");
-const manifestPath = path.resolve(repoRoot, "contracts/v1/manifest.json");
-const goldenDir = path.resolve(repoRoot, "contracts/v1/golden");
+const manifestPath = path.resolve(repoRoot, "contracts", "v1", "manifest.json");
+const goldenDir = path.resolve(repoRoot, "contracts", "v1", "golden");
 const tmpDir = path.resolve(repoRoot, ".tmp/api-contract-update");
 
 async function run(cmd, args, cwd = repoRoot) {
@@ -23,10 +24,6 @@ async function run(cmd, args, cwd = repoRoot) {
 
 function pkgDirFromName(name) {
   return path.resolve(repoRoot, "packages", name.replace("@mesh/", ""));
-}
-
-function pkgOutputName(name) {
-  return name.replace(/^@/, "").replace(/\//g, "__");
 }
 
 function normalizeDts(text) {
@@ -45,7 +42,7 @@ function normalizeDts(text) {
 }
 
 async function main() {
-  const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+  const manifest = JSON.parse(await fs.readFile(normalizeConfigPath(manifestPath), "utf8"));
   if (!Array.isArray(manifest) || manifest.length === 0) {
     throw new Error("contracts/v1/manifest.json must be a non-empty array");
   }
@@ -64,14 +61,14 @@ async function main() {
       throw new Error(`Invalid manifest item: ${JSON.stringify(item)}`);
     }
 
-    const pkgOutDir = path.join(tmpDir, pkgOutputName(item.name));
+    const pkgOutDir = path.join(tmpDir, packageSlug(item.name));
     await fs.mkdir(pkgOutDir, { recursive: true });
 
     await run("pnpm", [
       "exec",
       "tsc",
       "-p",
-      path.join(pkgDirFromName(item.name), "tsconfig.json"),
+      path.join(normalizeConfigPath(pkgDirFromName(item.name)), "tsconfig.json"),
       "--emitDeclarationOnly",
       "--declarationMap",
       "false",
@@ -79,9 +76,10 @@ async function main() {
       pkgOutDir
     ]);
 
-    const entryDts = item.entry.replace(/^src\//, "").replace(/\.ts$/, ".d.ts");
+    const normalizedEntry = normalizeConfigPath(item.entry);
+    const entryDts = normalizedEntry.replace(/^src[\\/]/, "").replace(/\.ts$/, ".d.ts");
     const sourceDtsPath = path.join(pkgOutDir, entryDts);
-    const targetName = `${pkgOutputName(item.name)}.d.ts`;
+    const targetName = await goldenNameForPackage(item.name, goldenDir);
     const targetPath = path.join(goldenDir, targetName);
 
     const sourceText = await fs.readFile(sourceDtsPath, "utf8");


### PR DESCRIPTION
### Motivation
- Ensure API-contract tooling works deterministically on Windows and POSIX by eliminating hardcoded separators and normalizing user/config paths. 
- Accept existing golden declaration files in either `.d` or `.d.ts` without changing the update intent, and preserve the existing format when writing. 
- Provide a stable, explicit package->golden filename mapping to avoid OS- or heuristic-dependent mismatches.

### Description
- Add a shared helper `tools/ci/api-contract-paths.mjs` providing `normalizeConfigPath`, stable `packageSlug`, `generatedNameForPackage`, and `goldenNameForPackage` which detects `.d` or `.d.ts` and prefers `.d` when present. 
- Update CI scripts (`tools/ci/check-api-contract.mjs`, `update-api-contract.mjs`, `dump-api.mjs`, `check-reasoncodes-policy.mjs`, `check-public-exports-exist.mjs`) to use `node:path` (`path.join`, `path.resolve`, `path.normalize`) and the shared helpers, remove hardcoded separators, and normalize manifest/entry paths. 
- Make index handling tolerant to `INDEX` or `INDEX.txt` and compare them as text, and make the generated names deterministic via `generatedNameForPackage`. 
- Adjust `contracts/v1/README.md` to document `.d`/`.d.ts` tolerance and the cross-platform/path-normalization behavior.

### Testing
- Ran `pnpm -r build` (after installing dependencies) and the workspace built successfully. 
- Ran `pnpm check:api-contract` and it passed (`API contract check passed.`). 
- Ran `pnpm api:contract:update` and it completed successfully, reporting overwritten golden files. 
- Ran `pnpm check:reasoncodes-policy` and it passed (`reasonCodes policy check passed`). 
- Ran `pnpm test` (conformance tests) and all conformance tests passed (12 test files, 51 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699226f1204883219108fb1b62a95efc)