### PR TITLE
Codex-generated pull request

### DIFF
--- a/packages/runtime-local/examples/restart-e2e.mjs
+++ b/packages/runtime-local/examples/restart-e2e.mjs
@@ -1,0 +1,43 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import assert from "node:assert/strict";
+import { createRuntimeLocal } from "../dist/index.js";
+
+const rootDir = path.resolve(process.cwd(), ".mesh-runtime-example");
+const config = {
+  rootDir,
+  graphSpaceId: "space-example",
+  principalId: "principal-example",
+  snapshotPolicy: { minTx: 2 }
+};
+
+const command = (idx) => ({
+  graphSpaceId: config.graphSpaceId,
+  commandId: `example-cmd-${idx}`,
+  actorId: "example-actor",
+  idempotencyKey: `example-idem-${idx}`,
+  payload: { idx }
+});
+
+await fs.rm(rootDir, { recursive: true, force: true });
+
+const runtime1 = await createRuntimeLocal(config);
+await runtime1.start();
+for (let i = 1; i <= 3; i += 1) {
+  await runtime1.write(command(i));
+}
+const state1 = await runtime1.read();
+await runtime1.stop();
+
+const runtime2 = await createRuntimeLocal(config);
+await runtime2.start();
+const state2 = await runtime2.read();
+await runtime2.stop();
+
+assert.equal(state2.head.tx, state1.head.tx);
+assert.deepEqual(state2.view, state1.view);
+
+console.log("Runtime restart e2e succeeded", {
+  head: state2.head.tx,
+  nodeCount: state2.view?.nodeCount
+});

--- a/packages/runtime-local/package.json
+++ b/packages/runtime-local/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@mesh/runtime-local",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@mesh/shared": "workspace:*",
+    "@mesh/kernel-minimal": "workspace:*",
+    "@mesh/eventstore-local": "workspace:*",
+    "@mesh/projection-minimal": "workspace:*",
+    "@mesh/snapshot-minimal": "workspace:*"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  }
+}

--- a/packages/runtime-local/src/index.ts
+++ b/packages/runtime-local/src/index.ts
@@ -1,0 +1,155 @@
+import path from "node:path";
+import { FileBackedLocalEventStore } from "@mesh/eventstore-local";
+import { KernelMinimalImpl } from "@mesh/kernel-minimal";
+import { PrincipalProjectionEngine, type ProjectionSnapshot } from "@mesh/projection-minimal";
+import { FileBackedSnapshotStore, type SnapshotEnvelope } from "@mesh/snapshot-minimal";
+import type { Command, CommandOutcome, PrincipalContext } from "@mesh/shared";
+
+export type RuntimeLocalConfig = {
+  rootDir: string;
+  graphSpaceId: string;
+  principalId: string;
+  snapshotPolicy?: { minTx?: number; intervalMs?: number };
+  replayBudget?: { maxTx?: number; maxMs?: number };
+  quotas?: { maxLogBytes?: number; maxSnapshots?: number };
+};
+
+export type TxHead = string;
+
+export type RuntimeState<TView = unknown> = {
+  head: { tx: TxHead };
+  view: TView;
+};
+
+export interface RuntimeLocal<TView = unknown> {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  write(cmd: Command): Promise<CommandOutcome>;
+  read(): Promise<RuntimeState<TView>>;
+  status(): { started: boolean };
+}
+
+export class RuntimeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RuntimeError";
+  }
+}
+
+class RuntimeLocalImpl implements RuntimeLocal {
+  private started = false;
+  private readonly principal: PrincipalContext;
+  private lastSnapshot: SnapshotEnvelope<ProjectionSnapshot> | null = null;
+
+  constructor(
+    private readonly config: RuntimeLocalConfig,
+    private readonly eventStore: FileBackedLocalEventStore,
+    private readonly kernel: KernelMinimalImpl,
+    private readonly projectionEngine: PrincipalProjectionEngine,
+    private readonly snapshotStore: FileBackedSnapshotStore<ProjectionSnapshot>
+  ) {
+    this.principal = { principalId: config.principalId };
+  }
+
+  async start(): Promise<void> {
+    if (this.started) return;
+
+    if (this.config.snapshotPolicy) {
+      this.lastSnapshot = await this.snapshotStore.loadLatestSnapshot({
+        graphSpaceId: this.config.graphSpaceId,
+        principalId: this.principal.principalId
+      });
+
+      if (await this.shouldSnapshot()) {
+        const startedAt = Date.now();
+        const rebuilt = await this.projectionEngine.rebuildWithSnapshot({
+          principal: this.principal,
+          snapshotStore: this.snapshotStore
+        });
+        this.enforceReplayBudget(rebuilt.replayStats.appliedTxCount, Date.now() - startedAt);
+        this.lastSnapshot = await this.snapshotStore.loadLatestSnapshot({
+          graphSpaceId: this.config.graphSpaceId,
+          principalId: this.principal.principalId
+        });
+      }
+    }
+
+    this.started = true;
+  }
+
+  async stop(): Promise<void> {
+    if (!this.started) return;
+    await this.eventStore.close();
+    this.started = false;
+  }
+
+  async write(cmd: Command): Promise<CommandOutcome> {
+    this.assertStarted();
+    return this.kernel.execute(cmd);
+  }
+
+  async read(): Promise<RuntimeState<ProjectionSnapshot>> {
+    this.assertStarted();
+    const view = await this.projectionEngine.incremental(this.principal);
+    return {
+      head: { tx: String(view.cursor) },
+      view
+    };
+  }
+
+  status(): { started: boolean } {
+    return { started: this.started };
+  }
+
+  private async shouldSnapshot(): Promise<boolean> {
+    if (!this.config.snapshotPolicy) return false;
+    if (!this.lastSnapshot) return true;
+
+    const principalHead = await this.eventStore.getPrincipalCursorHead(this.config.graphSpaceId, this.principal);
+    const minTx = this.config.snapshotPolicy.minTx;
+    if (typeof minTx === "number" && minTx > 0) {
+      const txDelta = principalHead - this.lastSnapshot.cursorAt;
+      if (txDelta < minTx) return false;
+    }
+
+    const intervalMs = this.config.snapshotPolicy.intervalMs;
+    if (typeof intervalMs === "number" && intervalMs > 0) {
+      const createdAtMs = this.lastSnapshot.createdAt ? Date.parse(this.lastSnapshot.createdAt) : Number.NaN;
+      if (Number.isFinite(createdAtMs) && Date.now() - createdAtMs < intervalMs) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private enforceReplayBudget(appliedTxCount: number, elapsedMs: number): void {
+    const maxTx = this.config.replayBudget?.maxTx;
+    if (typeof maxTx === "number" && appliedTxCount > maxTx) {
+      throw new RuntimeError(`Replay budget exceeded: appliedTxCount ${appliedTxCount} > maxTx ${maxTx}`);
+    }
+
+    const maxMs = this.config.replayBudget?.maxMs;
+    if (typeof maxMs === "number" && elapsedMs > maxMs) {
+      throw new RuntimeError(`Replay budget exceeded: elapsedMs ${elapsedMs} > maxMs ${maxMs}`);
+    }
+  }
+
+  private assertStarted(): void {
+    if (!this.started) {
+      throw new RuntimeError("Runtime not started");
+    }
+  }
+}
+
+export async function createRuntimeLocal(config: RuntimeLocalConfig): Promise<RuntimeLocal> {
+  const eventStorePath = path.join(config.rootDir, "eventstore", "events.json");
+  const snapshotPath = path.join(config.rootDir, "snapshots", "snapshots.json");
+
+  const eventStore = await FileBackedLocalEventStore.open(eventStorePath);
+  const kernel = new KernelMinimalImpl(eventStore);
+  const projectionEngine = new PrincipalProjectionEngine(eventStore, config.graphSpaceId);
+  const snapshotStore = new FileBackedSnapshotStore<ProjectionSnapshot>(snapshotPath);
+
+  return new RuntimeLocalImpl(config, eventStore, kernel, projectionEngine, snapshotStore);
+}

--- a/packages/runtime-local/src/node-shims.d.ts
+++ b/packages/runtime-local/src/node-shims.d.ts
@@ -1,0 +1,4 @@
+declare module "node:path" {
+  const path: any;
+  export default path;
+}

--- a/packages/runtime-local/test/runtime-local.test.ts
+++ b/packages/runtime-local/test/runtime-local.test.ts
@@ -1,0 +1,109 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { Command } from "@mesh/shared";
+import { createRuntimeLocal } from "../src/index.js";
+
+const roots: string[] = [];
+
+async function makeRootDir(prefix: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), `mesh-runtime-local-${prefix}-`));
+  roots.push(root);
+  return root;
+}
+
+function makeCommand(graphSpaceId: string, idx: number): Command {
+  return {
+    graphSpaceId,
+    commandId: `cmd-${idx}`,
+    actorId: "actor-a",
+    idempotencyKey: `idem-${idx}`,
+    payload: { idx }
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0, roots.length).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+describe("@mesh/runtime-local", () => {
+  it("restart preserves view and head", async () => {
+    const rootDir = await makeRootDir("restart");
+    const config = {
+      rootDir,
+      graphSpaceId: "space-restart",
+      principalId: "principal-restart"
+    };
+
+    const runtime1 = await createRuntimeLocal(config);
+    await runtime1.start();
+    await runtime1.write(makeCommand(config.graphSpaceId, 1));
+    await runtime1.write(makeCommand(config.graphSpaceId, 2));
+    const state1 = await runtime1.read();
+    await runtime1.stop();
+
+    const runtime2 = await createRuntimeLocal(config);
+    await runtime2.start();
+    const state2 = await runtime2.read();
+    await runtime2.stop();
+
+    expect(state2.head.tx).toBe(state1.head.tx);
+    expect(state2.view).toEqual(state1.view);
+  });
+
+  it("read() is pure and does not create snapshots", async () => {
+    const rootDir = await makeRootDir("read-pure");
+    const config = {
+      rootDir,
+      graphSpaceId: "space-pure",
+      principalId: "principal-pure",
+      snapshotPolicy: { minTx: 1 }
+    };
+
+    const runtime = await createRuntimeLocal(config);
+    await runtime.start();
+    await runtime.write(makeCommand(config.graphSpaceId, 1));
+
+    const snapshotPath = path.join(rootDir, "snapshots", "snapshots.json");
+    const beforeRead = await fs.readFile(snapshotPath, "utf8");
+    await runtime.read();
+    const afterRead = await fs.readFile(snapshotPath, "utf8");
+    await runtime.stop();
+
+    expect(afterRead).toBe(beforeRead);
+  });
+
+  it("start() writes snapshot when policy is enabled", async () => {
+    const rootDir = await makeRootDir("start-snapshot");
+    const graphSpaceId = "space-snapshot";
+
+    const seedRuntime = await createRuntimeLocal({
+      rootDir,
+      graphSpaceId,
+      principalId: "principal-snapshot"
+    });
+    await seedRuntime.start();
+    await seedRuntime.write(makeCommand(graphSpaceId, 1));
+    await seedRuntime.stop();
+
+    const runtime = await createRuntimeLocal({
+      rootDir,
+      graphSpaceId,
+      principalId: "principal-snapshot",
+      snapshotPolicy: { minTx: 1 }
+    });
+    await runtime.start();
+
+    const snapshotPath = path.join(rootDir, "snapshots", "snapshots.json");
+    const snapshotRaw = JSON.parse(await fs.readFile(snapshotPath, "utf8")) as {
+      snapshots: Array<{ cursorAt: number; graphSpaceId: string; principalId: string }>;
+    };
+
+    await runtime.stop();
+
+    const scoped = snapshotRaw.snapshots.filter((snap) => snap.graphSpaceId === graphSpaceId && snap.principalId === "principal-snapshot");
+    expect(scoped.length).toBeGreaterThanOrEqual(1);
+    expect(scoped.at(-1)?.cursorAt).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/runtime-local/tsconfig.json
+++ b/packages/runtime-local/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [
+    "src/**/*.ts"
+  ],
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  }
+}

--- a/packages/runtime-local/vitest.config.ts
+++ b/packages/runtime-local/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@mesh/shared": path.resolve(__dirname, "../shared/src/index.ts"),
+      "@mesh/kernel-minimal": path.resolve(__dirname, "../kernel-minimal/src/index.ts"),
+      "@mesh/eventstore-local": path.resolve(__dirname, "../eventstore-local/src/index.ts"),
+      "@mesh/projection-minimal": path.resolve(__dirname, "../projection-minimal/src/index.ts"),
+      "@mesh/snapshot-minimal": path.resolve(__dirname, "../snapshot-minimal/src/index.ts")
+    }
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,24 @@ importers:
         specifier: workspace:*
         version: link:../snapshot-minimal
 
+  packages/runtime-local:
+    dependencies:
+      '@mesh/eventstore-local':
+        specifier: workspace:*
+        version: link:../eventstore-local
+      '@mesh/kernel-minimal':
+        specifier: workspace:*
+        version: link:../kernel-minimal
+      '@mesh/projection-minimal':
+        specifier: workspace:*
+        version: link:../projection-minimal
+      '@mesh/shared':
+        specifier: workspace:*
+        version: link:../shared
+      '@mesh/snapshot-minimal':
+        specifier: workspace:*
+        version: link:../snapshot-minimal
+
   packages/shared: {}
 
   packages/snapshot-minimal:


### PR DESCRIPTION
## Phase 15-B: add @mesh/runtime-local minimal runtime library

What: nouveau package @mesh/runtime-local (start/stop/write/read), persistence via rootDir, read via projection-minimal, snapshot policy déclenchée hors read().
Why: runtime intégrable par une app sans importer d’internals.
Non-goals: pas de query DSL, pas de changement de surface @mesh/kernel-minimal.
Tests: pnpm -r build, pnpm -r test, + test runtime-local + example e2e.
Notes: read() pure, head.tx opaque string.