### PR TITLE
fix(shared): allow tests to pass when no test files exist

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "vitest run"
+    "test": "vitest run --passWithNoTests"
   },
   "types": "./dist/index.d.ts"
 }


### PR DESCRIPTION
### Motivation
- Prevent package-level or recursive `test` invocations from failing CI when `@mesh/shared` has no test files by making Vitest treat no-tests as success.

### Description
- Change `packages/shared/package.json` `scripts.test` from `vitest run` to `vitest run --passWithNoTests` and leave all other fields unchanged.

### Testing
- Ran `pnpm --filter @mesh/shared test`, which reported "No test files found, exiting with code 0" and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992378587708321a3424c77f93e1578)