### PR TITLE
Harden @mesh/runtime-local startup seeding and example isolation

### DIFF
--- a/packages/runtime-local/README.md
+++ b/packages/runtime-local/README.md
@@ -1,0 +1,52 @@
+# @mesh/runtime-local
+
+`@mesh/runtime-local` is a local persistent runtime for Mesh Explorer.
+It assembles:
+
+- `@mesh/kernel-minimal` for command execution
+- `@mesh/eventstore-local` for durable event storage
+- `@mesh/projection-minimal` for principal projection reads
+- `@mesh/snapshot-minimal` for optional startup snapshot maintenance
+
+## Public API
+
+```ts
+import { createRuntimeLocal } from "@mesh/runtime-local";
+
+const runtime = await createRuntimeLocal({
+  rootDir: "/tmp/mesh-runtime",
+  graphSpaceId: "space-1",
+  principalId: "principal-1",
+  snapshotPolicy: { minTx: 100, intervalMs: 60_000 }
+});
+
+await runtime.start();
+await runtime.write(command);
+const state = await runtime.read();
+await runtime.stop();
+```
+
+`createRuntimeLocal(config)` returns a runtime with:
+
+- `start()`
+- `write(cmd)`
+- `read()`
+- `stop()`
+- `status()`
+
+## Contract
+
+- `read()` is pure: it only reads projection state and does not write snapshots.
+- `head.tx` is an opaque string for equality checks (ETag-style semantics).
+- Snapshots may be created in `start()` as maintenance, based on `snapshotPolicy`.
+
+## Restart example
+
+Build workspace packages first, then run the runtime-local restart example:
+
+```bash
+pnpm -r build
+node packages/runtime-local/examples/restart-e2e.mjs
+```
+
+The example writes events, restarts the runtime, and verifies head/view stability across restarts.

--- a/packages/runtime-local/examples/restart-e2e.mjs
+++ b/packages/runtime-local/examples/restart-e2e.mjs
@@ -3,7 +3,8 @@ import path from "node:path";
 import assert from "node:assert/strict";
 import { createRuntimeLocal } from "../dist/index.js";
 
-const rootDir = path.resolve(process.cwd(), ".mesh-runtime-example");
+const runId = `${process.pid}-${Date.now()}`;
+const rootDir = path.resolve(process.cwd(), `.mesh-runtime-example-${runId}`);
 const config = {
   rootDir,
   graphSpaceId: "space-example",

--- a/packages/runtime-local/src/index.ts
+++ b/packages/runtime-local/src/index.ts
@@ -60,7 +60,9 @@ class RuntimeLocalImpl implements RuntimeLocal {
         principalId: this.principal.principalId
       });
 
-      if (await this.shouldSnapshot()) {
+      // Snapshot policy controls startup maintenance only; read() output must stay deterministic.
+      const shouldCreateSnapshot = await this.shouldSnapshot();
+      if (shouldCreateSnapshot) {
         const startedAt = Date.now();
         const rebuilt = await this.projectionEngine.rebuildWithSnapshot({
           principal: this.principal,
@@ -71,6 +73,8 @@ class RuntimeLocalImpl implements RuntimeLocal {
           graphSpaceId: this.config.graphSpaceId,
           principalId: this.principal.principalId
         });
+      } else {
+        await this.projectionEngine.rebuild(this.principal);
       }
     }
 
@@ -115,6 +119,7 @@ class RuntimeLocalImpl implements RuntimeLocal {
     const intervalMs = this.config.snapshotPolicy.intervalMs;
     if (typeof intervalMs === "number" && intervalMs > 0) {
       const createdAtMs = this.lastSnapshot.createdAt ? Date.parse(this.lastSnapshot.createdAt) : Number.NaN;
+      // Time gates snapshot maintenance only; it must never influence read() view contents.
       if (Number.isFinite(createdAtMs) && Date.now() - createdAtMs < intervalMs) {
         return false;
       }


### PR DESCRIPTION
### Motivation
- Ensure runtimes started with a `snapshotPolicy` always have their projection cache seeded so the first `read()` is not forced to replay from the beginning.
- Clarify that time-based snapshot gating is maintenance only and must not leak into or change the deterministic view returned by `read()`.
- Avoid collisions and leftover artifacts when running the restart example multiple times or in parallel.

### Description
- In `start()` seed the projection cache whenever `snapshotPolicy` is configured by calling `projectionEngine.rebuildWithSnapshot(...)` when `shouldSnapshot()` is true, or a pure `projectionEngine.rebuild(this.principal)` when snapshot creation is gated off, and set `started` only after initialization completes.
- Add inline comments in `start()`/`shouldSnapshot()` explaining that `Date.now()` is used only for maintenance gating and must not influence the `read()` view contents.
- Update `packages/runtime-local/examples/restart-e2e.mjs` to use a unique per-run `rootDir` via `const runId = \\`${process.pid}-${Date.now()}\\`` and retain cleanup for that directory to avoid collisions.
- Add `packages/runtime-local/README.md` with a brief description, public API snippet (`createRuntimeLocal(config)` → `start`/`write`/`read`/`stop`), contract bullets (including `read()` purity and opaque `head.tx`), and example run instructions.

### Testing
- Ran `pnpm install` which completed successfully.
- Ran `pnpm -r build` and the workspace built successfully including `packages/runtime-local`.
- Ran `pnpm --filter @mesh/runtime-local test` and the package tests passed (`3 tests` succeeded).
- Ran the example with `node packages/runtime-local/examples/restart-e2e.mjs` and it printed a successful restart result.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69923db43978832190a2b74b4d4dba2e)