### PR TITLE
feat(cli): add minimal local mesh CLI package

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,28 @@
+# @mesh/cli
+
+Minimal CLI for local Mesh runtime operations.
+
+## Usage
+
+```bash
+mesh status
+mesh read --rootDir ./data --graphSpaceId demo --principalId alice
+mesh write --rootDir ./data --graphSpaceId demo --principalId alice \
+  --actorId alice --commandId cmd-1 --idempotencyKey idem-1 \
+  --payloadJson '{"type":"set","value":1}'
+```
+
+All non-help output is JSON on stdout.
+
+## Commands
+
+- `mesh write`: starts runtime, submits one command, prints write outcome JSON, and stops.
+- `mesh read`: starts runtime, reads default view `{ head, view }`, and stops.
+- `mesh status`: prints basic status and optional file existence checks.
+
+Optional runtime flags for read/write:
+
+- `--snapshotMinTx <n>`
+- `--snapshotIntervalMs <n>`
+- `--replayMaxTx <n>`
+- `--replayMaxMs <n>`

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@mesh/cli",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "mesh": "./dist/bin/mesh.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@mesh/runtime-local": "workspace:*",
+    "@mesh/shared": "workspace:*"
+  }
+}

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -1,0 +1,109 @@
+export type CliCommandName = "write" | "read" | "status" | "help" | "version";
+
+export type ParsedCli = {
+  command: CliCommandName;
+  flags: Record<string, string>;
+};
+
+export type ParsedRuntimeConfig = {
+  rootDir: string;
+  graphSpaceId: string;
+  principalId: string;
+  snapshotPolicy?: { minTx?: number; intervalMs?: number };
+  replayBudget?: { maxTx?: number; maxMs?: number };
+};
+
+export function parseArgs(argv: string[]): ParsedCli {
+  const [rawCommand, ...rest] = argv;
+  const normalized = rawCommand ?? "help";
+
+  if (normalized === "--help" || normalized === "-h") {
+    return { command: "help", flags: {} };
+  }
+
+  if (normalized === "--version" || normalized === "-v") {
+    return { command: "version", flags: {} };
+  }
+
+  if (!isCliCommand(normalized)) {
+    throw new Error(`Unknown command: ${normalized}`);
+  }
+
+  if (rest.length === 1 && (rest[0] === "--help" || rest[0] === "-h")) {
+    return { command: "help", flags: {} };
+  }
+
+  if (rest.length === 1 && (rest[0] === "--version" || rest[0] === "-v")) {
+    return { command: "version", flags: {} };
+  }
+
+  const flags: Record<string, string> = {};
+  for (let i = 0; i < rest.length; i += 1) {
+    const token = rest[i];
+    if (!token.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${token}`);
+    }
+
+    const value = rest[i + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for ${token}`);
+    }
+
+    flags[token.slice(2)] = value;
+    i += 1;
+  }
+
+  return {
+    command: normalized,
+    flags
+  };
+}
+
+function isCliCommand(command: string): command is "write" | "read" | "status" {
+  return command === "write" || command === "read" || command === "status";
+}
+
+function getRequired(flags: Record<string, string>, key: string): string {
+  const value = flags[key];
+  if (!value) {
+    throw new Error(`Missing required flag --${key}`);
+  }
+  return value;
+}
+
+function getOptionalNumber(flags: Record<string, string>, key: string): number | undefined {
+  const value = flags[key];
+  if (value === undefined) return undefined;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Flag --${key} must be a number`);
+  }
+  return parsed;
+}
+
+export function buildRuntimeConfig(flags: Record<string, string>): ParsedRuntimeConfig {
+  const snapshotMinTx = getOptionalNumber(flags, "snapshotMinTx");
+  const snapshotIntervalMs = getOptionalNumber(flags, "snapshotIntervalMs");
+  const replayMaxTx = getOptionalNumber(flags, "replayMaxTx");
+  const replayMaxMs = getOptionalNumber(flags, "replayMaxMs");
+
+  return {
+    rootDir: getRequired(flags, "rootDir"),
+    graphSpaceId: getRequired(flags, "graphSpaceId"),
+    principalId: getRequired(flags, "principalId"),
+    snapshotPolicy:
+      snapshotMinTx !== undefined || snapshotIntervalMs !== undefined
+        ? {
+            minTx: snapshotMinTx,
+            intervalMs: snapshotIntervalMs
+          }
+        : undefined,
+    replayBudget:
+      replayMaxTx !== undefined || replayMaxMs !== undefined
+        ? {
+            maxTx: replayMaxTx,
+            maxMs: replayMaxMs
+          }
+        : undefined
+  };
+}

--- a/packages/cli/src/bin/mesh.ts
+++ b/packages/cli/src/bin/mesh.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+import { runCli } from "../index.js";
+
+const code = await runCli(process.argv.slice(2));
+process.exit(code);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,161 @@
+import { access } from "node:fs/promises";
+import path from "node:path";
+import { createRuntimeLocal } from "@mesh/runtime-local";
+import type { Command } from "@mesh/shared";
+import { buildRuntimeConfig, parseArgs } from "./args.js";
+
+const HELP_TEXT = `Usage: mesh <command> [options]
+
+Commands:
+  write    Write one command payload to local runtime.
+  read     Read default runtime view.
+  status   Print CLI/runtime status.
+  help     Show help.
+  version  Show version.
+
+Common options:
+  --rootDir <path>
+  --graphSpaceId <id>
+  --principalId <id>
+
+Write options:
+  --actorId <id>
+  --commandId <id>
+  --idempotencyKey <key>
+  --payloadJson <json>
+  --requireBaseRevision <json>
+
+Runtime tuning options:
+  --snapshotMinTx <n>
+  --snapshotIntervalMs <n>
+  --replayMaxTx <n>
+  --replayMaxMs <n>
+`;
+
+function getRequired(flags: Record<string, string>, key: string): string {
+  const value = flags[key];
+  if (!value) {
+    throw new Error(`Missing required flag --${key}`);
+  }
+  return value;
+}
+
+async function runWrite(flags: Record<string, string>): Promise<number> {
+  const runtime = await createRuntimeLocal(buildRuntimeConfig(flags));
+
+  try {
+    await runtime.start();
+    const payload = JSON.parse(getRequired(flags, "payloadJson")) as Record<string, unknown>;
+    const requireBaseRevisionRaw = flags.requireBaseRevision;
+
+    const command: Command = {
+      graphSpaceId: getRequired(flags, "graphSpaceId"),
+      actorId: getRequired(flags, "actorId"),
+      commandId: getRequired(flags, "commandId"),
+      idempotencyKey: getRequired(flags, "idempotencyKey"),
+      payload,
+      requireBaseRevision:
+        requireBaseRevisionRaw === undefined
+          ? undefined
+          : (JSON.parse(requireBaseRevisionRaw) as unknown as Command["requireBaseRevision"])
+    };
+
+    const outcome = await runtime.write(command);
+    process.stdout.write(`${JSON.stringify(outcome)}\n`);
+    return outcome.status === "committed" ? 0 : 2;
+  } finally {
+    await runtime.stop();
+  }
+}
+
+async function runRead(flags: Record<string, string>): Promise<number> {
+  const runtime = await createRuntimeLocal(buildRuntimeConfig(flags));
+
+  try {
+    await runtime.start();
+    const state = await runtime.read();
+    process.stdout.write(`${JSON.stringify({ head: state.head, view: state.view })}\n`);
+    return 0;
+  } finally {
+    await runtime.stop();
+  }
+}
+
+async function runStatus(flags: Record<string, string>): Promise<number> {
+  if (!flags.rootDir) {
+    process.stdout.write(`${JSON.stringify({ ok: true, started: false })}\n`);
+    return 0;
+  }
+
+  const eventstorePath = path.join(flags.rootDir, "eventstore", "events.json");
+  const snapshotsPath = path.join(flags.rootDir, "snapshots", "snapshots.json");
+
+  const [eventstoreExists, snapshotsExists] = await Promise.all([
+    exists(eventstorePath),
+    exists(snapshotsPath)
+  ]);
+
+  process.stdout.write(
+    `${JSON.stringify({
+      ok: true,
+      started: false,
+      rootDir: flags.rootDir,
+      files: {
+        eventstore: { path: eventstorePath, exists: eventstoreExists },
+        snapshots: { path: snapshotsPath, exists: snapshotsExists }
+      }
+    })}\n`
+  );
+
+  return 0;
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function printError(error: unknown): void {
+  const message = error instanceof Error ? error.message : "Unknown error";
+  process.stderr.write(`${message}\n`);
+}
+
+function printVersion(): void {
+  process.stdout.write(`${JSON.stringify({ name: "@mesh/cli", version: "0.1.0" })}\n`);
+}
+
+function printHelp(): void {
+  process.stdout.write(HELP_TEXT);
+}
+
+export async function runCli(argv: string[]): Promise<number> {
+  try {
+    const parsed = parseArgs(argv);
+
+    if (parsed.command === "help") {
+      printHelp();
+      return 0;
+    }
+
+    if (parsed.command === "version") {
+      printVersion();
+      return 0;
+    }
+
+    if (parsed.command === "write") return await runWrite(parsed.flags);
+    if (parsed.command === "read") return await runRead(parsed.flags);
+    return await runStatus(parsed.flags);
+  } catch (error) {
+    printError(error);
+    if (error instanceof Error && error.message.startsWith("Missing required flag")) {
+      printHelp();
+    }
+    return 1;
+  }
+}
+
+export { parseArgs, buildRuntimeConfig } from "./args.js";

--- a/packages/cli/src/node-shims.d.ts
+++ b/packages/cli/src/node-shims.d.ts
@@ -1,0 +1,15 @@
+declare module "node:fs/promises" {
+  export const access: any;
+}
+
+declare module "node:path" {
+  const path: any;
+  export default path;
+}
+
+declare const process: {
+  argv: string[];
+  stdout: { write: (chunk: string) => void };
+  stderr: { write: (chunk: string) => void };
+  exit: (code?: number) => never;
+};

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { buildRuntimeConfig, parseArgs } from "../src/args.js";
+
+describe("@mesh/cli arg parsing", () => {
+  it("parses write flags", () => {
+    const parsed = parseArgs([
+      "write",
+      "--rootDir",
+      "./tmp",
+      "--graphSpaceId",
+      "space-a",
+      "--principalId",
+      "principal-a",
+      "--actorId",
+      "actor-a",
+      "--commandId",
+      "cmd-1",
+      "--idempotencyKey",
+      "idem-1",
+      "--payloadJson",
+      '{"x":1}'
+    ]);
+
+    expect(parsed.command).toBe("write");
+    expect(parsed.flags.rootDir).toBe("./tmp");
+    expect(parsed.flags.payloadJson).toBe('{"x":1}');
+  });
+
+  it("requires values for flags", () => {
+    expect(() => parseArgs(["read", "--rootDir"])).toThrow("Missing value for --rootDir");
+  });
+
+  it("builds runtime config with optional tuning flags", () => {
+    const cfg = buildRuntimeConfig({
+      rootDir: "./tmp",
+      graphSpaceId: "space-a",
+      principalId: "principal-a",
+      snapshotMinTx: "1",
+      snapshotIntervalMs: "100",
+      replayMaxTx: "5",
+      replayMaxMs: "50"
+    });
+
+    expect(cfg.snapshotPolicy).toEqual({ minTx: 1, intervalMs: 100 });
+    expect(cfg.replayBudget).toEqual({ maxTx: 5, maxMs: 50 });
+  });
+});

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.d.ts"
+  ],
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,15 @@ importers:
         specifier: 4.57.1
         version: 4.57.1
 
+  packages/cli:
+    dependencies:
+      '@mesh/runtime-local':
+        specifier: workspace:*
+        version: link:../runtime-local
+      '@mesh/shared':
+        specifier: workspace:*
+        version: link:../shared
+
   packages/conformance-harness:
     dependencies:
       '@mesh/eventstore-local':


### PR DESCRIPTION
### Motivation

- Provide a tiny, dependency-light CLI that wraps the local runtime from `@mesh/runtime-local` so users can start a runtime, write a command, read the default view, and stop cleanly from the command line. 
- Keep scope minimal and deterministic: no interactive UI, no plugins, no distributed features, and only machine-readable JSON output for programmatic consumption.

### Description

- Add a new workspace package `@mesh/cli` with ESM output and a `mesh` binary mapped to `dist/bin/mesh.js` via `package.json`.
- Implement `mesh write`, `mesh read`, and `mesh status` subcommands that create/start a runtime via `createRuntimeLocal`, call `runtime.write()`/`runtime.read()`, print JSON to stdout, and always call `runtime.stop()` in a `finally` block.
- Provide flag parsing and validation (minimal custom parser) and plumb runtime tuning flags: `--snapshotMinTx`, `--snapshotIntervalMs`, `--replayMaxTx`, and `--replayMaxMs`.
- Ensure CLI does not expose internals; only imports `@mesh/runtime-local` and `@mesh/shared`; include small TypeScript node shims so package builds cleanly in the monorepo.
- Add lightweight unit tests for argument parsing and runtime-config building, and a concise `README.md` with usage examples.

### Testing

- Ran `pnpm --filter @mesh/cli test` which executed the unit tests and they passed (`3 tests` succeeded).
- Ran `pnpm -r build` to compile the workspace and the TypeScript build completed successfully.
- Performed smoke CLI validation: `node packages/cli/dist/bin/mesh.js --help` and an end-to-end smoke flow that executed `mesh write` then `mesh read` against a temporary `rootDir`, both of which produced expected JSON output (write returned a committed outcome and read returned `{ head, view }`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69924061e7988321bd29ff9fdfedeaad)