### PR TITLE
Phase 15-C: add CLI/runtime operational hardening tests and guarantees doc

### DIFF
--- a/docs/operational-guarantees.md
+++ b/docs/operational-guarantees.md
@@ -1,0 +1,54 @@
+# Mesh Explorer Operational Guarantees
+
+This note captures runtime-local + CLI operational contracts relied on by tooling and automation.
+
+## Runtime contracts (`@mesh/runtime-local`)
+
+### `runtime.start()` performs startup maintenance
+
+- `start()` is responsible for startup/rebuild behavior.
+- When `snapshotPolicy` is configured, `start()` **may** load snapshots and create/update snapshots as maintenance.
+- Snapshot policy gates are evaluated during `start()` (for example `minTx`, `intervalMs`).
+- Maintenance decisions do not change command semantics; they only affect startup performance.
+
+### `runtime.read()` is pure
+
+- `read()` returns a deterministic `{ head, view }` for current committed state.
+- `read()` does **not** run compaction.
+- `read()` does **not** create or update snapshots.
+- `read()` must remain side-effect free with respect to storage maintenance files.
+
+### `head.tx` semantics
+
+- `head.tx` is an opaque cursor/etag-like token.
+- Consumers must treat `head.tx` as equality-only (`===`/`!==`) for freshness checks.
+- Consumers must not parse or infer ordering from token format.
+
+## CLI contracts (`@mesh/cli`)
+
+### Output channels
+
+- Successful machine results are emitted as JSON on `stdout`.
+- Human-readable failures are emitted on `stderr`.
+- Callers should parse `stdout` only on success (`exit code 0` or command-specific success paths).
+
+### Exit code mapping
+
+`mesh write` has stable process exit semantics:
+
+- `0`: command committed (`outcome.status === "committed"`).
+- `2`: command rejected by runtime/kernel validation (`outcome.status === "rejected"`).
+- `1`: CLI/runtime errors (argument errors, malformed JSON, startup/runtime exceptions).
+
+Other commands (`read`, `status`, `help`, `version`) return:
+
+- `0` on success.
+- `1` on CLI/runtime errors.
+
+## Operational intent
+
+These guarantees are intentionally narrow:
+
+- They support scriptability and automation safety.
+- They avoid hidden state mutations during read paths.
+- They keep restart behavior predictable while allowing startup maintenance.

--- a/packages/cli/test/cli.integration.test.ts
+++ b/packages/cli/test/cli.integration.test.ts
@@ -1,0 +1,216 @@
+import { spawn, spawnSync } from "node:child_process";
+import { access, mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+type RunResult = { code: number | null; stdout: string; stderr: string };
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(testDir, "../../..");
+const cliEntrypoint = path.resolve(testDir, "../dist/bin/mesh.js");
+let buildPromise: Promise<void> | null = null;
+
+async function ensureCliBuilt(): Promise<void> {
+  if (buildPromise) return buildPromise;
+
+  buildPromise = access(cliEntrypoint).catch(() => {
+    const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+    const build = spawnSync(pnpmCmd, ["-r", "build"], {
+      cwd: repoRoot,
+      stdio: "pipe",
+      encoding: "utf8"
+    });
+
+    if (build.status !== 0) {
+      const stdout = typeof build.stdout === "string" ? build.stdout : "";
+      const stderr = typeof build.stderr === "string" ? build.stderr : "";
+      throw new Error(`Missing built CLI entrypoint at ${cliEntrypoint}, and auto-build failed. ${stdout}\n${stderr}`.trim());
+    }
+  });
+
+  return buildPromise;
+}
+
+async function runMesh(args: string[], cwd?: string): Promise<RunResult> {
+  await ensureCliBuilt();
+
+  return new Promise<RunResult>((resolve, reject) => {
+    const child = spawn(process.execPath, [cliEntrypoint, ...args], {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk: Buffer | string) => {
+      stdout += String(chunk);
+    });
+
+    child.stderr.on("data", (chunk: Buffer | string) => {
+      stderr += String(chunk);
+    });
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolve({ code, stdout: stdout.trim(), stderr: stderr.trim() });
+    });
+  });
+}
+
+function makeRootDir(name: string): string {
+  return path.resolve(
+    process.cwd(),
+    ".mesh-test-tmp",
+    `${name}-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`
+  );
+}
+
+describe("@mesh/cli integration", () => {
+  it(
+    "persists committed writes across restart via CLI",
+    async () => {
+      const rootDir = makeRootDir("cli-restart");
+      await mkdir(rootDir, { recursive: true });
+
+      try {
+        const write = await runMesh([
+          "write",
+          "--rootDir",
+          rootDir,
+          "--graphSpaceId",
+          "space-cli-restart",
+          "--principalId",
+          "principal-cli-restart",
+          "--actorId",
+          "actor-a",
+          "--commandId",
+          "cmd-1",
+          "--idempotencyKey",
+          "idem-1",
+          "--payloadJson",
+          '{"hello":"world"}'
+        ]);
+
+        expect(write.code).toBe(0);
+        expect(write.stderr).toBe("");
+        const writeOutcome = JSON.parse(write.stdout) as { status: string };
+        expect(writeOutcome.status).toBe("committed");
+
+        const firstRead = await runMesh([
+          "read",
+          "--rootDir",
+          rootDir,
+          "--graphSpaceId",
+          "space-cli-restart",
+          "--principalId",
+          "principal-cli-restart"
+        ]);
+        expect(firstRead.code).toBe(0);
+        const firstState = JSON.parse(firstRead.stdout) as { head: { tx: string }; view: unknown };
+
+        const secondRead = await runMesh([
+          "read",
+          "--rootDir",
+          rootDir,
+          "--graphSpaceId",
+          "space-cli-restart",
+          "--principalId",
+          "principal-cli-restart"
+        ]);
+        expect(secondRead.code).toBe(0);
+        const secondState = JSON.parse(secondRead.stdout) as { head: { tx: string }; view: unknown };
+
+        expect(secondState.head.tx).toBe(firstState.head.tx);
+        expect(secondState.view).toEqual(firstState.view);
+      } finally {
+        await rm(rootDir, { recursive: true, force: true });
+      }
+    },
+    20000
+  );
+
+  it(
+    "maps write outcomes and input errors to stable exit codes",
+    async () => {
+      const rootDir = makeRootDir("cli-exit-codes");
+      await mkdir(rootDir, { recursive: true });
+
+      try {
+        const rejected = await runMesh([
+          "write",
+          "--rootDir",
+          rootDir,
+          "--graphSpaceId",
+          "space-cli-exit",
+          "--principalId",
+          "principal-cli-exit",
+          "--actorId",
+          "actor-a",
+          "--commandId",
+          "cmd-rejected",
+          "--idempotencyKey",
+          "idem-rejected",
+          "--payloadJson",
+          "null"
+        ]);
+        expect(rejected.code).toBe(2);
+        expect(rejected.stderr).toBe("");
+        const rejectedOutcome = JSON.parse(rejected.stdout) as { status: string };
+        expect(rejectedOutcome.status).toBe("rejected");
+
+        const missingFlag = await runMesh([
+          "write",
+          "--rootDir",
+          rootDir,
+          "--graphSpaceId",
+          "space-cli-exit",
+          "--principalId",
+          "principal-cli-exit",
+          "--actorId",
+          "actor-a",
+          "--commandId",
+          "cmd-missing",
+          "--idempotencyKey",
+          "idem-missing"
+        ]);
+        expect(missingFlag.code).toBe(1);
+        expect(missingFlag.stderr).toContain("Missing required flag --payloadJson");
+
+        const malformedJson = await runMesh([
+          "write",
+          "--rootDir",
+          rootDir,
+          "--graphSpaceId",
+          "space-cli-exit",
+          "--principalId",
+          "principal-cli-exit",
+          "--actorId",
+          "actor-a",
+          "--commandId",
+          "cmd-bad-json",
+          "--idempotencyKey",
+          "idem-bad-json",
+          "--payloadJson",
+          "{"
+        ]);
+        expect(malformedJson.code).toBe(1);
+        expect(malformedJson.stderr.length).toBeGreaterThan(0);
+      } finally {
+        await rm(rootDir, { recursive: true, force: true });
+      }
+    },
+    20000
+  );
+
+  it("runs --help quickly as a cold-start guardrail", async () => {
+    const startedAt = Date.now();
+    const help = await runMesh(["--help"]);
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(help.code).toBe(0);
+    expect(help.stdout).toContain("Usage: mesh <command>");
+    expect(elapsedMs).toBeLessThan(5000);
+  });
+});

--- a/packages/runtime-local/test/snapshot-policy.test.ts
+++ b/packages/runtime-local/test/snapshot-policy.test.ts
@@ -1,0 +1,71 @@
+import { mkdir, readFile, rm, stat } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { Command } from "@mesh/shared";
+import { createRuntimeLocal } from "../src/index.js";
+
+function makeRootDir(name: string): string {
+  return path.resolve(
+    process.cwd(),
+    ".mesh-test-tmp",
+    `${name}-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`
+  );
+}
+
+function makeCommand(graphSpaceId: string, idx: number): Command {
+  return {
+    graphSpaceId,
+    commandId: `cmd-${idx}`,
+    actorId: "actor-a",
+    idempotencyKey: `idem-${idx}`,
+    payload: { idx }
+  };
+}
+
+describe("@mesh/runtime-local snapshot policy", () => {
+  it("applies maintenance during start() and never writes snapshots during read()", async () => {
+    const rootDir = makeRootDir("runtime-snapshot-policy");
+    const graphSpaceId = "space-snapshot-hardening";
+    const principalId = "principal-snapshot-hardening";
+    await mkdir(rootDir, { recursive: true });
+
+    try {
+      const seed = await createRuntimeLocal({
+        rootDir,
+        graphSpaceId,
+        principalId,
+        snapshotPolicy: { minTx: 1 }
+      });
+
+      await seed.start();
+      await seed.write(makeCommand(graphSpaceId, 1));
+      await seed.write(makeCommand(graphSpaceId, 2));
+      await seed.write(makeCommand(graphSpaceId, 3));
+      await seed.stop();
+
+      const runtime = await createRuntimeLocal({
+        rootDir,
+        graphSpaceId,
+        principalId,
+        snapshotPolicy: { minTx: 1 }
+      });
+      await runtime.start();
+
+      const snapshotPath = path.join(rootDir, "snapshots", "snapshots.json");
+      const beforeReadStat = await stat(snapshotPath);
+      const beforeReadContent = await readFile(snapshotPath, "utf8");
+
+      await runtime.read();
+
+      const afterReadStat = await stat(snapshotPath);
+      const afterReadContent = await readFile(snapshotPath, "utf8");
+      await runtime.stop();
+
+      expect(beforeReadStat.size).toBeGreaterThan(0);
+      expect(afterReadStat.mtimeMs).toBe(beforeReadStat.mtimeMs);
+      expect(afterReadContent).toBe(beforeReadContent);
+    } finally {
+      await rm(rootDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide deterministic, cross-platform CLI integration tests that exercise the real built entrypoint and validate persistence and exit-code semantics.
- Ensure snapshot maintenance is only applied during `start()` and that `read()` remains pure (no snapshot writes) to protect automation invariants.
- Ship a short operational contract describing runtime/CLI guarantees so callers and automation can rely on stable semantics.

### Description

- Add end-to-end CLI integration tests in `packages/cli/test/cli.integration.test.ts` which spawn the built CLI (`dist/bin/mesh.js`), include a `runMesh(args, cwd)` helper, use unique `.mesh-test-tmp/...` roots per run, and clean up with `fs.rm(..., { recursive: true, force: true })`.
- Implement auto-build / guard logic in the integration test to ensure the CLI entrypoint exists (attempts a repository `pnpm -r build` when missing) and increase per-test timeout where needed to avoid spurious timeouts.
- Add a targeted snapshot policy test in `packages/runtime-local/test/snapshot-policy.test.ts` that seeds a runtime, verifies a snapshot exists after `start()` with `snapshotPolicy`, then asserts `runtime.read()` does not modify snapshot file mtime or content.
- Add `docs/operational-guarantees.md` documenting precise contracts for `runtime.start()`, `runtime.read()`, `head.tx` semantics, CLI stdout/stderr channels, and `mesh write` exit-code mapping (`0` committed, `2` rejected, `1` errors).

### Testing

- Ran `pnpm install` and it completed successfully.
- Ran `pnpm --filter @mesh/runtime-local test` and all runtime-local tests (including the new snapshot policy test) passed.
- Ran `pnpm --filter @mesh/cli test` and all CLI tests (including the new integration tests) passed.
- Ran `pnpm -r build` and the repository build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992441372808321b7a999aae4dfc1c9)