### PR TITLE
Add packaging discipline checks, packaging smoke test, and SUPPORT_MATRIX

### DIFF
--- a/SUPPORT_MATRIX.md
+++ b/SUPPORT_MATRIX.md
@@ -1,0 +1,19 @@
+# SUPPORT_MATRIX
+
+## 1) Implemented today
+
+- **Node.js support**: Node 18+.
+- **Module format**: ESM-only.
+- **Runtime package**: `@mesh/runtime-local`.
+- **CLI package**: `@mesh/cli`.
+- **Backends**: Local backend only (`InMemoryLocalEventStore` and `FileBackedLocalEventStore`).
+- **Desktop/Web**: `@mesh/runtime-local` targets Node.js runtime environments and is not a browser runtime.
+- **Security behavior**: Security model is specified in the spec, but runtime-local currently does not activate payload masking or principal-based filtering.
+- **Writer model**: single-writer behavior (no multi-writer support).
+
+## 2) Spec-ready / Not implemented
+
+- **IndexedDB backend**: not implemented.
+- **Remote backend**: not implemented; future implementations are expected to conform to Remote EventStore Contract v1.
+- **Sync/distributed operation**: not implemented as a real distributed runtime; v1 spec remains single-writer with no merge semantics.
+- **Masking and filtered cursors**: spec-ready but not active in current runtime-local execution.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "pnpm -r build && pnpm --filter @mesh/conformance-tests test",
     "test:all": "pnpm -r test",
     "smoke:node": "node ./scripts/smoke-node.mjs",
+    "check:packaging": "node ./scripts/check-packaging.mjs",
     "ci:validate-workflows": "node scripts/ci/validate-conformance-workflow.mjs",
     "api:contract:update": "node tools/ci/update-api-contract.mjs",
     "check:api-contract": "node tools/ci/check-api-contract.mjs",

--- a/scripts/check-packaging.mjs
+++ b/scripts/check-packaging.mjs
@@ -1,0 +1,94 @@
+import { readFile } from 'node:fs/promises';
+import { access } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+const packagesToCheck = [
+  'packages/shared',
+  'packages/eventstore-local',
+  'packages/kernel-minimal',
+  'packages/projection-minimal',
+  'packages/snapshot-minimal',
+  'packages/runtime-local',
+  'packages/cli'
+];
+
+function collectEntrypoints(exportsField) {
+  const points = [];
+  const walk = (value) => {
+    if (typeof value === 'string') {
+      points.push(value);
+      return;
+    }
+    if (value && typeof value === 'object') {
+      for (const nested of Object.values(value)) walk(nested);
+    }
+  };
+
+  walk(exportsField);
+  return points;
+}
+
+async function assertPathExists(absPath, label) {
+  try {
+    await access(absPath);
+  } catch {
+    throw new Error(`${label} does not exist: ${path.relative(repoRoot, absPath)}`);
+  }
+}
+
+for (const packageDir of packagesToCheck) {
+  const packageJsonPath = path.join(repoRoot, packageDir, 'package.json');
+  const raw = await readFile(packageJsonPath, 'utf8');
+  const manifest = JSON.parse(raw);
+
+  const entryCandidates = [manifest.main, manifest.module, manifest.types].filter(Boolean);
+  const exportEntries = collectEntrypoints(manifest.exports);
+
+  for (const value of [...entryCandidates, ...exportEntries]) {
+    if (typeof value !== 'string') continue;
+    if (value.includes('src/')) {
+      throw new Error(`${manifest.name}: entrypoint must not reference src/: ${value}`);
+    }
+    if (value.startsWith('./')) {
+      const abs = path.join(repoRoot, packageDir, value);
+      await assertPathExists(abs, `${manifest.name} entrypoint`);
+    }
+  }
+
+  if (manifest.bin) {
+    const binValues = typeof manifest.bin === 'string' ? [manifest.bin] : Object.values(manifest.bin);
+    for (const binPath of binValues) {
+      if (binPath.includes('src/')) {
+        throw new Error(`${manifest.name}: bin must not reference src/: ${binPath}`);
+      }
+      const abs = path.join(repoRoot, packageDir, binPath);
+      await assertPathExists(abs, `${manifest.name} bin`);
+      const binContents = await readFile(abs, 'utf8');
+      if (!binContents.startsWith('#!')) {
+        throw new Error(`${manifest.name}: bin is missing shebang: ${binPath}`);
+      }
+    }
+  }
+}
+
+await new Promise((resolve, reject) => {
+  const child = spawn(process.execPath, [path.join(repoRoot, 'scripts/packaging-smoke/run.mjs')], {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: 'inherit'
+  });
+
+  child.on('error', reject);
+  child.on('close', (code) => {
+    if (code === 0) resolve();
+    else reject(new Error(`packaging smoke test failed with exit code ${code}`));
+  });
+});
+
+console.log('check:packaging ok');

--- a/scripts/packaging-smoke/run.mjs
+++ b/scripts/packaging-smoke/run.mjs
@@ -1,0 +1,98 @@
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+function runNode(args, cwd = repoRoot) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, args, {
+      cwd,
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+      } else {
+        reject(new Error(`node ${args.join(' ')} failed with code ${code}\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+      }
+    });
+  });
+}
+
+const packagesForLink = [
+  'shared',
+  'eventstore-local',
+  'kernel-minimal',
+  'projection-minimal',
+  'snapshot-minimal',
+  'runtime-local',
+  'cli'
+];
+
+const smokeRoot = path.join(repoRoot, '.tmp', 'packaging-smoke');
+await mkdir(smokeRoot, { recursive: true });
+const tempProjectDir = await mkdtemp(path.join(smokeRoot, 'case-'));
+
+try {
+  await writeFile(
+    path.join(tempProjectDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'mesh-packaging-smoke',
+        private: true,
+        type: 'module'
+      },
+      null,
+      2
+    )
+  );
+
+  const meshNodeModulesDir = path.join(tempProjectDir, 'node_modules', '@mesh');
+  await mkdir(meshNodeModulesDir, { recursive: true });
+
+  for (const name of packagesForLink) {
+    const linkPath = path.join(meshNodeModulesDir, name);
+    const targetPath = path.join(repoRoot, 'packages', name);
+    await symlink(targetPath, linkPath, 'dir');
+  }
+
+  await writeFile(
+    path.join(tempProjectDir, 'consumer.mjs'),
+    `import * as shared from '@mesh/shared';\nimport { createRuntimeLocal } from '@mesh/runtime-local';\n\nif (!shared || typeof createRuntimeLocal !== 'function') {\n  throw new Error('failed to resolve package exports');\n}\n\nconsole.log('esm-imports-ok');\n`
+  );
+
+  const consumerResult = await runNode([path.join(tempProjectDir, 'consumer.mjs')], tempProjectDir);
+
+  if (!consumerResult.stdout.includes('esm-imports-ok')) {
+    throw new Error(`consumer smoke did not print success marker. stdout:\n${consumerResult.stdout}`);
+  }
+
+  const cliBinPath = path.join(tempProjectDir, 'node_modules', '@mesh', 'cli', 'dist', 'bin', 'mesh.js');
+  const cliResult = await runNode([cliBinPath, '--help'], tempProjectDir);
+
+  if (!cliResult.stdout.includes('Usage: mesh')) {
+    throw new Error(`cli help smoke did not print usage. stdout:\n${cliResult.stdout}`);
+  }
+
+  console.log('packaging-smoke-ok');
+} finally {
+  await rm(tempProjectDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
### Motivation
- Ensure published packages are "dist-only" and safe for plain Node ESM consumers without relying on `src/` at runtime.
- Provide an automated, CI-friendly check that reproduces a minimal external Node ESM consumer importing `@mesh/*` and invoking the CLI.
- Document current supported surface and the spec-ready but not implemented items in a concise support matrix.

### Description
- Added a root script `check:packaging` in `package.json` which runs `scripts/check-packaging.mjs` to validate packaging entrypoints and run the smoke test.
- Added `scripts/check-packaging.mjs` that audits `main/module/types/exports` for `src/*` leakage, verifies referenced build artifact paths exist, and validates CLI `bin` JS + shebang for the runtime-relevant packages.
- Added `scripts/packaging-smoke/run.mjs` which creates a temporary ESM project, symlinks `@mesh/*` workspace packages into the temp project's `node_modules/@mesh`, imports `@mesh/shared` and `@mesh/runtime-local` as a plain Node ESM consumer, and invokes the built CLI binary with `--help`.
- Added `SUPPORT_MATRIX.md` at repo root containing the two required sections: "Implemented today" (Node 18+, ESM-only, `@mesh/runtime-local`, `@mesh/cli`, local backends, security model specified but not active, single-writer) and "Spec-ready / Not implemented" (IndexedDB, Remote backend, Sync/distributed, masking/cursors).
- No public API, type, or runtime-signature changes were made; package manifests were already dist-oriented so the work was limited to adding checks and documentation.

### Testing
- Ran `pnpm -r build` and it completed successfully.
- Ran `pnpm check:api-contract` and the API contract check passed.
- Ran conformance tests via `pnpm --filter @mesh/conformance-tests test` and all tests passed (`12 files, 51 tests` passed).
- Ran conformance critical checks via `pnpm --filter @mesh/conformance-tests check:critical` and the critical gate passed.
- Ran `pnpm check:packaging` which performed the manifest audit and executed the packaging smoke test (consumer imports + CLI `--help`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69925a5cacec8321b6af5ab16f56edfa)