### PR TITLE
Phase 16 pass 1: add remote readiness/versioning/release docs and cold-start bench

### DIFF
--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,0 +1,9 @@
+- Run `pnpm -r build`.
+- Run `pnpm check:api-contract`.
+- Run `pnpm test`.
+- Run conformance tests (`pnpm --filter @mesh/conformance-tests test`).
+- Run critical gate (`pnpm --filter @mesh/conformance-tests check:critical`).
+- Run `pnpm check:packaging`.
+- Run bench scripts (`pnpm bench` and/or `pnpm bench:*`) and record JSON output (informational, non-blocking).
+- Validate documentation sanity: `SUPPORT_MATRIX.md`, `KNOWN_LIMITATIONS.md`, and current security status are still accurate.
+- Apply version bump, create tag, and update changelog/release notes.

--- a/REMOTE_READINESS.md
+++ b/REMOTE_READINESS.md
@@ -1,0 +1,44 @@
+# Remote Readiness (Spec-Ready, Not Implemented)
+
+## 1) Scope
+
+This document defines the required conditions to enable a Remote / Sync backend in Mesh Explorer.
+
+It does **not** describe a feature that is implemented today.
+
+## 2) Required invariants (Remote MUST)
+
+A Remote backend MUST preserve all execution invariants already enforced by local/conformance behavior:
+
+- Append-only logical history.
+- Strict tx-closed visibility (`commit-or-nothing`).
+- Total order per stream (meta stream and graph stream).
+- Deterministic replay outcomes.
+- Persistent idempotency keyed by `(actor, idempotencyKey)`.
+- Tx-closed read ranges (pagination MUST NOT expose partial transactions).
+- No user-safe exposure without security filtering (masking MUST be non-leaking).
+
+## 3) Conformance gates before enabling Remote (MUST PASS)
+
+Before any Remote backend can be enabled, the following conformance gates MUST pass:
+
+- Append-only immutability test suite.
+- Tx-closed range/pagination test suite.
+- Replay equivalence tests (full replay vs snapshot+replay when snapshots exist).
+- Strict idempotency persistence tests.
+- If security is active:
+  - mask indistinguishability tests,
+  - principal-filtered cursor/range tests.
+
+## 4) v1 Non-goals (explicit)
+
+- No merge semantics.
+- No multi-writer coordination.
+- No distributed locking.
+- No "live collaborative sync" claims/marketing.
+
+## 5) Local implementation status
+
+- `runtime-local` is a structural reference implementation.
+- Local backend is used as a reference for conformance testing (harness), not as a canonical oracle.
+- Equivalence is defined by invariants + normalized outputs, not by matching local implementation details.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,19 @@
+# Versioning Policy
+
+## 1) Version scheme
+
+- Mesh Explorer versions track internal delivery phases.
+- Phase-aligned releases use the `0.<phase>.<patch>` pattern (example: `0.16.x` for Phase 16 updates).
+
+## 2) 0.x discipline
+
+For every release in `0.x`, the following gates are mandatory:
+
+- API contract check is required (`pnpm check:api-contract`).
+- Conformance critical gate is required.
+- Packaging check is required (`pnpm check:packaging`).
+
+## 3) Breaking behavior policy
+
+- Activation/enforcement of security (`allow|deny|mask`, principal filtering, tx-wide masking) changes observable behavior and is treated as a breaking change.
+- In `0.x`, breaking behavior may still ship under minor/phase progression, but MUST be explicitly labeled as breaking behavior in release notes/changelog.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "api:contract:update": "node tools/ci/update-api-contract.mjs",
     "check:api-contract": "node tools/ci/check-api-contract.mjs",
     "check:reasoncodes-policy": "node tools/ci/check-reasoncodes-policy.mjs",
-    "check:public-exports-exist": "node tools/ci/check-public-exports-exist.mjs"
+    "check:public-exports-exist": "node tools/ci/check-public-exports-exist.mjs",
+    "bench:cold-start": "node ./scripts/bench/cold-start.mjs",
+    "bench": "pnpm bench:cold-start"
   },
   "devDependencies": {
     "typescript": "^5.6.3",

--- a/scripts/bench/cold-start.mjs
+++ b/scripts/bench/cold-start.mjs
@@ -1,0 +1,61 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { performance } from "node:perf_hooks";
+
+const tempRoot = await mkdtemp(path.join(tmpdir(), "mesh-bench-"));
+
+const nowIso = new Date().toISOString();
+const metrics = {
+  bench: "cold-start",
+  timestamp: nowIso,
+  timingsMs: {}
+};
+
+try {
+  const importStart = performance.now();
+  const runtimeLocalModuleUrl = pathToFileURL(
+    path.resolve("packages/runtime-local/dist/index.js")
+  ).href;
+  const runtimeLocalModule = await import(runtimeLocalModuleUrl);
+  const importEnd = performance.now();
+
+  const createRuntimeLocal = runtimeLocalModule.createRuntimeLocal;
+  if (typeof createRuntimeLocal !== "function") {
+    throw new Error("createRuntimeLocal export not found in runtime-local dist build");
+  }
+
+  metrics.timingsMs.importRuntimeLocal = Number((importEnd - importStart).toFixed(3));
+
+  const initStart = performance.now();
+  const runtime = await createRuntimeLocal({
+    rootDir: tempRoot,
+    graphSpaceId: "bench-graph",
+    principalId: "bench-principal"
+  });
+  const initEnd = performance.now();
+  metrics.timingsMs.createRuntime = Number((initEnd - initStart).toFixed(3));
+
+  const startT0 = performance.now();
+  await runtime.start();
+  const startT1 = performance.now();
+  metrics.timingsMs.start = Number((startT1 - startT0).toFixed(3));
+
+  const readT0 = performance.now();
+  const state = await runtime.read();
+  const readT1 = performance.now();
+  metrics.timingsMs.read = Number((readT1 - readT0).toFixed(3));
+
+  const stopT0 = performance.now();
+  await runtime.stop();
+  const stopT1 = performance.now();
+  metrics.timingsMs.stop = Number((stopT1 - stopT0).toFixed(3));
+
+  metrics.txHead = state.head.tx;
+  metrics.started = runtime.status().started;
+
+  console.log(JSON.stringify(metrics, null, 2));
+} finally {
+  await rm(tempRoot, { recursive: true, force: true });
+}


### PR DESCRIPTION
### Motivation
- Add spec-ready documentation and release discipline artifacts required for Phase 16 product stabilization while making no public API or runtime Remote/Sync feature changes.
- Provide an informational, non-blocking performance bench and `pnpm` scripts to capture cold-start metrics for `runtime-local` to support release decision-making.

### Description
- Add `REMOTE_READINESS.md` defining scope, required invariants, conformance gates, v1 non-goals, and the `runtime-local` status as a structural reference implementation.
- Add `VERSIONING.md` describing phase-aligned `0.<phase>.<patch>` scheme, 0.x release discipline (`pnpm check:api-contract`, conformance critical, packaging) and an explicit breaking-behavior policy for security activation/enforcement.
- Add `RELEASE_CHECKLIST.md` with an executable release checklist and add `scripts/bench/cold-start.mjs` which measures import/create/start/read/stop of `runtime-local` and prints JSON, and add `bench:cold-start` and `bench` scripts to the root `package.json`.

### Testing
- Ran `pnpm -r build` which completed successfully and produced compiled artifacts for workspace packages.
- Ran `pnpm check:api-contract` which reported the API contract check passed.
- Ran `pnpm test` (includes `@mesh/conformance-tests`) where all Vitest suites passed (12 files, 51 tests, all passed) and post-test evidence was generated.
- Ran `pnpm --filter @mesh/conformance-tests check:critical` and `pnpm check:packaging`, both returned PASS, and ran `pnpm bench:cold-start` which printed JSON-formatted metrics (informational, non-blocking).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69925ea04db483218c96fe3095a67547)