### PR TITLE
feat(kernel): activate authorization gate (allow|deny|mask) before commit

### DIFF
--- a/packages/kernel-minimal/src/KernelMinimalImpl.ts
+++ b/packages/kernel-minimal/src/KernelMinimalImpl.ts
@@ -3,8 +3,36 @@ import { REASON_CODES, type Command, type CommandOutcome, type IdempotencyCtx } 
 import { canonicalStringify, sha256Hex } from "./canonicalHash.js";
 import type { KernelMinimal } from "./KernelMinimal.js";
 
+type AuthorizationDecision = "allow" | "deny" | "mask";
+
+interface AuthorizationResult {
+  decision: AuthorizationDecision;
+  reasonCode?: string;
+  masked?: boolean;
+}
+
+interface Authorizer {
+  authorize(command: Command): AuthorizationResult | Promise<AuthorizationResult>;
+}
+
+const PERMISSIVE_AUTHORIZER: Authorizer = {
+  authorize(): AuthorizationResult {
+    return { decision: "allow" };
+  }
+};
+
+const PERMISSION_DENIED_REASON_CODE = "CMD.PERMISSION.DENIED";
+
+type EventStoreWithInternalAuthorizer = LocalEventStore & {
+  __meshInternalAuthorizer?: Authorizer;
+};
+
 export class KernelMinimalImpl implements KernelMinimal {
-  constructor(private readonly eventStore: LocalEventStore) {}
+  private readonly authorizer: Authorizer;
+
+  constructor(private readonly eventStore: LocalEventStore) {
+    this.authorizer = (this.eventStore as EventStoreWithInternalAuthorizer).__meshInternalAuthorizer ?? PERMISSIVE_AUTHORIZER;
+  }
 
   async execute(command: Command): Promise<CommandOutcome> {
     if (!command.graphSpaceId || !command.commandId || !command.actorId || !command.idempotencyKey || !command.payload) {
@@ -15,12 +43,6 @@ export class KernelMinimalImpl implements KernelMinimal {
         reasonCode: REASON_CODES.MALFORMED_COMMAND
       };
     }
-
-    const idempotencyCtx: IdempotencyCtx = {
-      actorId: command.actorId,
-      idempotencyKey: command.idempotencyKey,
-      payloadHash: sha256Hex(canonicalStringify({ payload: command.payload, requireBaseRevision: command.requireBaseRevision }))
-    };
 
     if (command.requireBaseRevision) {
       const resolvedBaseRevision = await this.eventStore.resolveRevision(command.graphSpaceId, command.requireBaseRevision);
@@ -34,6 +56,17 @@ export class KernelMinimalImpl implements KernelMinimal {
       }
     }
 
+    const authorization = await this.authorizer.authorize(command);
+    if (authorization.decision !== "allow") {
+      return this.toAuthorizationError(command, authorization);
+    }
+
+    const idempotencyCtx: IdempotencyCtx = {
+      actorId: command.actorId,
+      idempotencyKey: command.idempotencyKey,
+      payloadHash: sha256Hex(canonicalStringify({ payload: command.payload, requireBaseRevision: command.requireBaseRevision }))
+    };
+
     return this.eventStore.appendTx(
       command.graphSpaceId,
       {
@@ -43,5 +76,23 @@ export class KernelMinimalImpl implements KernelMinimal {
       },
       idempotencyCtx
     );
+  }
+
+  private toAuthorizationError(command: Command, authorization: AuthorizationResult): CommandOutcome {
+    if (authorization.decision === "mask") {
+      return {
+        status: "rejected",
+        commandId: command.commandId,
+        category: "NOT_FOUND",
+        reasonCode: REASON_CODES.NOT_FOUND_GENERIC
+      };
+    }
+
+    return {
+      status: "rejected",
+      commandId: command.commandId,
+      category: "PERMISSION",
+      reasonCode: PERMISSION_DENIED_REASON_CODE
+    };
   }
 }

--- a/packages/kernel-minimal/test/kernelAuthorization.test.ts
+++ b/packages/kernel-minimal/test/kernelAuthorization.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import type { LocalEventStore } from "@mesh/eventstore-local";
+import type { Command, CommandError, CommandOutcome, Cursor, IdempotencyCtx, TransactionReceipt } from "@mesh/shared";
+import { REASON_CODES } from "@mesh/shared";
+import { KernelMinimalImpl } from "../src/KernelMinimalImpl.js";
+
+type AuthorizationDecision = "allow" | "deny" | "mask";
+
+type StoreWithInternalAuthorizer = LocalEventStore & {
+  __meshInternalAuthorizer?: {
+    authorize(command: Command): { decision: AuthorizationDecision };
+  };
+};
+
+interface StoreState {
+  writes: number;
+  appendCalls: number;
+  idempotency: IdempotencyCtx[];
+}
+
+function makeStore(params?: { appendOutcome?: CommandOutcome; authorizerDecision?: AuthorizationDecision }): {
+  store: StoreWithInternalAuthorizer;
+  state: StoreState;
+} {
+  const state: StoreState = {
+    writes: 0,
+    appendCalls: 0,
+    idempotency: []
+  };
+
+  const appendOutcome =
+    params?.appendOutcome ??
+    ({
+      status: "committed",
+      commandId: "cmd-1",
+      txId: "cmd-1",
+      txIndex: 1,
+      cursorAfter: { metaSeq: 0, graphSeq: 1 },
+      eventRefs: { meta: [], graph: [] }
+    } satisfies TransactionReceipt);
+
+  const store: StoreWithInternalAuthorizer = {
+    async appendTx(_graphSpaceId, _txBundle, idempotencyCtx): Promise<TransactionReceipt | CommandError> {
+      state.appendCalls += 1;
+      state.idempotency.push(idempotencyCtx);
+      if (appendOutcome.status === "committed") {
+        state.writes += 1;
+      }
+      return appendOutcome;
+    },
+    async readTx() {
+      return null;
+    },
+    async readTxForPrincipal() {
+      return { status: "rejected", category: "NOT_FOUND", reasonCode: REASON_CODES.NOT_FOUND_OR_MASKED };
+    },
+    async readRange() {
+      return [];
+    },
+    async readTxIndex() {
+      return [];
+    },
+    async getCursorHead(): Promise<Cursor> {
+      return { metaSeq: 0, graphSeq: 0 };
+    },
+    async readPrincipalTxRange() {
+      return { txs: [], cursor: 0 };
+    },
+    async getPrincipalCursorHead() {
+      return 0;
+    },
+    async resolveRevision() {
+      return { metaSeq: 0, graphSeq: 0 };
+    },
+    async compactUpToCursor() {
+      return;
+    }
+  };
+
+  if (params?.authorizerDecision) {
+    store.__meshInternalAuthorizer = {
+      authorize() {
+        return { decision: params.authorizerDecision ?? "allow" };
+      }
+    };
+  }
+
+  return { store, state };
+}
+
+const baseCommand: Command = {
+  graphSpaceId: "space-a",
+  commandId: "cmd-1",
+  actorId: "actor-a",
+  idempotencyKey: "idem-a",
+  payload: { op: "set", value: 1 }
+};
+
+function normalizeUserSafeError(outcome: CommandOutcome) {
+  if (outcome.status === "committed") {
+    throw new Error("Expected rejected outcome");
+  }
+
+  return {
+    status: outcome.status,
+    commandId: outcome.commandId,
+    category: outcome.category,
+    reasonCode: outcome.reasonCode
+  };
+}
+
+describe("KernelMinimal authorization", () => {
+  it("deny returns PERMISSION and causes no write", async () => {
+    const { store, state } = makeStore({ authorizerDecision: "deny" });
+    const kernel = new KernelMinimalImpl(store);
+
+    const outcome = await kernel.execute(baseCommand);
+
+    expect(outcome).toEqual({
+      status: "rejected",
+      commandId: baseCommand.commandId,
+      category: "PERMISSION",
+      reasonCode: "CMD.PERMISSION.DENIED"
+    });
+    expect(state.writes).toBe(0);
+    expect(state.appendCalls).toBe(0);
+    expect(state.idempotency).toHaveLength(0);
+  });
+
+  it("mask is user-safe indistinguishable from generic NOT_FOUND", async () => {
+    const masked = makeStore({ authorizerDecision: "mask" });
+    const kernelMasked = new KernelMinimalImpl(masked.store);
+
+    const notFound = makeStore({
+      authorizerDecision: "allow",
+      appendOutcome: {
+        status: "rejected",
+        commandId: baseCommand.commandId,
+        category: "NOT_FOUND",
+        reasonCode: REASON_CODES.NOT_FOUND_GENERIC
+      }
+    });
+    const kernelNotFound = new KernelMinimalImpl(notFound.store);
+
+    const maskedOutcome = await kernelMasked.execute(baseCommand);
+    const notFoundOutcome = await kernelNotFound.execute(baseCommand);
+
+    expect(normalizeUserSafeError(maskedOutcome)).toEqual(normalizeUserSafeError(notFoundOutcome));
+    expect(masked.state.writes).toBe(0);
+    expect(masked.state.appendCalls).toBe(0);
+    expect(notFound.state.writes).toBe(0);
+  });
+
+  it("retry under mask is stable and causes no write", async () => {
+    const { store, state } = makeStore({ authorizerDecision: "mask" });
+    const kernel = new KernelMinimalImpl(store);
+
+    const first = await kernel.execute(baseCommand);
+    const second = await kernel.execute(baseCommand);
+
+    expect(normalizeUserSafeError(first)).toEqual(normalizeUserSafeError(second));
+    expect(state.writes).toBe(0);
+    expect(state.appendCalls).toBe(0);
+    expect(state.idempotency).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
### Motivation
- Enforce an internal authorization step in the Kernel commit path to support `allow | deny | mask` security semantics without changing public API surface or adding product features.
- Ensure `deny` / `mask` produce user-safe error surfaces and do not cause any writes or events to be persisted prior to `appendTx`.
- Keep existing flows working by providing a default permissive authorizer and a test seam for injecting stricter authorizers.

### Description
- Added internal types and an injectable `Authorizer` seam with `AuthorizationDecision = "allow" | "deny" | "mask"` and `AuthorizationResult` to `packages/kernel-minimal/src/KernelMinimalImpl.ts` and a default `PERMISSIVE_AUTHORIZER` so behavior is opt-in. 
- Wired authorization into `KernelMinimalImpl.execute` after base-revision resolution and before idempotency context creation and `appendTx`, returning early on `deny`/`mask` to avoid any writes. 
- Implemented user-safe mapping where `mask` returns a `NOT_FOUND` with `REASON_CODES.NOT_FOUND_GENERIC` and `deny` returns `PERMISSION` with `CMD.PERMISSION.DENIED`, and no masking flags or revealing details are exposed to end-users. 
- Added targeted unit tests in `packages/kernel-minimal/test/kernelAuthorization.test.ts` covering `deny` causes no write, `mask` is indistinguishable from generic NOT_FOUND, and retry under `mask` is stable and causes no write.

### Testing
- Ran build and tests: `pnpm -r build` which succeeded. 
- Verified API contract with `pnpm check:api-contract` which passed. 
- Ran conformance suite with `pnpm --filter @mesh/conformance-tests test` and `pnpm --filter @mesh/conformance-tests check:critical` which both passed. 
- Ran packaging check `pnpm check:packaging` and unit tests for the Kernel package `pnpm --filter @mesh/kernel-minimal test`, and all newly added tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992626d860483219d2fbb545dcf4bb5)