### PR TITLE
feat(runtime-local): wire indexeddb backend via MESH_BACKEND

### DIFF
--- a/packages/runtime-local/src/index.ts
+++ b/packages/runtime-local/src/index.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { FileBackedLocalEventStore } from "@mesh/eventstore-local";
+import { makePersistentEventStore, type LocalEventStore } from "@mesh/eventstore-local";
 import { KernelMinimalImpl } from "@mesh/kernel-minimal";
 import { PrincipalProjectionEngine, type ProjectionSnapshot } from "@mesh/projection-minimal";
 import { FileBackedSnapshotStore, type SnapshotEnvelope } from "@mesh/snapshot-minimal";
@@ -43,7 +43,7 @@ class RuntimeLocalImpl implements RuntimeLocal {
 
   constructor(
     private readonly config: RuntimeLocalConfig,
-    private readonly eventStore: FileBackedLocalEventStore,
+    private readonly eventStore: LocalEventStoreClosable,
     private readonly kernel: KernelMinimalImpl,
     private readonly projectionEngine: PrincipalProjectionEngine,
     private readonly snapshotStore: FileBackedSnapshotStore<ProjectionSnapshot>
@@ -147,11 +147,29 @@ class RuntimeLocalImpl implements RuntimeLocal {
   }
 }
 
+type LocalEventStoreClosable = LocalEventStore & {
+  close: () => Promise<void>;
+};
+
+function resolveBackend(): "persistent" | "indexeddb" {
+  const requested = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env?.MESH_BACKEND
+    ?.trim()
+    .toLowerCase();
+  return requested === "indexeddb" ? "indexeddb" : "persistent";
+}
+
+function resolveEventStoreTarget(config: RuntimeLocalConfig): string {
+  if (resolveBackend() === "indexeddb") {
+    return `indexeddb://${["mesh_local_v1", config.graphSpaceId].join("-")}`;
+  }
+  return path.join(config.rootDir, "eventstore", "events.json");
+}
+
 export async function createRuntimeLocal(config: RuntimeLocalConfig): Promise<RuntimeLocal> {
-  const eventStorePath = path.join(config.rootDir, "eventstore", "events.json");
+  const eventStorePath = resolveEventStoreTarget(config);
   const snapshotPath = path.join(config.rootDir, "snapshots", "snapshots.json");
 
-  const eventStore = await FileBackedLocalEventStore.open(eventStorePath);
+  const eventStore = (await makePersistentEventStore(eventStorePath)) as LocalEventStoreClosable;
   const kernel = new KernelMinimalImpl(eventStore);
   const projectionEngine = new PrincipalProjectionEngine(eventStore, config.graphSpaceId);
   const snapshotStore = new FileBackedSnapshotStore<ProjectionSnapshot>(snapshotPath);

--- a/packages/runtime-local/test/indexeddb-smoke.test.ts
+++ b/packages/runtime-local/test/indexeddb-smoke.test.ts
@@ -1,0 +1,60 @@
+import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { makePersistentEventStore } from "@mesh/eventstore-local";
+import { createRuntimeLocal } from "../src/index.js";
+
+const roots: string[] = [];
+
+async function makeRootDir(prefix: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), `mesh-runtime-local-${prefix}-`));
+  roots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0, roots.length).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+describe("@mesh/runtime-local indexeddb smoke", () => {
+  it("starts, executes a minimal command, reads state, and stops cleanly", async () => {
+    const previousBackend = process.env.MESH_BACKEND;
+    const graphSpaceId = `space-indexeddb-smoke-${randomUUID()}`;
+    const dbUri = `indexeddb://mesh_local_v1-${graphSpaceId}`;
+
+    process.env.MESH_BACKEND = "indexeddb";
+
+    try {
+      const runtime = await createRuntimeLocal({
+        rootDir: await makeRootDir("indexeddb-smoke"),
+        graphSpaceId,
+        principalId: "principal-indexeddb-smoke"
+      });
+
+      await runtime.start();
+      const outcome = await runtime.write({
+        graphSpaceId,
+        commandId: "cmd-indexeddb-smoke-1",
+        actorId: "actor-indexeddb-smoke",
+        idempotencyKey: "idem-indexeddb-smoke-1",
+        payload: { smoke: true }
+      });
+      expect(outcome.status).toBe("committed");
+
+      const state = await runtime.read();
+      expect(state.head.tx).toBe("1");
+
+      await runtime.stop();
+    } finally {
+      process.env.MESH_BACKEND = previousBackend;
+      const store = await makePersistentEventStore(dbUri);
+      const deleteDatabase = (store as { deleteDatabase?: () => Promise<void> }).deleteDatabase;
+      if (deleteDatabase) {
+        await deleteDatabase.call(store);
+      }
+      await (store as { close: () => Promise<void> }).close();
+    }
+  });
+});


### PR DESCRIPTION
### Motivation

- Enable the IndexedDB-backed local event store to be selectable at runtime via `MESH_BACKEND=indexeddb` while preserving existing v1 public API and default behavior. 
- Provide a minimal, deterministic Node smoke test to validate runtime-local can start, execute a command and stop when wired to the IndexedDB backend. 

### Description

- Added backend resolution in `@mesh/runtime-local` keyed by `MESH_BACKEND` and introduced `indexeddb` target selection without changing exported types or signatures. 
- Switched runtime store creation to the shared factory `makePersistentEventStore(...)` so `indexeddb://...` URIs are supported; the deterministic DB name format is `indexeddb://mesh_local_v1-<graphSpaceId>`. 
- Introduced a small internal `LocalEventStoreClosable` type and safe resolver helpers `resolveBackend()` and `resolveEventStoreTarget()` to keep behavior stable when `MESH_BACKEND` is unset. 
- Added a deterministic smoke test `packages/runtime-local/test/indexeddb-smoke.test.ts` that sets `MESH_BACKEND=indexeddb`, starts the runtime, writes a minimal command, reads state, stops, and performs `deleteDatabase` cleanup for isolation. 
- No files under `specs/` were modified and no public API contract changes were introduced. 

### Testing

- Ran `pnpm --filter @mesh/runtime-local test` and the test suite (including the new smoke test) passed. 
- Ran `pnpm -r build` and the workspace build completed successfully. 
- Ran `pnpm check:api-contract` and the API contract check passed. 
- Ran `pnpm --filter @mesh/conformance-tests test` (default) and all conformance tests passed. 
- Ran `MESH_BACKEND=indexeddb pnpm --filter @mesh/conformance-tests test` and conformance executed successfully with `indexeddb`. 
- Ran `pnpm --filter @mesh/conformance-tests check:critical` and `pnpm check:packaging` and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993160dc5048321a00d0495da6dd2ca)