### PR TITLE
Perf-1: add deterministic multi-backend benchmark and performance budgets

### DIFF
--- a/PERFORMANCE_BUDGETS.md
+++ b/PERFORMANCE_BUDGETS.md
@@ -1,0 +1,50 @@
+# PERFORMANCE_BUDGETS
+
+## 1) Scope
+
+Perf-1 introduces informative-only benchmarks for local Mesh backends. The benchmark output is intended for trend tracking and release-note comparison, not for CI enforcement. No thresholds are asserted and no release gate is blocked by these measurements.
+
+## 2) Measured scenarios
+
+`scripts/bench/perf-1.mjs` measures three deterministic scenarios on each backend (`inmemory`, `persistent`, `indexeddb`):
+
+1. **append**: append `N` deterministic transactions.
+2. **replay**: cold restart against the same store and replay to current head.
+3. **projection rebuild**: rebuild principal projection from cursor `0`.
+
+The dataset size is controlled by `MESH_BENCH_N` (default: `1000`).
+
+## 3) Indicative budgets
+
+Budgets for Perf-1 are intentionally **non-blocking**:
+
+- Use results as a baseline and watch for significant regressions over time.
+- Compare runs on similar hardware/Node versions before drawing conclusions.
+- Prefer relative changes (e.g. `% delta`) rather than absolute times.
+
+If teams choose internal targets, record them in release notes with machine context and keep them advisory.
+
+## 4) Known performance risks
+
+Current known risks (already documented elsewhere) include:
+
+- Some local EventStore paths rely on repeated filtering/scans and can drift toward O(N²)-like behavior on large histories.
+- Projection snapshots currently retain `txIds`, so snapshot payload growth is roughly linear with transaction count.
+- IndexedDB backend remains experimental/beta and may vary significantly across environments.
+
+See `KNOWN_LIMITATIONS.md` for the source-of-truth wording.
+
+## 5) How to run
+
+```bash
+pnpm bench:perf-1
+```
+
+Optional parameters:
+
+```bash
+MESH_BENCH_N=200 pnpm bench:perf-1
+MESH_BENCH_BACKENDS=inmemory,persistent pnpm bench:perf-1
+```
+
+The script prints one JSON document to stdout for manual archival in release notes.

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -4,6 +4,6 @@
 - Run conformance tests (`pnpm --filter @mesh/conformance-tests test`).
 - Run critical gate (`pnpm --filter @mesh/conformance-tests check:critical`).
 - Run `pnpm check:packaging`.
-- Run bench scripts (`pnpm bench` and/or `pnpm bench:*`) and record JSON output (informational, non-blocking).
+- Run `pnpm bench:perf-1` (record JSON output in release notes; informational, non-blocking).
 - Validate documentation sanity: `SUPPORT_MATRIX.md`, `KNOWN_LIMITATIONS.md`, and current security status are still accurate.
 - Apply version bump, create tag, and update changelog/release notes.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "check:public-exports-exist": "node tools/ci/check-public-exports-exist.mjs",
     "bench:cold-start": "node ./scripts/bench/cold-start.mjs",
     "bench": "pnpm bench:cold-start",
-    "bench:compare": "pnpm --filter @mesh/eventstore-local build && node ./scripts/bench/compare-backends.mjs"
+    "bench:compare": "pnpm --filter @mesh/eventstore-local build && node ./scripts/bench/compare-backends.mjs",
+    "bench:perf-1": "node scripts/bench/perf-1.mjs",
+    "bench:perf-1:small": "MESH_BENCH_N=200 node scripts/bench/perf-1.mjs"
   },
   "devDependencies": {
     "typescript": "^5.6.3",

--- a/scripts/bench/perf-1.mjs
+++ b/scripts/bench/perf-1.mjs
@@ -1,0 +1,180 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { InMemoryLocalEventStore, makePersistentEventStore } from "../../packages/eventstore-local/dist/index.js";
+import { KernelMinimalImpl } from "../../packages/kernel-minimal/dist/index.js";
+import { PrincipalProjectionEngine } from "../../packages/projection-minimal/dist/index.js";
+
+const SUPPORTED_BACKENDS = ["inmemory", "persistent", "indexeddb"];
+const DEFAULT_BACKENDS = ["inmemory", "persistent", "indexeddb"];
+const DEFAULT_N = 1000;
+
+function parsePositiveInt(value, fallback) {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseBackends(value) {
+  if (!value || value.trim() === "") {
+    return [...DEFAULT_BACKENDS];
+  }
+  const requested = value
+    .split(",")
+    .map((backend) => backend.trim().toLowerCase())
+    .filter(Boolean);
+
+  const uniqueRequested = [...new Set(requested)];
+  const unknown = uniqueRequested.filter((backend) => !SUPPORTED_BACKENDS.includes(backend));
+  if (unknown.length > 0) {
+    throw new Error(`Unsupported backend(s): ${unknown.join(", ")}`);
+  }
+
+  return SUPPORTED_BACKENDS.filter((backend) => uniqueRequested.includes(backend));
+}
+
+function hrtimeMs(startNs) {
+  return Number(process.hrtime.bigint() - startNs) / 1e6;
+}
+
+async function createStoreContext(backend) {
+  if (backend === "inmemory") {
+    let currentStore = new InMemoryLocalEventStore();
+    return {
+      store: currentStore,
+      reopen: async () => {
+        currentStore = new InMemoryLocalEventStore();
+        return currentStore;
+      },
+      cleanup: async () => {}
+    };
+  }
+
+  if (backend === "persistent") {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "mesh-perf-1-persistent-"));
+    const filePath = path.join(tempDir, "eventstore.json");
+    let currentStore = await makePersistentEventStore(filePath);
+
+    return {
+      store: currentStore,
+      reopen: async () => {
+        currentStore = await makePersistentEventStore(filePath);
+        return currentStore;
+      },
+      cleanup: async () => {
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    };
+  }
+
+  const dbName = `mesh-perf-1-indexeddb`;
+  const dbUri = `indexeddb://${dbName}`;
+  const primingStore = await makePersistentEventStore(dbUri);
+  const primingDelete = primingStore.deleteDatabase;
+  if (typeof primingDelete === "function") {
+    await primingDelete.call(primingStore);
+  }
+
+  let currentStore = await makePersistentEventStore(dbUri);
+  return {
+    store: currentStore,
+    reopen: async () => {
+      currentStore = await makePersistentEventStore(dbUri);
+      return currentStore;
+    },
+    cleanup: async () => {
+      const deleteDatabase = currentStore.deleteDatabase;
+      if (typeof deleteDatabase === "function") {
+        await deleteDatabase.call(currentStore);
+      }
+    }
+  };
+}
+
+async function runBackendScenario(backend, datasetN) {
+  const graphSpaceId = `bench-perf-1-${backend}`;
+  const principal = { principalId: "system" };
+
+  const previousBackend = process.env.MESH_BACKEND;
+  process.env.MESH_BACKEND = backend;
+
+  const context = await createStoreContext(backend);
+
+  try {
+    let store = context.store;
+    let kernel = new KernelMinimalImpl(store);
+    let projection = new PrincipalProjectionEngine(store, graphSpaceId);
+
+    const appendStart = process.hrtime.bigint();
+    for (let i = 1; i <= datasetN; i += 1) {
+      const commandId = `perf-1-${backend}-tx-${String(i).padStart(8, "0")}`;
+      const outcome = await kernel.execute({
+        graphSpaceId,
+        commandId,
+        actorId: "perf-1-actor",
+        idempotencyKey: `perf-1-idem-${String(i).padStart(8, "0")}`,
+        payload: { type: "CMD.NOOP", i }
+      });
+      if (outcome.status !== "committed") {
+        throw new Error(`Append failed for backend ${backend} at i=${i}`);
+      }
+    }
+    const appendMs = hrtimeMs(appendStart);
+
+    store = await context.reopen();
+    projection = new PrincipalProjectionEngine(store, graphSpaceId);
+
+    const replayStart = process.hrtime.bigint();
+    await projection.incremental(principal);
+    const replayMs = hrtimeMs(replayStart);
+
+    const projectionStart = process.hrtime.bigint();
+    projection.invalidate(graphSpaceId);
+    await projection.rebuild(principal);
+    const projectionMs = hrtimeMs(projectionStart);
+
+    return {
+      appendMs,
+      replayMs,
+      projectionMs,
+      rssBytes: process.memoryUsage().rss
+    };
+  } finally {
+    try {
+      await context.cleanup();
+    } finally {
+      if (previousBackend === undefined) {
+        delete process.env.MESH_BACKEND;
+      } else {
+        process.env.MESH_BACKEND = previousBackend;
+      }
+    }
+  }
+}
+
+function resolveCommitHash() {
+  try {
+    return execSync("git rev-parse HEAD", { encoding: "utf8" }).trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+const datasetN = parsePositiveInt(process.env.MESH_BENCH_N, DEFAULT_N);
+const backends = parseBackends(process.env.MESH_BENCH_BACKENDS);
+
+const backendResults = {};
+for (const backend of backends) {
+  backendResults[backend] = await runBackendScenario(backend, datasetN);
+}
+
+const output = {
+  dataset: { N: datasetN },
+  backends: backendResults,
+  meta: {
+    node: process.version,
+    commit: resolveCommitHash()
+  }
+};
+
+console.log(JSON.stringify(output, null, 2));


### PR DESCRIPTION
### Motivation

- Provide a deterministic, informational performance harness (Perf-1) to make append/replay/projection timings observable and comparable without changing the public API.
- Keep the benchmark non-blocking and repeatable across the three supported backends (`inmemory`, `persistent`, `indexeddb`) using a fixed dataset and no unseeded randomness.
- Produce a single stable JSON output for archival in release notes and avoid writing artifacts to repo locations.

### Description

- Add `scripts/bench/perf-1.mjs` that reads `MESH_BENCH_N` (default `1000`) and `MESH_BENCH_BACKENDS` CSV (default `inmemory,persistent,indexeddb`) and executes the three scenarios (`append`, `cold replay`, `projection rebuild`) per backend in a stable order, measuring durations via `process.hrtime.bigint()`.
- Ensure per-backend setup/teardown: deterministic `graphSpaceId`, `fs.mkdtemp()` and cleanup for `persistent`, `deleteDatabase` priming + cleanup for `indexeddb`, and no filesystem for `inmemory`, while scoping `MESH_BACKEND` to the bench process and restoring it after each backend run.
- Emit a single JSON document to stdout containing `dataset`, `backends` timings (ms) and `rssBytes`, plus `meta.node` and `meta.commit` (via `git rev-parse HEAD`); all other logs are kept off stdout.
- Add root npm scripts `bench:perf-1` and `bench:perf-1:small`, create `PERFORMANCE_BUDGETS.md` with scope, scenarios, known risks and run instructions, and update `RELEASE_CHECKLIST.md` to include running and archiving the bench JSON (informational, non-blocking).

### Testing

- Ran `pnpm -r build` and the workspace built successfully.
- Ran `pnpm check:api-contract` and the API contract check passed.
- Ran conformance tests via `pnpm --filter @mesh/conformance-tests test` and `pnpm --filter @mesh/conformance-tests check:critical`, both passed.
- Ran `pnpm check:packaging` and it passed, and executed `pnpm bench:perf-1` which produced the single JSON payload on stdout successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69932666ad708321b51bcb5f108aaa9f)