### PR TITLE
fix(graph-server): align start/main with TypeScript emit path

### DIFF
--- a/apps/mesh-graph-server/package.json
+++ b/apps/mesh-graph-server/package.json
@@ -2,11 +2,11 @@
   "name": "@mesh/graph-server",
   "version": "0.1.0",
   "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/apps/mesh-graph-server/src/index.js",
+  "types": "./dist/apps/mesh-graph-server/src/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "start": "node ./dist/index.js"
+    "start": "node ./dist/apps/mesh-graph-server/src/index.js"
   },
   "dependencies": {
     "@mesh/eventstore-local": "workspace:*",


### PR DESCRIPTION
### Motivation
- The `start` command failed because `tsc` emits a workspace-relative layout so the runtime entry is `dist/apps/mesh-graph-server/src/index.js` instead of the expected `dist/index.js`.

### Description
- Updated `apps/mesh-graph-server/package.json` to set `main`, `types`, and the `start` script to `./dist/apps/mesh-graph-server/src/index.js`/`.d.ts` so runtime entrypoints match the actual TypeScript output without changing build tooling or `tsconfig`.

### Testing
- Ran `pnpm --dir apps/mesh-graph-server build` which completed successfully.
- Verified the emitted entry exists with `test -f apps/mesh-graph-server/dist/apps/mesh-graph-server/src/index.js` which returned success.
- Ran `pnpm --dir apps/mesh-graph-server start` which now resolves the built entry but then failed due to missing workspace-installed dependencies (node_modules not present), confirming the original `dist/index.js` missing error is resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699382bf89bc8321b0dd9b832fba8e34)