### PR TITLE
fix(eventstore-local): ensure built dist files are present for runtime resolution

### DIFF
--- a/packages/eventstore-local/package.json
+++ b/packages/eventstore-local/package.json
@@ -4,6 +4,9 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run --passWithNoTests"


### PR DESCRIPTION
### Motivation
- Node attempted to load `dist/index.js` because the package `main`/`exports` point at `./dist/index.js`, but the package payload installed into `node_modules` did not always include the emitted `dist` files, causing runtime ESM resolution to fail.

### Description
- Add a `files` allowlist to `packages/eventstore-local/package.json` with `"dist"` so the published/workspaced package payload explicitly includes the compiled output at `dist/index.js` and `dist/index.d.ts`, keeping `main`, `types`, and `exports` unchanged and consistent with the TypeScript output.

### Testing
- Ran `pnpm --filter @mesh/eventstore-local exec tsc -p tsconfig.json --listEmittedFiles` (confirmed emission includes `packages/eventstore-local/dist/index.js` and `dist/index.d.ts`) and `cd packages/eventstore-local && npm pack --dry-run` (confirmed the tarball lists `dist/index.js` and `dist/index.d.ts`), and attempted broader `pnpm -r build` and `pnpm install` where `pnpm install` failed due to external registry auth (not related to this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69938511c0688321bba4c84aa18c0109)