### PR TITLE
fix(graph-server): build workspace deps before start

### DIFF
--- a/apps/mesh-graph-server/package.json
+++ b/apps/mesh-graph-server/package.json
@@ -6,7 +6,8 @@
   "types": "./dist/apps/mesh-graph-server/src/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "start": "node ./dist/apps/mesh-graph-server/src/index.js"
+    "start": "node ./dist/apps/mesh-graph-server/src/index.js",
+    "prestart": "pnpm -r --filter @mesh/graph-server... build"
   },
   "dependencies": {
     "@mesh/eventstore-local": "workspace:*",


### PR DESCRIPTION
### Motivation
- The graph server fails at runtime when a workspace dependency like `@mesh/eventstore-local` hasn’t been built, because pnpm workspace links local package folders and Node ESM import resolution requires the `dist/index.js` files to exist. 
- Adding `"files": ["dist"]` to a package.json only affects packaging/publishing and does not make build artifacts appear in a workspace link, so it did not fix the runtime error.

### Description
- Added a `prestart` script to `apps/mesh-graph-server/package.json` that runs `pnpm -r --filter @mesh/graph-server... build` so the graph server and its direct workspace runtime deps are built before Node starts. 
- The only code change is in `apps/mesh-graph-server/package.json` where the `prestart` script is set to `pnpm -r --filter @mesh/graph-server... build`, keeping the change minimal and cross-platform.

### Testing
- Ran `pnpm --dir apps/mesh-graph-server prestart` and it successfully built `@mesh/shared`, `@mesh/eventstore-local`, `@mesh/sync-http`, `@mesh/kernel-minimal`, and the graph-server itself. (succeeded)
- Ran `pnpm --dir apps/mesh-graph-server start`; the `prestart` build step executed successfully but the overall start failed in this environment due to an incomplete `pnpm install` (registry `403` for a package) so full runtime resolution could not be validated here. (build step succeeded; full start validation blocked by install failure)
- This change ensures that on a normal/clean workspace install, running `pnpm --dir apps/mesh-graph-server start` will run the filtered recursive build first and therefore make `@mesh/eventstore-local/dist/index.js` available before Node ESM resolves imports.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699387a4d3548321b6e32a0cf41fde74)