### PR TITLE
Fix principal header observability and request-path consistency

### DIFF
--- a/apps/mesh-graph-server/src/index.ts
+++ b/apps/mesh-graph-server/src/index.ts
@@ -11,6 +11,7 @@ import type { Command, CommandOutcome, Cursor, PrincipalContext } from "@mesh/sh
 
 const GRAPH_SPACE_ID = "mesh-explorer-graph-v1";
 const PRINCIPAL_HEADER = "x-mesh-principal";
+const DEBUG_AUTH_ENABLED = process.env.MESH_DEBUG_AUTH === "1";
 const STORE_CACHE = new Map<string, FileBackedLocalEventStore>();
 
 type GraphNode = { id: string; label: string; level?: number; metadata?: Record<string, unknown> };
@@ -131,8 +132,16 @@ async function handleRequest(
   deps: { gateway: LocalSyncGatewayLike; graphSpaceId: string; syncBaseUrl: string }
 ): Promise<void> {
   const requestUrl = new URL(req.url ?? "/", "http://graph.local");
+  applyCorsHeaders(res);
+  if (req.method === "OPTIONS") {
+    res.statusCode = 204;
+    res.end();
+    return;
+  }
+
   const principal = parsePrincipal(req);
   if (!principal) {
+    debugAuthLog(req, requestUrl);
     writeJson(res, 401, { status: "rejected", category: "PERMISSION", reasonCode: "AUTH.PRINCIPAL_REQUIRED" });
     return;
   }
@@ -266,6 +275,23 @@ function parsePrincipal(req: IncomingMessage): PrincipalContext | null {
   const trimmed = value.trim();
   if (!trimmed) return null;
   return { principalId: trimmed };
+}
+
+function debugAuthLog(req: IncomingMessage, requestUrl: URL): void {
+  if (!DEBUG_AUTH_ENABLED) return;
+  const raw = req.headers[PRINCIPAL_HEADER];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  const normalized = typeof value === "string" ? value.trim() : "";
+  process.stdout.write(
+    `[mesh-auth-debug] reject ${req.method ?? "UNKNOWN"} ${requestUrl.pathname}${requestUrl.search} ` +
+      `${PRINCIPAL_HEADER}=${JSON.stringify(value ?? null)} missing=${typeof value !== "string"} blank=${normalized.length === 0}\n`
+  );
+}
+
+function applyCorsHeaders(res: ServerResponse): void {
+  res.setHeader("access-control-allow-origin", "*");
+  res.setHeader("access-control-allow-methods", "GET,POST,OPTIONS");
+  res.setHeader("access-control-allow-headers", "content-type,x-mesh-principal");
 }
 
 function maskForOtherPrincipal(principal: string): Record<string, "mask"> {

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -52,6 +52,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     cursor: { metaSeq: 0, graphSeq: 0 } as Cursor,
     stop: false
   };
+  const debugAuth = isDebugAuthEnabled();
 
   const graph3d = ForceGraph3D()(el.graph3d)
     .nodeId("id")
@@ -73,11 +74,11 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   el.addNode.onclick = () => {
     const label = prompt("Node label", "new node") ?? "";
     if (!label) return;
-    void fetch(`${el.baseUrl.value}/graph/nodes`, {
+    void meshFetch(`${el.baseUrl.value}/graph/nodes`, {
       method: "POST",
       headers: headers(el.principal.value),
       body: JSON.stringify({ label, idempotencyKey: crypto.randomUUID() })
-    });
+    }, { principal: el.principal.value, transport: "fetch", debugAuth });
   };
 
   el.addLink.onclick = () => {
@@ -85,11 +86,11 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     const target = prompt("Target node id") ?? "";
     const type = prompt("Link type", "related") ?? "related";
     if (!source || !target) return;
-    void fetch(`${el.baseUrl.value}/graph/links`, {
+    void meshFetch(`${el.baseUrl.value}/graph/links`, {
       method: "POST",
       headers: headers(el.principal.value),
       body: JSON.stringify({ source, target, type, idempotencyKey: crypto.randomUUID() })
-    });
+    }, { principal: el.principal.value, transport: "fetch", debugAuth });
   };
 
   void connectAndSync();
@@ -106,7 +107,11 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       while (!state.stop) {
         try {
           const url = `${el.baseUrl.value}/v1/${encodeURIComponent(el.graphSpaceId.value)}/sync:subscribe?from=${state.cursor.graphSeq}`;
-          const response = await fetch(url, { headers: headers(el.principal.value) });
+          const response = await meshFetch(url, { headers: headers(el.principal.value) }, {
+            principal: el.principal.value,
+            transport: "fetch-sse",
+            debugAuth
+          });
           if (!response.body) {
             await wait(300);
             continue;
@@ -132,9 +137,10 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     async function pollFromCursor(): Promise<void> {
       const limits = encodeURIComponent(JSON.stringify({ graph: 128, meta: 32 }));
       const cursor = encodeURIComponent(JSON.stringify(state.cursor));
-      const response = await fetch(
+      const response = await meshFetch(
         `${el.baseUrl.value}/v1/${encodeURIComponent(el.graphSpaceId.value)}/sync:poll?cursor=${cursor}&limits=${limits}`,
-        { headers: headers(el.principal.value) }
+        { headers: headers(el.principal.value) },
+        { principal: el.principal.value, transport: "fetch", debugAuth }
       );
       if (!response.ok) return;
       const payload = (await response.json()) as { graph?: GraphEvent[]; cursorAfter?: Cursor };
@@ -215,6 +221,41 @@ function headers(principal: string): HeadersInit {
     "content-type": "application/json",
     "x-mesh-principal": normalizePrincipal(principal)
   };
+}
+
+type MeshFetchMeta = {
+  principal: string;
+  transport: "fetch" | "fetch-sse";
+  debugAuth: boolean;
+};
+
+async function meshFetch(input: string, init: RequestInit, meta: MeshFetchMeta): Promise<Response> {
+  if (meta.debugAuth) {
+    const resolvedUrl = resolveDebugUrl(input);
+    const resolvedPrincipal = normalizePrincipal(meta.principal);
+    console.info("[mesh-auth-debug] request", {
+      transport: meta.transport,
+      url: resolvedUrl,
+      principal: resolvedPrincipal
+    });
+  }
+  return fetch(input, init);
+}
+
+function isDebugAuthEnabled(): boolean {
+  try {
+    return localStorage.getItem("meshDebugAuth") === "1";
+  } catch {
+    return false;
+  }
+}
+
+function resolveDebugUrl(input: string): string {
+  try {
+    return new URL(input, window.location.href).toString();
+  } catch {
+    return input;
+  }
 }
 
 const DEFAULT_PRINCIPAL = "local-dev";


### PR DESCRIPTION
### Motivation
- Diagnose why requests reached the graph server without a valid principal (resulting in `AUTH.PRINCIPAL_REQUIRED`) by adding targeted instrumentation on both sides. 
- Ensure every UI network path consistently attaches the `x-mesh-principal` header without weakening server-side rejection semantics. 
- Make the failure mode observable in dev so root causes (CORS preflight, raw fetch paths, EventSource limits) can be validated safely.

### Description
- Server: add a dev-only auth debug logger gated by `MESH_DEBUG_AUTH=1` that prints method, path and the exact `x-mesh-principal` header state at the rejection point, and add minimal CORS/preflight handling so `OPTIONS` is answered before principal enforcement (in `apps/mesh-graph-server/src/index.ts`).
- UI: centralize all graph requests behind a new `meshFetch` wrapper and switch `add node`, `add link`, `sync:poll` and `sync:subscribe` code paths to call `meshFetch` so header attachment and instrumentation are consistent (in `packages/mesh-explorer-ui/src/index.ts`).
- UI instrumentation: add a dev-only client log guarded by `localStorage.meshDebugAuth === "1"` that prints the resolved principal, transport (`fetch` / `fetch-sse`), and URL before each network call.
- Behavior notes: subscribe in this codebase uses fetch-streaming (not `EventSource`), so inability to set headers on `EventSource` was not the root cause; a likely root cause was preflight `OPTIONS` negotiation dropping principal checks and being rejected before CORS was handled—this is addressed by answering `OPTIONS` and advertising `x-mesh-principal` in allow-headers.
- Invariant preserved: non-`OPTIONS` requests still require a non-empty `x-mesh-principal` and the server continues to reject requests with `AUTH.PRINCIPAL_REQUIRED` when the header is missing or blank.

### Testing
- Built the modified packages successfully with `pnpm --filter @mesh/graph-server build` and `pnpm --filter @mesh/mesh-explorer-ui build`, and both builds completed without errors (succeeds).
- No production auth invariant was relaxed and no automated runtime tests were modified in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69938fdc2a7083219b0a60641aeb6f6f)