### PR TITLE
docs: make demo setup deterministic with root pnpm install

### DIFF
--- a/docs/DEMO_2_MINUTES.md
+++ b/docs/DEMO_2_MINUTES.md
@@ -1,13 +1,15 @@
 # Demo 2 minutes
 
+0. Install workspace dependencies once (from repo root):
+   - `pnpm install`
 1. Start graph server:
-   - `pnpm --dir apps/mesh-graph-server install`
-   - `pnpm --dir apps/mesh-graph-server build`
+   - `pnpm -r --filter @mesh/graph-server... build`
    - `pnpm --dir apps/mesh-graph-server start`
 2. Start webapp:
-   - `pnpm --dir apps/mesh-explorer-webapp install`
    - `pnpm --dir apps/mesh-explorer-webapp dev`
 3. In UI, click **Connect**.
 4. Click **Add node** and create at least 2 nodes.
 5. Click **Add link** and create a typed link between node IDs.
 6. Restart server using same storage dir (`MESH_GRAPH_STORAGE_DIR=...`) and reload webapp; graph recovers to same `{nodes, links}`.
+
+Windows note: if Vite fails with `Cannot find module '@rollup/rollup-win32-x64-msvc'`, rerun root install with `pnpm install --force`.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "bench:snapshot-maintenance": "node scripts/bench/snapshot-maintenance.mjs",
     "bench:nightly": "node scripts/bench/nightly-perf.mjs",
     "smoke:serve-and-submit": "node ./scripts/smoke-serve-and-submit.mjs",
+    "graph-server": "pnpm --dir apps/mesh-graph-server start",
     "webapp": "pnpm --dir apps/mesh-explorer-webapp dev",
     "desktop": "pnpm --dir apps/mesh-explorer-desktop start",
     "check:lockfile-clean": "node scripts/ci/check-lockfile-clean.mjs"


### PR DESCRIPTION
### Motivation
- Per-app `pnpm --dir ... install` steps in the demo can miss platform optional dependencies on Windows (e.g. `@rollup/rollup-win32-x64-msvc`), causing Vite/Rollup startup failures. 
- Use a single root install and filtered builds to make the demo deterministic for monorepo usage while keeping per-app run ergonomics.

### Description
- Add Step 0 to `docs/DEMO_2_MINUTES.md` to run `pnpm install` from the repo root and remove per-app `install` lines. 
- Replace the graph server install/build sequence with a filtered build `pnpm -r --filter @mesh/graph-server... build` followed by `pnpm --dir apps/mesh-graph-server start`. 
- Keep the webapp run command as `pnpm --dir apps/mesh-explorer-webapp dev`. 
- Add a short Windows troubleshooting note advising `pnpm install --force` if Vite reports a missing `@rollup/rollup-win32-x64-msvc`. 
- Add a minimal root `package.json` convenience script: `"graph-server": "pnpm --dir apps/mesh-graph-server start"`.

### Testing
- Ran file/diff checks including `git status --short` and `git diff -- docs/DEMO_2_MINUTES.md package.json` to verify changes were applied successfully. 
- Printed updated files with `nl -ba docs/DEMO_2_MINUTES.md` and `nl -ba package.json` to confirm content and script insertion. 
- No runtime or unit tests were executed as this change is documentation and a small ergonomics script only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69939be4ec6c8321b143ee62dbcadc9f)