### PR TITLE
fix: ensure Windows esbuild + rollup native binaries are pinned and repairable

### DIFF
--- a/docs/DEMO_2_MINUTES.md
+++ b/docs/DEMO_2_MINUTES.md
@@ -12,4 +12,4 @@
 5. Click **Add link** and create a typed link between node IDs.
 6. Restart server using same storage dir (`MESH_GRAPH_STORAGE_DIR=...`) and reload webapp; graph recovers to same `{nodes, links}`.
 
-Windows note: if Vite fails with `Cannot find module '@rollup/rollup-win32-x64-msvc'`, run `pnpm repair:win-rollup` from the repo root.
+Windows note: if Vite fails with `Cannot find module '@rollup/rollup-win32-x64-msvc'` or `The package '@esbuild/win32-x64' could not be found`, run `pnpm repair:win-rollup` from the repo root (Vite needs both native optional binaries: Rollup + esbuild).

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "optionalDependencies": {
     "@esbuild/linux-x64": "0.21.5",
+    "@esbuild/win32-x64": "0.21.5",
     "@rollup/rollup-linux-x64-gnu": "4.57.1",
     "@rollup/rollup-win32-x64-msvc": "4.57.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@esbuild/linux-x64':
         specifier: 0.21.5
         version: 0.21.5
+      '@esbuild/win32-x64':
+        specifier: 0.21.5
+        version: 0.21.5
       '@rollup/rollup-linux-x64-gnu':
         specifier: 4.57.1
         version: 4.57.1
@@ -226,6 +229,11 @@ packages:
     resolution: {}
     cpu: [x64]
     os: [linux]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {}
+    cpu: [x64]
+    os: [win32]
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -461,6 +469,9 @@ snapshots:
       "@types/node": 22.18.1
 
   '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@jridgewell/sourcemap-codec@1.5.5': {}

--- a/scripts/repair-windows-rollup.mjs
+++ b/scripts/repair-windows-rollup.mjs
@@ -2,15 +2,17 @@ import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
-const packageName = "@rollup/rollup-win32-x64-msvc";
+const packages = ["@rollup/rollup-win32-x64-msvc", "@esbuild/win32-x64"];
 
-function hasWindowsRollup() {
-  try {
-    require(packageName);
-    return true;
-  } catch {
-    return false;
-  }
+function findMissingWindowsPackages() {
+  return packages.filter((packageName) => {
+    try {
+      require(packageName);
+      return false;
+    } catch {
+      return true;
+    }
+  });
 }
 
 if (process.platform !== "win32") {
@@ -18,12 +20,15 @@ if (process.platform !== "win32") {
   process.exit(0);
 }
 
-if (hasWindowsRollup()) {
-  console.log(`${packageName} is already available.`);
+let missingPackages = findMissingWindowsPackages();
+if (missingPackages.length === 0) {
+  console.log(`Windows native optional packages are already available: ${packages.join(", ")}.`);
   process.exit(0);
 }
 
-console.log(`${packageName} is missing. Running pnpm install --prefer-frozen-lockfile --force...`);
+console.log(
+  `Missing Windows native optional packages (${missingPackages.join(", ")}). Running pnpm install --prefer-frozen-lockfile --force...`
+);
 const install = spawnSync("pnpm", ["install", "--prefer-frozen-lockfile", "--force"], {
   stdio: "inherit",
   shell: process.platform === "win32"
@@ -33,12 +38,13 @@ if (install.status !== 0) {
   process.exit(install.status ?? 1);
 }
 
-if (hasWindowsRollup()) {
-  console.log(`${packageName} is now available.`);
+missingPackages = findMissingWindowsPackages();
+if (missingPackages.length === 0) {
+  console.log(`Windows native optional packages are now available: ${packages.join(", ")}.`);
   process.exit(0);
 }
 
 console.error(
-  `${packageName} is still missing after forced install. As a last resort, a clean install may be required.`
+  `Windows native optional packages are still missing after forced install: ${missingPackages.join(", ")}. As a last resort, a clean install may be required.`
 );
 process.exit(1);


### PR DESCRIPTION
### Motivation
- Vite on Windows can fail when platform-native optional binaries are not materialized, so the repair flow for Rollup was extended to also ensure esbuild's Windows binary is present. 
- Making the Windows dev experience deterministic requires pinning the exact esbuild platform package and reusing the existing deterministic repair approach.

### Description
- Added `@esbuild/win32-x64` pinned to `0.21.5` to the root `optionalDependencies` in `package.json` so the esbuild Windows platform binary is explicit. 
- Updated `pnpm-lock.yaml` to record the `@esbuild/win32-x64@0.21.5` package metadata (os: [win32]) and snapshot entry. 
- Extended `scripts/repair-windows-rollup.mjs` to check for both `@rollup/rollup-win32-x64-msvc` and `@esbuild/win32-x64`, to run `pnpm install --prefer-frozen-lockfile --force` if either is missing, and to re-check and emit a clear error listing any still-missing packages. 
- Updated `docs/DEMO_2_MINUTES.md` to mention that Vite needs both Rollup and esbuild native optional binaries and to point maintainers to the same repair script (`pnpm repair:win-rollup`).

### Testing
- Executed `node scripts/repair-windows-rollup.mjs` in this environment (non-Windows) and it exited cleanly with `not needed`, indicating the platform guard is correct and the script runs without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69939e589b1883218eb6d3e051bb1c39)