### PR TITLE
Build workspace deps before webapp dev to fix Vite dep-scan on Windows

### DIFF
--- a/apps/mesh-explorer-webapp/package.json
+++ b/apps/mesh-explorer-webapp/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
+    "predev": "pnpm -r --filter @mesh/mesh-explorer-webapp... build",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview"


### PR DESCRIPTION
### Motivation
- On Windows, Vite's dependency scan can fail when a workspace package (here `@mesh/mesh-explorer-ui`) exposes `dist/*` entrypoints that do not yet exist at dev startup, causing unresolved-package errors.

### Description
- Added a `predev` script to `apps/mesh-explorer-webapp/package.json` that runs `pnpm -r --filter @mesh/mesh-explorer-webapp... build` so workspace dependencies (including `@mesh/mesh-explorer-ui`) are compiled to `dist` before `vite` runs, and kept `packages/mesh-explorer-ui/package.json` unchanged because its `main`/`types`/`exports` already point to `dist/index.*`.

### Testing
- Ran `pnpm -r build` which completed successfully and ran `pnpm --dir apps/mesh-explorer-webapp dev` (interrupted via timeout) and observed Vite start and serve without the previous dep-scan resolution error for `@mesh/mesh-explorer-ui`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993a0b01bf8832184c61dcbb54fc14f)