### PR TITLE
fix(mesh-explorer-ui): disable imperative 3D path and make 2D renderer primary

### DIFF
--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -1,4 +1,3 @@
-import ForceGraph3D from "react-force-graph-3d";
 import ForceGraph2D from "force-graph";
 import { createGraphStore, type GraphEvent, type GraphLink, type GraphNode, type GraphState, type GraphStore } from "./graphStore.js";
 
@@ -54,9 +53,8 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   const debugEnabled = isDebugEnabled();
   const store = createGraphStore();
   let stopSync = false;
-  let graph3d: any = null;
   let graph2d: any = null;
-  let rendererMode: "3d" | "2d" | "fallback-json" = "3d";
+  let rendererMode: "2d" | "fallback-json" = "2d";
   let lastSync = "n/a";
 
   setupRenderer();
@@ -72,7 +70,6 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       nodes: Array.from(snapshot.nodesById.values()),
       links: Array.from(snapshot.linksById.values()).filter((link: GraphLink) => snapshot.nodesById.has(link.source) && snapshot.nodesById.has(link.target))
     };
-    graph3d?.graphData(data);
     graph2d?.graphData(data);
     updateSelectionUi(snapshot);
     renderStatus(snapshot.cursor, lastSync, data.nodes.length, data.links.length);
@@ -209,30 +206,27 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
 
   function setupRenderer(): void {
     try {
-      graph3d = ForceGraph3D()(el.graph3d)
-        .nodeId("id")
-        .nodeLabel((node: unknown) => (node as GraphNode).label)
-        .linkLabel((link: unknown) => `${(link as GraphLink).type}`)
-        .linkColor((link: unknown) => colorForType((link as GraphLink).type));
-      (graph3d as any).onNodeClick((node: unknown) => {
-        const id = String((node as GraphNode).id);
-        store.toggleSelectNode(id);
-      });
+      el.graph3d.style.display = "none";
+      reportDevError(el, "3D renderer disabled (react-force-graph-3d is a React component; imperative 3D not wired).");
 
       graph2d = ForceGraph2D()(el.graph2d)
         .nodeId("id")
         .nodeLabel("label")
         .linkColor((link: unknown) => colorForType((link as GraphLink).type));
-      (graph2d as any).onNodeClick((node: unknown) => {
-        const id = String((node as GraphNode).id);
-        store.toggleSelectNode(id);
-      });
+      if (typeof (graph2d as { onNodeClick?: unknown }).onNodeClick === "function") {
+        (graph2d as any).onNodeClick((node: unknown) => {
+          const id = String((node as GraphNode).id);
+          store.toggleSelectNode(id);
+        });
+      } else {
+        reportDevError(el, "2D renderer onNodeClick API unavailable; node click selection disabled.");
+      }
 
-      setRendererMode("3d");
+      setRendererMode("2d");
     } catch (error) {
       setRendererMode("fallback-json");
-      el.graph3d.innerHTML = `<pre style="margin:0;padding:8px;overflow:auto;">Renderer fallback:\n${escapeHtml(String(error))}</pre>`;
-      el.graph2d.innerHTML = "";
+      el.graph3d.style.display = "none";
+      el.graph2d.innerHTML = `<pre style="margin:0;padding:8px;overflow:auto;">Renderer fallback:\n${escapeHtml(String(error))}</pre>`;
       reportDevError(el, `renderer init failed: ${String(error)}`, error);
     }
   }
@@ -260,7 +254,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     }
   }
 
-  function setRendererMode(mode: "3d" | "2d" | "fallback-json"): void {
+  function setRendererMode(mode: "2d" | "fallback-json"): void {
     rendererMode = mode;
     el.rendererBadge.textContent = `Renderer: ${rendererMode}`;
   }

--- a/tests/e2e/mesh-explorer-sync-materialization.spec.ts
+++ b/tests/e2e/mesh-explorer-sync-materialization.spec.ts
@@ -22,8 +22,8 @@ describe("mesh explorer sync materialization", { timeout: 30_000 }, () => {
     const server: MeshGraphServerHandle = await startMeshGraphServer({ storageDir, port: 0 });
     cleanups.push(async () => server.close());
 
-    await createNode(server.url, "alice", "Node A");
-    await createNode(server.url, "alice", "Node B");
+    await createNode(server.url, "alice", "test01");
+    await createNode(server.url, "alice", "test02");
 
     const store = createGraphStore();
     const cursor = { metaSeq: 0, graphSeq: 0 };
@@ -34,8 +34,11 @@ describe("mesh explorer sync materialization", { timeout: 30_000 }, () => {
     store.applyGraphEvents(graphEvents);
     store.applyGraphEvents(graphEvents);
 
-    const nodeIds = Array.from(store.getState().nodesById.keys());
-    expect(nodeIds.length).toBe(2);
+    const nodes = Array.from(store.getState().nodesById.values());
+    expect(nodes.length).toBe(2);
+    expect(nodes.map((node) => node.label).sort()).toEqual(["test01", "test02"]);
+
+    const nodeIds = nodes.map((node) => node.id);
     expect(nodeIds[0]).not.toBe(nodeIds[1]);
 
     store.replaceSelection(nodeIds.slice(0, 2));


### PR DESCRIPTION
### Motivation

- The UI crashed with `TypeError: graph3d.onNodeClick is not a function` because `react-force-graph-3d` (a React component) was being used as an imperative instance in `packages/mesh-explorer-ui/src/index.ts`.
- The workspace does not include an imperative `3d-force-graph` dependency, so the safest immediate fix is to stop attempting the 3D imperative path and restore a working renderer.
- The goal is a minimal, safe Phase 17 fix that restores rendering and interactions by using the existing 2D imperative renderer and preserves selection-driven link creation.

### Description

- Removed the imperative `react-force-graph-3d` usage and import, hid the `#graph3d` panel non-fatally, and emit a DEV banner message: `3D renderer disabled (react-force-graph-3d is a React component; imperative 3D not wired).`.
- Standardized on the existing imperative 2D renderer via `ForceGraph2D()(el.graph2d)`, set `rendererMode` default to `"2d"`, and ensured store updates call `graph2d.graphData({ nodes, links })`.
- Added a guarded binding for node clicks on the 2D instance: if `(graph2d as any).onNodeClick` exists it toggles selection via `store.toggleSelectNode(id)`, otherwise a DEV error is reported.
- Preserved selection-driven link creation logic (requires exactly two selected node IDs; POST `/graph/links` uses `source`, `target`, `type`, and `idempotencyKey`), and kept the JSON fallback behavior rendering into the 2D panel on init failure.
- Updated an e2e test fixture to use deterministic labels (`test01`/`test02`) while keeping assertions that links are created between node IDs from the materialized store.

### Testing

- Ran `pnpm --filter @mesh/mesh-explorer-ui build` and the package compiled successfully.
- Ran full workspace build with `pnpm -r build` and it completed successfully.
- Ran the materialization e2e spec with `pnpm vitest run tests/e2e/mesh-explorer-sync-materialization.spec.ts` and the test suite passed (`1 test` passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699453476f2c8321bcfeefd74388b1d8)