### PR TITLE
Fix bootstrap cursor handling and persistence in mesh explorer UI

### DIFF
--- a/packages/mesh-explorer-ui/src/bootstrapCursor.ts
+++ b/packages/mesh-explorer-ui/src/bootstrapCursor.ts
@@ -1,0 +1,18 @@
+import type { Cursor } from "./graphStore.js";
+import { compareCursor } from "./syncGuards.js";
+
+export const ZERO_CURSOR: Cursor = { metaSeq: 0, graphSeq: 0 };
+
+export function resolveBootstrapFromCursor(saved: Cursor | null): Cursor {
+  return saved ?? ZERO_CURSOR;
+}
+
+export function nextMonotonicCursor(current: Cursor, candidate: Cursor): Cursor {
+  return compareCursor(candidate, current) > 0 ? candidate : current;
+}
+
+export function shouldPersistBootstrapCursor(fromCursor: Cursor, finalCursor: Cursor, currentCursor: Cursor): boolean {
+  if (compareCursor(finalCursor, fromCursor) <= 0) return false;
+  if (compareCursor(finalCursor, currentCursor) < 0) return false;
+  return true;
+}

--- a/packages/mesh-explorer-ui/src/cursorStorage.ts
+++ b/packages/mesh-explorer-ui/src/cursorStorage.ts
@@ -1,0 +1,3 @@
+export function cursorStorageKey(principal: string, graphSpaceId: string): string {
+  return `mesh.cursor.${principal}.${graphSpaceId}`;
+}

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -9,6 +9,8 @@ import {
   type GraphStore
 } from "./graphStore.js";
 import { compareCursor, persistCursorSafely, rotateAbortController } from "./syncGuards.js";
+import { nextMonotonicCursor, resolveBootstrapFromCursor, shouldPersistBootstrapCursor } from "./bootstrapCursor.js";
+import { cursorStorageKey } from "./cursorStorage.js";
 
 type Cursor = { metaSeq: number; graphSeq: number };
 type GraphData = { nodes: GraphNode[]; links: GraphLink[] };
@@ -111,16 +113,16 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     setConnectionStatus("connecting");
     const normalizedPrincipal = normalizePrincipal(el.principal.value);
     const storageKey = cursorStorageKey(normalizedPrincipal, el.graphSpaceId.value);
-    const savedCursor = readCursor(storageKey) ?? { metaSeq: 0, graphSeq: 0 };
+    const savedCursor = resolveBootstrapFromCursor(readCursor(storageKey));
+    dbg("sync:bootstrap:cursor-key", {
+      principal: normalizedPrincipal,
+      graphSpaceId: el.graphSpaceId.value,
+      storageKey,
+      savedCursor
+    });
     const replayResult = await pollReplayFromCursor(savedCursor, sessionId, activeAbort.signal);
     if (sessionId !== syncSession) return;
-    if (savedCursor.graphSeq > 0 && replayResult.graphEventsApplied === 0 && store.getState().nodesById.size === 0) {
-      const fallbackReplay = await pollReplayFromCursor({ metaSeq: 0, graphSeq: 0 }, sessionId, activeAbort.signal);
-      if (sessionId !== syncSession) return;
-      applyCursorIfAdvanced(storageKey, fallbackReplay.cursor, "poll");
-    } else {
-      applyCursorIfAdvanced(storageKey, replayResult.cursor, "poll");
-    }
+    persistBootstrapCursor(storageKey, savedCursor, replayResult.cursor);
     setConnectionStatus("connected (poll-only)");
     void subscribeLoop(sessionId, activeAbort.signal);
 
@@ -202,17 +204,18 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
             .map((entry) => asGraphEvent(entry.payload))
             .filter((event): event is GraphEvent => event !== null);
           const nextCursor = payload.cursorAfter ?? cursor;
-          const advanced = applyCursorIfAdvanced(storageKey, nextCursor, "poll");
-          if (advanced || graphEvents.length === 0) {
-            graphEventsApplied += graphEvents.length;
-            store.applyGraphEvents(graphEvents);
-            if (graphEvents.length > 0) setLastSyncNow();
-          }
+          graphEventsApplied += graphEvents.length;
+          store.applyGraphEvents(graphEvents);
+          if (graphEvents.length > 0) setLastSyncNow();
 
           const metaCount = payload.meta?.length ?? 0;
           const graphCount = payload.graph?.length ?? 0;
-          const cursorUnchanged = cursorEq(nextCursor, cursor);
-          cursor = nextCursor;
+          const nextMonotonic = nextMonotonicCursor(cursor, nextCursor);
+          const cursorUnchanged = cursorEq(nextMonotonic, cursor);
+          if (!cursorEq(nextCursor, nextMonotonic)) {
+            dbg("sync:poll:cursor-regression", { current: cursor, candidate: nextCursor });
+          }
+          cursor = nextMonotonic;
 
           if ((metaCount === 0 && graphCount === 0) || cursorUnchanged) {
             break;
@@ -324,6 +327,17 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     store.setCursor(candidate);
     persistCursor(storageKey, candidate);
     return true;
+  }
+
+  function persistBootstrapCursor(storageKey: string, fromCursor: Cursor, finalCursor: Cursor): void {
+    const current = store.getState().cursor;
+    if (!shouldPersistBootstrapCursor(fromCursor, finalCursor, current)) {
+      dbg("sync:bootstrap:cursor-regression", { fromCursor, current, finalCursor });
+      return;
+    }
+    store.setCursor(finalCursor);
+    persistCursor(storageKey, finalCursor);
+    dbg("sync:bootstrap:cursor-persisted", { storageKey, fromCursor, finalCursor });
   }
 
   function setRendererMode(mode: "2d" | "fallback-json"): void {
@@ -475,10 +489,6 @@ function colorForType(type: string): string {
   if (type === "parent") return "#3b82f6";
   if (type === "depends") return "#ef4444";
   return "#6b7280";
-}
-
-function cursorStorageKey(principal: string, graphSpaceId: string): string {
-  return `mesh.cursor.${principal}.${graphSpaceId}`;
 }
 
 function readCursor(storageKey: string): Cursor | null {

--- a/packages/mesh-explorer-ui/test/bootstrapCursor.test.ts
+++ b/packages/mesh-explorer-ui/test/bootstrapCursor.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { cursorStorageKey } from "../src/cursorStorage.js";
+import { nextMonotonicCursor, resolveBootstrapFromCursor, shouldPersistBootstrapCursor, ZERO_CURSOR } from "../src/bootstrapCursor.js";
+
+describe("mesh explorer bootstrap cursor", () => {
+  it("uses {0,0} when no local cursor exists (fresh browser)", () => {
+    expect(resolveBootstrapFromCursor(null)).toEqual({ metaSeq: 0, graphSeq: 0 });
+  });
+
+  it("keeps replaying history from {0,0} across refresh when local cursor is still absent", () => {
+    expect(resolveBootstrapFromCursor(null)).toEqual(ZERO_CURSOR);
+  });
+
+  it("uses persisted cursor when local cursor exists", () => {
+    expect(resolveBootstrapFromCursor({ metaSeq: 2, graphSeq: 8 })).toEqual({ metaSeq: 2, graphSeq: 8 });
+  });
+
+  it("writes exact storage key format mesh.cursor.<principal>.<graphSpaceId>", () => {
+    expect(cursorStorageKey("local-dev", "mesh-explorer-graph-v1")).toBe("mesh.cursor.local-dev.mesh-explorer-graph-v1");
+  });
+
+  it("keeps cursor monotonic during bootstrap replay", () => {
+    expect(nextMonotonicCursor({ metaSeq: 0, graphSeq: 4 }, { metaSeq: 0, graphSeq: 2 })).toEqual({ metaSeq: 0, graphSeq: 4 });
+    expect(nextMonotonicCursor({ metaSeq: 0, graphSeq: 4 }, { metaSeq: 0, graphSeq: 6 })).toEqual({ metaSeq: 0, graphSeq: 6 });
+  });
+
+  it("persists bootstrap cursor only when it advanced and remains monotonic", () => {
+    expect(shouldPersistBootstrapCursor({ metaSeq: 0, graphSeq: 0 }, { metaSeq: 0, graphSeq: 5 }, { metaSeq: 0, graphSeq: 5 })).toBe(true);
+    expect(shouldPersistBootstrapCursor({ metaSeq: 0, graphSeq: 5 }, { metaSeq: 0, graphSeq: 5 }, { metaSeq: 0, graphSeq: 5 })).toBe(false);
+    expect(shouldPersistBootstrapCursor({ metaSeq: 0, graphSeq: 0 }, { metaSeq: 0, graphSeq: 5 }, { metaSeq: 0, graphSeq: 6 })).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Users saw an empty graph after refresh because bootstrap replay could skip valid history when a non-local/server cursor was treated as the starting point. 
- The goal is to ensure bootstrap always replays history from a local cursor when present, otherwise from `{metaSeq:0,graphSeq:0}`, and to persist the final cursor only when it legitimately advanced and is monotonic. 
- This is a client-only fix to make cursor storage/readback and poll-replay behavior deterministic and auditable. 

### Description
- Use local storage as the authoritative `fromCursor` via `resolveBootstrapFromCursor(readCursor(...))` and default to `{metaSeq:0,graphSeq:0}` when absent. 
- Always apply graph events returned by `sync:poll` during bootstrap and advance the local cursor only monotonically via `nextMonotonicCursor`, logging any cursor regressions. 
- Persist the final bootstrap cursor only if it advanced relative to the bootstrap `fromCursor` and is monotonic relative to the current store cursor via `shouldPersistBootstrapCursor`. 
- Extracted helper modules and tests: added `packages/mesh-explorer-ui/src/bootstrapCursor.ts`, `packages/mesh-explorer-ui/src/cursorStorage.ts`, updated `packages/mesh-explorer-ui/src/index.ts`, and added `packages/mesh-explorer-ui/test/bootstrapCursor.test.ts`. 

### Testing
- Ran `pnpm --filter @mesh/mesh-explorer-ui build` and the package built successfully. 
- Ran `pnpm exec vitest run packages/mesh-explorer-ui/test/bootstrapCursor.test.ts` and all tests passed (6 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994cedbe1d4832191bfe136c5fe616a)