### PR TITLE
Fix bootstrap replay when UI store is empty

### DIFF
--- a/packages/mesh-explorer-ui/src/bootstrapCursor.ts
+++ b/packages/mesh-explorer-ui/src/bootstrapCursor.ts
@@ -3,8 +3,17 @@ import { compareCursor } from "./syncGuards.js";
 
 export const ZERO_CURSOR: Cursor = { metaSeq: 0, graphSeq: 0 };
 
-export function resolveBootstrapFromCursor(saved: Cursor | null): Cursor {
-  return saved ?? ZERO_CURSOR;
+type StoreSnapshot = { nodesCount: number; linksCount: number };
+
+export function resolveBootstrapFromCursor(saved: Cursor | null, snapshot: StoreSnapshot): Cursor {
+  if (isStoreEmpty(snapshot)) return ZERO_CURSOR;
+  if (!saved) return ZERO_CURSOR;
+  if (compareCursor(saved, ZERO_CURSOR) < 0) return ZERO_CURSOR;
+  return saved;
+}
+
+export function isStoreEmpty(snapshot: StoreSnapshot): boolean {
+  return snapshot.nodesCount === 0 && snapshot.linksCount === 0;
 }
 
 export function nextMonotonicCursor(current: Cursor, candidate: Cursor): Cursor {

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -9,8 +9,9 @@ import {
   type GraphStore
 } from "./graphStore.js";
 import { compareCursor, persistCursorSafely, rotateAbortController } from "./syncGuards.js";
-import { nextMonotonicCursor, resolveBootstrapFromCursor, shouldPersistBootstrapCursor } from "./bootstrapCursor.js";
+import { isStoreEmpty, nextMonotonicCursor, resolveBootstrapFromCursor, shouldPersistBootstrapCursor } from "./bootstrapCursor.js";
 import { cursorStorageKey } from "./cursorStorage.js";
+import { buildSyncPollUrl } from "./syncPollRequest.js";
 
 type Cursor = { metaSeq: number; graphSeq: number };
 type GraphData = { nodes: GraphNode[]; links: GraphLink[] };
@@ -113,16 +114,23 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     setConnectionStatus("connecting");
     const normalizedPrincipal = normalizePrincipal(el.principal.value);
     const storageKey = cursorStorageKey(normalizedPrincipal, el.graphSpaceId.value);
-    const savedCursor = resolveBootstrapFromCursor(readCursor(storageKey));
+    const persistedCursor = readCursor(storageKey);
+    const storeSnapshot = {
+      nodesCount: store.getState().nodesById.size,
+      linksCount: store.getState().linksById.size
+    };
+    const fromCursor = resolveBootstrapFromCursor(persistedCursor, storeSnapshot);
     dbg("sync:bootstrap:cursor-key", {
       principal: normalizedPrincipal,
       graphSpaceId: el.graphSpaceId.value,
       storageKey,
-      savedCursor
+      isStoreEmpty: isStoreEmpty(storeSnapshot),
+      persistedCursor,
+      fromCursor
     });
-    const replayResult = await pollReplayFromCursor(savedCursor, sessionId, activeAbort.signal);
+    const replayResult = await pollReplayFromCursor(fromCursor, sessionId, activeAbort.signal);
     if (sessionId !== syncSession) return;
-    persistBootstrapCursor(storageKey, savedCursor, replayResult.cursor);
+    persistBootstrapCursor(storageKey, fromCursor, replayResult.cursor);
     setConnectionStatus("connected (poll-only)");
     void subscribeLoop(sessionId, activeAbort.signal);
 
@@ -187,11 +195,9 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       let cursor = initialCursor;
       let graphEventsApplied = 0;
       try {
-        const limits = encodeURIComponent(JSON.stringify({ graph: 128, meta: 32 }));
         while (activeSessionId === syncSession) {
-          const encodedCursor = encodeURIComponent(JSON.stringify(cursor));
           const response = await meshFetch(
-            `${el.baseUrl.value}/v1/${encodeURIComponent(el.graphSpaceId.value)}/sync:poll?cursor=${encodedCursor}&limits=${limits}`,
+            buildSyncPollUrl(el.baseUrl.value, el.graphSpaceId.value, cursor, { graph: 128, meta: 32 }),
             { headers: headers(normalizedPrincipal), signal },
             { principal: normalizedPrincipal, transport: "fetch", debugAuth }
           );

--- a/packages/mesh-explorer-ui/src/syncPollRequest.ts
+++ b/packages/mesh-explorer-ui/src/syncPollRequest.ts
@@ -1,0 +1,7 @@
+import type { Cursor } from "./graphStore.js";
+
+export function buildSyncPollUrl(baseUrl: string, graphSpaceId: string, cursor: Cursor, limits: { graph: number; meta: number }): string {
+  const encodedCursor = encodeURIComponent(JSON.stringify(cursor));
+  const encodedLimits = encodeURIComponent(JSON.stringify(limits));
+  return `${baseUrl}/v1/${encodeURIComponent(graphSpaceId)}/sync:poll?cursor=${encodedCursor}&limits=${encodedLimits}`;
+}

--- a/packages/mesh-explorer-ui/test/bootstrapCursor.test.ts
+++ b/packages/mesh-explorer-ui/test/bootstrapCursor.test.ts
@@ -1,19 +1,28 @@
 import { describe, expect, it } from "vitest";
 
 import { cursorStorageKey } from "../src/cursorStorage.js";
-import { nextMonotonicCursor, resolveBootstrapFromCursor, shouldPersistBootstrapCursor, ZERO_CURSOR } from "../src/bootstrapCursor.js";
+import { isStoreEmpty, nextMonotonicCursor, resolveBootstrapFromCursor, shouldPersistBootstrapCursor, ZERO_CURSOR } from "../src/bootstrapCursor.js";
 
 describe("mesh explorer bootstrap cursor", () => {
   it("uses {0,0} when no local cursor exists (fresh browser)", () => {
-    expect(resolveBootstrapFromCursor(null)).toEqual({ metaSeq: 0, graphSeq: 0 });
+    expect(resolveBootstrapFromCursor(null, { nodesCount: 1, linksCount: 0 })).toEqual({ metaSeq: 0, graphSeq: 0 });
   });
 
   it("keeps replaying history from {0,0} across refresh when local cursor is still absent", () => {
-    expect(resolveBootstrapFromCursor(null)).toEqual(ZERO_CURSOR);
+    expect(resolveBootstrapFromCursor(null, { nodesCount: 0, linksCount: 0 })).toEqual(ZERO_CURSOR);
   });
 
-  it("uses persisted cursor when local cursor exists", () => {
-    expect(resolveBootstrapFromCursor({ metaSeq: 2, graphSeq: 8 })).toEqual({ metaSeq: 2, graphSeq: 8 });
+  it("uses {0,0} when store is empty even when persisted cursor exists", () => {
+    expect(resolveBootstrapFromCursor({ metaSeq: 2, graphSeq: 8 }, { nodesCount: 0, linksCount: 0 })).toEqual(ZERO_CURSOR);
+  });
+
+  it("uses persisted cursor when store is not empty", () => {
+    expect(resolveBootstrapFromCursor({ metaSeq: 2, graphSeq: 8 }, { nodesCount: 1, linksCount: 0 })).toEqual({ metaSeq: 2, graphSeq: 8 });
+  });
+
+  it("detects when store snapshot is empty", () => {
+    expect(isStoreEmpty({ nodesCount: 0, linksCount: 0 })).toBe(true);
+    expect(isStoreEmpty({ nodesCount: 1, linksCount: 0 })).toBe(false);
   });
 
   it("writes exact storage key format mesh.cursor.<principal>.<graphSpaceId>", () => {

--- a/packages/mesh-explorer-ui/test/syncPollRequest.test.ts
+++ b/packages/mesh-explorer-ui/test/syncPollRequest.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveBootstrapFromCursor } from "../src/bootstrapCursor.js";
+import { buildSyncPollUrl } from "../src/syncPollRequest.js";
+
+describe("sync poll request bootstrap", () => {
+  it("builds initial sync:poll with {0,0} when store is empty and persisted cursor is non-zero", () => {
+    const fromCursor = resolveBootstrapFromCursor({ metaSeq: 0, graphSeq: 39 }, { nodesCount: 0, linksCount: 0 });
+    const url = new URL(buildSyncPollUrl("http://127.0.0.1:8090", "mesh-explorer-graph-v1", fromCursor, { graph: 128, meta: 32 }));
+
+    expect(JSON.parse(url.searchParams.get("cursor") ?? "{}")).toEqual({ metaSeq: 0, graphSeq: 0 });
+  });
+
+  it("builds initial sync:poll with persisted cursor when store is non-empty", () => {
+    const fromCursor = resolveBootstrapFromCursor({ metaSeq: 0, graphSeq: 39 }, { nodesCount: 1, linksCount: 0 });
+    const url = new URL(buildSyncPollUrl("http://127.0.0.1:8090", "mesh-explorer-graph-v1", fromCursor, { graph: 128, meta: 32 }));
+
+    expect(JSON.parse(url.searchParams.get("cursor") ?? "{}")).toEqual({ metaSeq: 0, graphSeq: 39 });
+  });
+});


### PR DESCRIPTION
### Motivation
- On a fresh browser/session the UI store can be empty while a non-zero cursor is restored from localStorage, which made the client poll from that persisted cursor and miss prior history (partial/empty graph).
- Product rule: if the store snapshot is empty at Connect then bootstrap must request a full replay from `{metaSeq:0,graphSeq:0}` until a materialized snapshot exists.

### Description
- Add store-aware bootstrap logic in `bootstrapCursor.ts` with `isStoreEmpty` and `resolveBootstrapFromCursor(saved, snapshot)` so an empty store forces `ZERO_CURSOR`.
- Compute a store snapshot before the first request in `connectAndSync` and resolve `fromCursor` from `(persistedCursor, storeSnapshot)`, then log `isStoreEmpty`, `persistedCursor`, and `fromCursor` before issuing the first `sync:poll`.
- Extract `buildSyncPollUrl` helper and use it for poll requests so the initial poll URL/cursor payload is testable.
- Update unit tests to cover the new rule: empty-store + persisted cursor ⇒ `{0,0}`, non-empty store ⇒ use persisted cursor, and added a `syncPollRequest` test to assert the built `sync:poll` URL contains the expected `cursor` payload.

### Testing
- Ran unit tests: `pnpm vitest packages/mesh-explorer-ui/test/bootstrapCursor.test.ts packages/mesh-explorer-ui/test/syncPollRequest.test.ts --run` — all tests passed (10 tests total).
- Built package: `pnpm --filter @mesh/mesh-explorer-ui build` — build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994e11fccf88321b4b3c6118284d529)