### PR TITLE
Fix cold-start sync:poll backlog reads and add sync diagnostics

### DIFF
--- a/docs/recovery-endpoints-sync-v1.md
+++ b/docs/recovery-endpoints-sync-v1.md
@@ -15,9 +15,12 @@
 
 ## Poll vs Subscribe
 
-- Use `sync:subscribe` for low-latency deltas.
-- Always keep a durable local cursor (`metaSeq`, `graphSeq`).
-- On reconnect, uncertainty, duplicate ambiguity, or cursor mismatch, run `sync:poll` from the durable cursor.
+- `sync:poll` is the authoritative recovery path and must return backlog from the provided event cursor `{metaSeq,graphSeq}`.
+- `sync:subscribe` is best-effort low-latency acceleration and may replay visible tx bundles from `from` (principal-visible tx cursor), but replay completeness is not guaranteed.
+- Cursor families are different by design:
+  - `sync:poll` / `events:read`: event-sequence cursors (`metaSeq`, `graphSeq`).
+  - `sync:subscribe` / `sync:pull`: principal-visible transaction cursor (`from`, `cursorVisible`).
+- Always keep a durable local event cursor (`metaSeq`, `graphSeq`) for recovery and call `sync:poll` on reconnect, uncertainty, duplicate ambiguity, or cursor mismatch.
 
 ## Gap / mismatch handling
 

--- a/packages/eventstore-local/src/FileBackedLocalEventStore.ts
+++ b/packages/eventstore-local/src/FileBackedLocalEventStore.ts
@@ -148,6 +148,7 @@ export class FileBackedLocalEventStore implements LocalEventStore {
   }
 
   async readTx(graphSpaceId: string, txId: TxId): Promise<{ txId: TxId; meta: EventEnvelope[]; graph: EventEnvelope[] } | null> {
+    await this.loadState();
     const space = this.getSpace(graphSpaceId);
     if (!space) return null;
     recordTxIndexLookup();
@@ -180,6 +181,7 @@ export class FileBackedLocalEventStore implements LocalEventStore {
     _mode: ReadMode,
     options?: ReadRangeOptions
   ): Promise<EventEnvelope[]> {
+    await this.loadState();
     const space = this.getSpace(graphSpaceId);
     if (!space) return [];
     recordRangeRead();
@@ -210,11 +212,13 @@ export class FileBackedLocalEventStore implements LocalEventStore {
   }
 
   async readTxIndex(graphSpaceId: string): Promise<TxIndexEntry[]> {
+    await this.loadState();
     const space = this.getSpace(graphSpaceId);
     return space ? [...space.txIndex] : [];
   }
 
   async getCursorHead(graphSpaceId: string): Promise<Cursor> {
+    await this.loadState();
     const space = this.getSpace(graphSpaceId);
     return { metaSeq: space?.meta.length ?? 0, graphSeq: space?.graph.length ?? 0 };
   }
@@ -225,6 +229,7 @@ export class FileBackedLocalEventStore implements LocalEventStore {
     limit: number,
     principal?: PrincipalContext
   ): Promise<{ txs: Array<{ txId: TxId; txIndex: number; meta: EventEnvelope[]; graph: EventEnvelope[] }>; cursor: number }> {
+    await this.loadState();
     const space = this.getSpace(graphSpaceId);
     if (!space) return { txs: [], cursor: fromPrincipalCursorExclusive };
 
@@ -239,6 +244,7 @@ export class FileBackedLocalEventStore implements LocalEventStore {
   }
 
   async getPrincipalCursorHead(graphSpaceId: string, principal?: PrincipalContext): Promise<number> {
+    await this.loadState();
     const space = this.getSpace(graphSpaceId);
     if (!space) return 0;
     const txs = buildTxBundles(space.txIndex, space.meta, space.graph);

--- a/packages/eventstore-local/test/fileBackedRestartReadPath.test.ts
+++ b/packages/eventstore-local/test/fileBackedRestartReadPath.test.ts
@@ -1,0 +1,49 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { FileBackedLocalEventStore } from "../src/index.js";
+
+describe("file-backed store cold-start read path", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (dir) {
+        await rm(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("loads persisted tx history for readPrincipalTxRange after process-style restart", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "mesh-eventstore-restart-"));
+    tempDirs.push(dir);
+    const filePath = path.join(dir, "store.json");
+    const graphSpaceId = "space-restart";
+    const principal = { principalId: "local-dev" };
+
+    const first = new FileBackedLocalEventStore(filePath);
+    await first.appendTx(
+      graphSpaceId,
+      {
+        txId: "tx-1",
+        metaEvents: [{ type: "meta.created" }],
+        graphEvents: [{ type: "graph.node.created", node: { id: "n-1", label: "N1" } }]
+      },
+      {
+        actorId: principal.principalId,
+        idempotencyKey: "idem-1",
+        payloadHash: "hash-1"
+      }
+    );
+    await first.close();
+
+    const restarted = new FileBackedLocalEventStore(filePath);
+    const range = await restarted.readPrincipalTxRange(graphSpaceId, 0, 10, principal);
+
+    expect(range.txs).toHaveLength(1);
+    expect(range.txs[0]?.txId).toBe("tx-1");
+    expect(range.cursor).toBe(1);
+  });
+});

--- a/packages/sync-local/src/internal/transportGateway.ts
+++ b/packages/sync-local/src/internal/transportGateway.ts
@@ -86,6 +86,7 @@ const DEFAULT_LIMIT_BYTES = 128 * 1024;
 const DEFAULT_POLL_INTERVAL_MS = 15;
 const DEFAULT_HEARTBEAT_EVERY_MS = 200;
 const utf8Encoder = new TextEncoder();
+const DEBUG_SYNC_ENABLED = process.env.MESH_DEBUG_SYNC === "1";
 
 export class LocalSyncGateway {
   constructor(
@@ -176,6 +177,11 @@ export class LocalSyncGateway {
     options: SyncSubscribeOptions = {}
   ): AsyncIterable<SyncFrame> {
     this.assertGraphSpaceScope(graphSpaceId);
+    debugSync("sync:subscribe:start", {
+      graphSpaceId,
+      principalId: principal.principalId,
+      fromCursorVisible
+    });
 
     const pollIntervalMs = Math.max(1, options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
     const heartbeatEveryMs = Math.max(pollIntervalMs, options.heartbeatEveryMs ?? DEFAULT_HEARTBEAT_EVERY_MS);
@@ -186,6 +192,13 @@ export class LocalSyncGateway {
     while (true) {
       const pulled = await this.syncPull(graphSpaceId, principal, cursor, options);
       if (pulled.txBundlesVisible.length > 0) {
+        debugSync("sync:subscribe:txBundles", {
+          graphSpaceId,
+          principalId: principal.principalId,
+          cursorBefore: cursor,
+          txBundlesVisibleCount: pulled.txBundlesVisible.length,
+          cursorAfterVisible: pulled.cursorAfterVisible
+        });
         yield {
           kind: "txBundles",
           txBundlesVisible: pulled.txBundlesVisible
@@ -200,6 +213,11 @@ export class LocalSyncGateway {
 
       const now = Date.now();
       if (now - lastHeartbeatAt >= heartbeatEveryMs) {
+        debugSync("sync:subscribe:heartbeat", {
+          graphSpaceId,
+          principalId: principal.principalId,
+          cursorVisible: cursor
+        });
         yield {
           kind: "heartbeat",
           cursorVisible: cursor
@@ -265,7 +283,7 @@ export class LocalSyncGateway {
       limitBytes: options.graphLimitBytes
     });
 
-    return {
+    const result = {
       meta,
       graph,
       cursorAfter: {
@@ -273,6 +291,18 @@ export class LocalSyncGateway {
         graphSeq: graph[graph.length - 1]?.seq ?? cursor.graphSeq
       }
     };
+
+    debugSync("sync:poll", {
+      graphSpaceId,
+      principalId: principal.principalId,
+      cursor,
+      cursorAfter: result.cursorAfter,
+      metaCount: result.meta.length,
+      graphCount: result.graph.length,
+      options
+    });
+
+    return result;
   }
 
   private assertGraphSpaceScope(graphSpaceId: string): void {
@@ -305,6 +335,13 @@ export class LocalSyncGateway {
 
     return { meta, graph };
   }
+}
+
+function debugSync(message: string, details: Record<string, unknown>): void {
+  if (!DEBUG_SYNC_ENABLED) {
+    return;
+  }
+  process.stdout.write(`[sync-local] ${message} ${JSON.stringify(details)}\n`);
 }
 
 function sleep(ms: number): Promise<void> {


### PR DESCRIPTION
### Motivation
- On cold start `sync:poll` could return an empty backlog even when persisted history existed because read paths did not ensure the file-backed store was loaded before serving reads.  
- The goal is to make `sync:poll` (the recovery path) consistent with `sync:subscribe` and make it possible to diagnose first-request differences at startup.

### Description
- Ensure persisted state is loaded for read APIs by adding `await this.loadState()` to key `FileBackedLocalEventStore` read methods (`readTx`, `readRange`, `readTxIndex`, `getCursorHead`, `readPrincipalTxRange`, `getPrincipalCursorHead`).
- Add a regression test `packages/eventstore-local/test/fileBackedRestartReadPath.test.ts` that writes, re-opens the store, and verifies `readPrincipalTxRange(..., 0, ...)` immediately returns persisted txs.
- Add opt-in debug instrumentation in `LocalSyncGateway` (guarded by `MESH_DEBUG_SYNC=1`) to emit traces for `sync:poll` and `sync:subscribe` (start cursor, replay bundle counts, heartbeat cursor, and poll results).
- Clarify docs in `docs/recovery-endpoints-sync-v1.md` to state `sync:poll` uses event-sequence cursors (`{metaSeq,graphSeq}`) and `sync:subscribe`/`sync:pull` use principal-visible tx cursors (`from`/`cursorVisible`).

### Testing
- Ran `pnpm --filter @mesh/eventstore-local test` and the package tests passed (all tests in `@mesh/eventstore-local` succeeded). 
- Ran the targeted recovery conformance test with `MESH_TX_VISIBILITY_POLICY=acl pnpm --filter @mesh/conformance-tests exec vitest run src/ct_http_recovery.test.ts` and the file passed.
- An attempted isolated `pnpm --filter @mesh/eventstore-local build && pnpm --filter @mesh/sync-local build` hit workspace dependency resolution issues for `@mesh/shared` in the transient environment, which did not affect the above unit/integration test results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69950725ef98832194d62a5ea3d23867)