### PR TITLE
Reduce sync heartbeat frequency and pace subscribe retries

### DIFF
--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -12,6 +12,11 @@ import { compareCursor, persistCursorSafely, rotateAbortController } from "./syn
 import { isStoreEmpty, nextMonotonicCursor, resolveBootstrapFromCursor, shouldPersistBootstrapCursor } from "./bootstrapCursor.js";
 import { cursorStorageKey } from "./cursorStorage.js";
 import { buildSyncPollUrl } from "./syncPollRequest.js";
+import {
+  SUBSCRIBE_ERROR_LOG_THROTTLE_MS,
+  SUBSCRIBE_RETRY_DELAY_MS,
+  isSyncDebugEnabled
+} from "./syncConfig.js";
 
 type Cursor = { metaSeq: number; graphSeq: number };
 type GraphData = { nodes: GraphNode[]; links: GraphLink[] };
@@ -27,6 +32,7 @@ type SyncPollPayload = {
   graph?: Array<{ payload?: unknown }>;
   cursorAfter?: Cursor;
 };
+
 
 export function mountMeshExplorerUi(container: HTMLElement): void {
   const initialPrincipal = readInitialPrincipal();
@@ -63,6 +69,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   const el = byId(container);
   const debugAuth = isDebugAuthEnabled();
   const debugEnabled = isDebugEnabled();
+  const verboseSyncErrors = isSyncDebugEnabled();
   const store = createGraphStore();
   let syncSession = 0;
   let graph2d: any = null;
@@ -135,6 +142,8 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     void subscribeLoop(sessionId, activeAbort.signal);
 
     async function subscribeLoop(activeSessionId: number, signal: AbortSignal): Promise<void> {
+      let retryDelayMs = SUBSCRIBE_RETRY_DELAY_MS;
+      let lastSubscribeErrorLogAt = 0;
       while (activeSessionId === syncSession) {
         try {
           const url = `${el.baseUrl.value}/v1/${encodeURIComponent(el.graphSpaceId.value)}/sync:subscribe?from=${store.getState().cursor.graphSeq}`;
@@ -145,10 +154,11 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
           });
           if (!response.body) {
             setConnectionStatus("reconnecting");
-            await wait(300);
+            await wait(retryDelayMs);
             continue;
           }
           setConnectionStatus("connected");
+          retryDelayMs = SUBSCRIBE_RETRY_DELAY_MS;
           for await (const data of parseSse(response.body)) {
             if (activeSessionId !== syncSession) return;
             if (data.kind === "heartbeat") {
@@ -185,8 +195,15 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
         } catch (error) {
           if (signal.aborted) return;
           setConnectionStatus("reconnecting");
-          reportDevError(el, `sync subscribe failed: ${String(error)}`, error);
-          await wait(500);
+          const now = Date.now();
+          const shouldLog =
+            verboseSyncErrors ||
+            now - lastSubscribeErrorLogAt >= SUBSCRIBE_ERROR_LOG_THROTTLE_MS;
+          if (shouldLog) {
+            reportDevError(el, `sync subscribe failed: ${String(error)}`, error);
+            lastSubscribeErrorLogAt = now;
+          }
+          await wait(retryDelayMs);
         }
       }
     }

--- a/packages/mesh-explorer-ui/src/syncConfig.ts
+++ b/packages/mesh-explorer-ui/src/syncConfig.ts
@@ -1,0 +1,9 @@
+export const SUBSCRIBE_RETRY_DELAY_MS = 1000;
+export const SUBSCRIBE_ERROR_LOG_THROTTLE_MS = 5000;
+
+export function isSyncDebugEnabled(): boolean {
+  const env = (import.meta as ImportMeta & { env?: Record<string, string | boolean | undefined> }).env;
+  if (env?.MESH_DEBUG_SYNC === "1") return true;
+  const processEnv = (globalThis as typeof globalThis & { process?: { env?: Record<string, string | undefined> } }).process?.env;
+  return processEnv?.MESH_DEBUG_SYNC === "1";
+}

--- a/packages/sync-local/src/internal/transportGateway.ts
+++ b/packages/sync-local/src/internal/transportGateway.ts
@@ -84,7 +84,9 @@ export interface LocalSyncGatewayConfig {
 const DEFAULT_LIMIT_TX = 64;
 const DEFAULT_LIMIT_BYTES = 128 * 1024;
 const DEFAULT_POLL_INTERVAL_MS = 15;
-const DEFAULT_HEARTBEAT_EVERY_MS = 200;
+export const HEARTBEAT_INTERVAL_MS = Number(
+  process.env.MESH_HEARTBEAT_INTERVAL_MS ?? 5000
+);
 const utf8Encoder = new TextEncoder();
 const DEBUG_SYNC_ENABLED = process.env.MESH_DEBUG_SYNC === "1";
 
@@ -184,7 +186,7 @@ export class LocalSyncGateway {
     });
 
     const pollIntervalMs = Math.max(1, options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
-    const heartbeatEveryMs = Math.max(pollIntervalMs, options.heartbeatEveryMs ?? DEFAULT_HEARTBEAT_EVERY_MS);
+    const heartbeatEveryMs = Math.max(pollIntervalMs, options.heartbeatEveryMs ?? HEARTBEAT_INTERVAL_MS);
 
     let cursor = fromCursorVisible;
     let lastHeartbeatAt = Date.now();

--- a/tests/e2e/sync-subscribe-timing.spec.ts
+++ b/tests/e2e/sync-subscribe-timing.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { InMemoryLocalEventStore } from "../../packages/eventstore-local/src/InMemoryLocalEventStore.js";
+import { HEARTBEAT_INTERVAL_MS, LocalSyncGateway } from "../../packages/sync-local/src/internal/transportGateway.js";
+import { SUBSCRIBE_RETRY_DELAY_MS } from "../../packages/mesh-explorer-ui/src/syncConfig.js";
+
+describe("sync subscribe timing controls", () => {
+  it("uses 5s heartbeat interval by default", () => {
+    expect(HEARTBEAT_INTERVAL_MS).toBe(5000);
+  });
+
+  it("emits heartbeat around the configured 5s interval", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+    const gateway = new LocalSyncGateway(new InMemoryLocalEventStore(), {
+      graphSpaceId: "mesh-explorer-graph-v1"
+    });
+
+    const iterator = gateway
+      .syncSubscribe("mesh-explorer-graph-v1", { principalId: "alice" }, 0, { pollIntervalMs: 25 })
+      [Symbol.asyncIterator]();
+
+    let settled = false;
+    const nextFrame = iterator.next().then((frame) => {
+      settled = true;
+      return frame;
+    });
+
+    await vi.advanceTimersByTimeAsync(4900);
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(150);
+    const frame = await nextFrame;
+    expect(frame.value?.kind).toBe("heartbeat");
+
+    await iterator.return?.();
+    vi.useRealTimers();
+  });
+
+  it("paces subscribe retries at 1s", () => {
+    expect(SUBSCRIBE_RETRY_DELAY_MS).toBe(1000);
+  });
+});


### PR DESCRIPTION
### Motivation
- Reduce noisy frequent `sync:subscribe` retries and heartbeats while preserving sync semantics and liveness. 
- Make heartbeat cadence configurable so deployments can choose lower-frequency keepalive without affecting business logic. 
- Pace frontend subscribe retries and throttle repeated error logs to avoid log spam when server is down.

### Description
- Backend: introduce `HEARTBEAT_INTERVAL_MS` (from `MESH_HEARTBEAT_INTERVAL_MS ?? 5000`) and use it in `syncSubscribe` instead of the previous tight default, so heartbeats are emitted roughly every 5s by default (`packages/sync-local/src/internal/transportGateway.ts`).
- Frontend: add `syncConfig.ts` with `SUBSCRIBE_RETRY_DELAY_MS = 1000`, `SUBSCRIBE_ERROR_LOG_THROTTLE_MS = 5000`, and `isSyncDebugEnabled()` to gate verbose sync logging (`packages/mesh-explorer-ui/src/syncConfig.ts`).
- Frontend: update `subscribeLoop` in `mountMeshExplorerUi` to use a fixed 1s retry delay when SSE is unavailable or on network errors, reset delay on successful connect, and throttle error reporting to once per `SUBSCRIBE_ERROR_LOG_THROTTLE_MS` unless `MESH_DEBUG_SYNC=1` enables verbose errors (`packages/mesh-explorer-ui/src/index.ts`).
- Tests: add timing-focused tests `tests/e2e/sync-subscribe-timing.spec.ts` to assert the heartbeat default value and timing behavior and to assert the subscribe retry constant.

### Testing
- Ran `pnpm vitest run tests/e2e/sync-subscribe-timing.spec.ts` which passed (3 tests passed). 
- Ran `pnpm vitest run tests/e2e/mesh-explorer-sync-hardening.spec.ts` which passed (6 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995a925f4c4832187c13f5e8d03cb06)