### PR TITLE
Enable edge hit-testing and live renderer zoom badge updates

### DIFF
--- a/packages/mesh-explorer-ui/src/graphCanvas2d.ts
+++ b/packages/mesh-explorer-ui/src/graphCanvas2d.ts
@@ -32,7 +32,7 @@ export type GraphCanvasCallbacks = {
 const NODE_RADIUS = 22;
 const NODE_HIT_SLOP_PX = 0;
 const EDGE_HIT_SLOP_PX = 8;
-export const ENABLE_EDGE_HIT_TEST = false;
+export const ENABLE_EDGE_HIT_TEST = true;
 
 export function worldToScreen(world: Vec2, camera: CameraState): Vec2 {
   return { x: (world.x - camera.x) * camera.zoom, y: (world.y - camera.y) * camera.zoom };
@@ -158,6 +158,8 @@ export class GraphCanvas2D {
   private pointer = { x: 0, y: 0 };
   private panning = false;
   private dragging: { pointerStart: Vec2; original: Map<string, Vec2> } | null = null;
+  private hoveredEdgeId: string | null = null;
+  private selectedEdgeId: string | null = null;
 
   constructor(
     private readonly canvas: HTMLCanvasElement,
@@ -245,6 +247,9 @@ export class GraphCanvas2D {
       }
       if (!this.dragging) {
         this.ui.hoveredNodeId = hitTestNode(this.readModel.nodes, this.ui.camera, this.pointer);
+        this.hoveredEdgeId = this.ui.hoveredNodeId
+          ? null
+          : hitTestEdges(this.readModel.links, this.nodePositions(), this.ui.camera, this.pointer);
         this.render();
         return;
       }
@@ -279,9 +284,20 @@ export class GraphCanvas2D {
       const pointerWorld = screenToWorld({ x: event.offsetX, y: event.offsetY }, this.ui.camera);
       if (!wasDragging) {
         const hit = hitTestNode(this.readModel.nodes, this.ui.camera, { x: event.offsetX, y: event.offsetY });
-        const next = nextEdgeDraft(this.ui.edgeDraft, hit, pointerWorld);
-        this.callbacks.onEdgeDraftChange(next.edgeDraft);
-        if (next.commit) this.callbacks.onCreateEdge(next.commit.source, next.commit.target);
+        if (hit) {
+          this.selectedEdgeId = null;
+          const next = nextEdgeDraft(this.ui.edgeDraft, hit, pointerWorld);
+          this.callbacks.onEdgeDraftChange(next.edgeDraft);
+          if (next.commit) this.callbacks.onCreateEdge(next.commit.source, next.commit.target);
+        } else {
+          const edgeHit = hitTestEdges(this.readModel.links, this.nodePositions(), this.ui.camera, { x: event.offsetX, y: event.offsetY });
+          if (edgeHit) {
+            this.selectedEdgeId = edgeHit;
+            this.callbacks.onEdgeDraftChange(null);
+          } else if (this.readModel.selectedNodeIds.size === 0) {
+            this.selectedEdgeId = null;
+          }
+        }
       }
       this.render();
     };
@@ -353,7 +369,9 @@ export class GraphCanvas2D {
       const source = this.nodePos(link.source);
       const target = this.nodePos(link.target);
       if (!source || !target) continue;
-      this.ctx.strokeStyle = "#94a3b8";
+      const selected = this.selectedEdgeId === link.id;
+      const hovered = !selected && this.hoveredEdgeId === link.id;
+      this.ctx.strokeStyle = selected ? "#2563eb" : hovered ? "#0ea5e9" : "#94a3b8";
       this.ctx.lineWidth = 2 / this.ui.camera.zoom;
       this.ctx.beginPath();
       this.ctx.moveTo(source.x, source.y);
@@ -399,6 +417,14 @@ export class GraphCanvas2D {
     if (overlay) return overlay;
     const node = this.readModel.nodes.find((item) => item.id === id);
     return node?.position ?? null;
+  }
+
+  private nodePositions(): Map<string, Vec2> {
+    const output = new Map<string, Vec2>();
+    for (const node of this.readModel.nodes) {
+      output.set(node.id, this.nodePos(node.id) ?? node.position);
+    }
+    return output;
   }
 }
 

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -85,9 +85,12 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   const pendingMoveCommits = new Map<string, Vec2>();
   let hasUserMovedCamera = false;
   let autoFitApplied = false;
+  let cameraInfo: CameraState = { x: -280, y: -180, zoom: 1, minZoom: 0.2, maxZoom: 3.5 };
+  let badgeStats = { nodes: 0, links: 0 };
+  let badgeRaf = 0;
 
   const uiState: CanvasUiState = {
-    camera: { x: -280, y: -180, zoom: 1, minZoom: 0.2, maxZoom: 3.5 },
+    camera: cameraInfo,
     hoveredNodeId: null,
     edgeDraft: null,
     overlayPositions: new Map(),
@@ -337,10 +340,11 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
         onCreateEdge: (source, target) => {
           void createLinkFromDraft(source, target);
         },
-        onMoveCommit: commitNodeMove
-        ,
-        onCameraChange: () => {
+        onMoveCommit: commitNodeMove,
+        onCameraChange: (camera) => {
           hasUserMovedCamera = true;
+          cameraInfo = camera;
+          queueBadgeRender();
         },
         onFitRequest: () => {
           fitCameraToCurrentGraph(materializeNodePositions(Array.from(store.getState().nodesById.values())));
@@ -400,6 +404,8 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     if (!bounds) return;
     const rect = el.graphCanvas.getBoundingClientRect();
     uiState.camera = fitCameraToBounds(bounds, { width: rect.width, height: rect.height }, uiState.camera, 0.12);
+    cameraInfo = uiState.camera;
+    queueBadgeRender();
     canvasRenderer?.update({
       nodes,
       links: Array.from(store.getState().linksById.values()),
@@ -425,7 +431,8 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     el.status.textContent = snapshot.connectionStatus;
     el.lastCursor.textContent = `cursor: ${JSON.stringify(snapshot.cursor)}`;
     el.lastSync.textContent = `last sync: ${snapshot.lastSync}`;
-    el.rendererBadge.textContent = `Renderer: ${rendererMode} | nodes=${nodes} links=${links} zoom=${uiState.camera.zoom.toFixed(2)}`;
+    badgeStats = { nodes, links };
+    queueBadgeRender();
     if (!el.principal.value.trim()) {
       el.status.textContent = `principal required: sending default "${DEFAULT_PRINCIPAL}" via x-mesh-principal`;
     }
@@ -459,7 +466,15 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
 
   function setRendererMode(mode: "canvas-2d" | "fallback-json"): void {
     rendererMode = mode;
-    el.rendererBadge.textContent = `Renderer: ${rendererMode}`;
+    queueBadgeRender();
+  }
+
+  function queueBadgeRender(): void {
+    if (badgeRaf) return;
+    badgeRaf = requestAnimationFrame(() => {
+      badgeRaf = 0;
+      el.rendererBadge.textContent = `Renderer: ${rendererMode} | nodes=${badgeStats.nodes} links=${badgeStats.links} zoom=x${cameraInfo.zoom.toFixed(2)}`;
+    });
   }
 
   function dbg(message: string, detail?: unknown): void {

--- a/packages/mesh-explorer-ui/test/canvasFlow.integration.test.ts
+++ b/packages/mesh-explorer-ui/test/canvasFlow.integration.test.ts
@@ -1,8 +1,27 @@
 import { describe, expect, it } from "vitest";
 
-import { nextEdgeDraft, type Vec2 } from "../src/graphCanvas2d.js";
+import { hitTestEdges, nextEdgeDraft, type CameraState, type Vec2 } from "../src/graphCanvas2d.js";
 
 describe("canvas flow integration", () => {
+  it("click near edge at various zoom levels hits edge", () => {
+    const links = [{ id: "edge-1", source: "n1", target: "n2" }];
+    const nodePositions = new Map([
+      ["n1", { x: 0, y: 0 }],
+      ["n2", { x: 200, y: 0 }]
+    ]);
+
+    const cameras: CameraState[] = [
+      { x: 0, y: 0, zoom: 0.2, minZoom: 0.2, maxZoom: 4 },
+      { x: 0, y: 0, zoom: 1, minZoom: 0.2, maxZoom: 4 },
+      { x: 0, y: 0, zoom: 3.5, minZoom: 0.2, maxZoom: 4 }
+    ];
+
+    for (const camera of cameras) {
+      const centerX = 100 * camera.zoom;
+      expect(hitTestEdges(links, nodePositions, camera, { x: centerX, y: 7.9 })).toBe("edge-1");
+      expect(hitTestEdges(links, nodePositions, camera, { x: centerX, y: 8.1 })).toBeNull();
+    }
+  });
   it("creates an edge through start -> end clicks", () => {
     const cursor: Vec2 = { x: 0, y: 0 };
     const start = nextEdgeDraft(null, "n1", cursor);

--- a/packages/mesh-explorer-ui/test/graphCanvas2d.test.ts
+++ b/packages/mesh-explorer-ui/test/graphCanvas2d.test.ts
@@ -65,18 +65,20 @@ describe("edge hit-test helpers", () => {
     expect(computeEdgeHitSlopWorld(camera)).toBe(4);
   });
 
-  it("keeps edge hit-testing disabled by default", () => {
-    const camera: CameraState = { x: 0, y: 0, zoom: 1, minZoom: 0.2, maxZoom: 4 };
-    const edgeId = hitTestEdges(
-      [{ id: "e1", source: "a", target: "b" }],
-      new Map([
-        ["a", { x: 0, y: 0 }],
-        ["b", { x: 10, y: 0 }]
-      ]),
-      camera,
-      { x: 5, y: 0 }
-    );
-    expect(edgeId).toBeNull();
+  it("hits edges using constant screen-pixel slop", () => {
+    const edge = [{ id: "e1", source: "a", target: "b" }];
+    const positions = new Map([
+      ["a", { x: 0, y: 0 }],
+      ["b", { x: 100, y: 0 }]
+    ]);
+
+    const lowZoom: CameraState = { x: 0, y: 0, zoom: 0.25, minZoom: 0.2, maxZoom: 4 };
+    expect(hitTestEdges(edge, positions, lowZoom, { x: 50 * lowZoom.zoom, y: 7.5 })).toBe("e1");
+    expect(hitTestEdges(edge, positions, lowZoom, { x: 50 * lowZoom.zoom, y: 8.5 })).toBeNull();
+
+    const highZoom: CameraState = { x: 0, y: 0, zoom: 3.5, minZoom: 0.2, maxZoom: 4 };
+    expect(hitTestEdges(edge, positions, highZoom, { x: 50 * highZoom.zoom, y: 7.5 })).toBe("e1");
+    expect(hitTestEdges(edge, positions, highZoom, { x: 50 * highZoom.zoom, y: 8.5 })).toBeNull();
   });
 });
 


### PR DESCRIPTION
### Motivation
- Make edge click/hover behavior reliable across zoom levels by using a constant screen-pixel slop and expose live camera zoom in the UI badge.
- Provide a minimal edge selection/hover interaction so edges can be clicked without interfering with node hit semantics.

### Description
- Turned on edge hit-testing by setting `ENABLE_EDGE_HIT_TEST = true` and kept screen-pixel slop via `computeEdgeHitSlopWorld(camera) = EDGE_HIT_SLOP_PX / camera.zoom`.
- Added edge interaction state to the canvas renderer (`hoveredEdgeId`, `selectedEdgeId`) and hit-testing logic that preserves node hit priority and computes edge hits using `hitTestEdges` with `nodePositions()`.
- Implemented click behavior: clicking an edge selects it (UI-local), clicking background clears selected edge only when no nodes are selected, and edge hover/selected styling is drawn in the renderer.
- Wired `onCameraChange` to a RAF-throttled UI badge update pipeline (`cameraInfo`, `queueBadgeRender`) and formatted the badge zoom as `x1.23`; fit-to-graph updates also trigger the same badge refresh.
- Added/updated tests to validate edge hit behavior at multiple zoom levels and added an integration test `click near edge at various zoom levels hits edge`.

### Testing
- Ran unit/integration tests with `pnpm vitest run packages/mesh-explorer-ui/test/graphCanvas2d.test.ts packages/mesh-explorer-ui/test/canvasFlow.integration.test.ts` and all tests passed (`16 passed`).
- Built the UI package with `pnpm --filter @mesh/mesh-explorer-ui build` and the TypeScript build succeeded.
- Performed a quick browser render capture of the running app to verify the live badge update (screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699635ac93a883219101a4fab90af340)