### PR TITLE
feat(ui): clear edge selection on node click and add SHIFT multi-edge toggle

### DIFF
--- a/packages/mesh-explorer-ui/src/graphCanvas2d.ts
+++ b/packages/mesh-explorer-ui/src/graphCanvas2d.ts
@@ -151,6 +151,21 @@ export function nextEdgeDraft(current: EdgeDraft | null, clickedNodeId: string |
   return { edgeDraft: null, commit: { source: current.startNodeId, target: clickedNodeId } };
 }
 
+export function nextSelectedEdgeIds(
+  current: ReadonlySet<string>,
+  params: { nodeHit: string | null; edgeHit: string | null; shiftKey: boolean }
+): Set<string> {
+  if (params.nodeHit) return new Set();
+  if (params.edgeHit) {
+    if (!params.shiftKey) return new Set([params.edgeHit]);
+    const next = new Set(current);
+    if (next.has(params.edgeHit)) next.delete(params.edgeHit);
+    else next.add(params.edgeHit);
+    return next;
+  }
+  return new Set();
+}
+
 export class GraphCanvas2D {
   private readonly ctx: CanvasRenderingContext2D;
   private raf = 0;
@@ -159,7 +174,7 @@ export class GraphCanvas2D {
   private panning = false;
   private dragging: { pointerStart: Vec2; original: Map<string, Vec2> } | null = null;
   private hoveredEdgeId: string | null = null;
-  private selectedEdgeId: string | null = null;
+  private selectedEdgeIds = new Set<string>();
 
   constructor(
     private readonly canvas: HTMLCanvasElement,
@@ -210,6 +225,7 @@ export class GraphCanvas2D {
         return;
       }
       if (hit) {
+        this.selectedEdgeIds.clear();
         if (event.shiftKey) {
           this.callbacks.onSelectionToggle(hit);
         } else if (!this.readModel.selectedNodeIds.has(hit)) {
@@ -284,19 +300,16 @@ export class GraphCanvas2D {
       const pointerWorld = screenToWorld({ x: event.offsetX, y: event.offsetY }, this.ui.camera);
       if (!wasDragging) {
         const hit = hitTestNode(this.readModel.nodes, this.ui.camera, { x: event.offsetX, y: event.offsetY });
+        const edgeHit = hit
+          ? null
+          : hitTestEdges(this.readModel.links, this.nodePositions(), this.ui.camera, { x: event.offsetX, y: event.offsetY });
+        this.selectedEdgeIds = nextSelectedEdgeIds(this.selectedEdgeIds, { nodeHit: hit, edgeHit, shiftKey: event.shiftKey });
         if (hit) {
-          this.selectedEdgeId = null;
           const next = nextEdgeDraft(this.ui.edgeDraft, hit, pointerWorld);
           this.callbacks.onEdgeDraftChange(next.edgeDraft);
           if (next.commit) this.callbacks.onCreateEdge(next.commit.source, next.commit.target);
-        } else {
-          const edgeHit = hitTestEdges(this.readModel.links, this.nodePositions(), this.ui.camera, { x: event.offsetX, y: event.offsetY });
-          if (edgeHit) {
-            this.selectedEdgeId = edgeHit;
-            this.callbacks.onEdgeDraftChange(null);
-          } else if (this.readModel.selectedNodeIds.size === 0) {
-            this.selectedEdgeId = null;
-          }
+        } else if (edgeHit) {
+          this.callbacks.onEdgeDraftChange(null);
         }
       }
       this.render();
@@ -369,7 +382,7 @@ export class GraphCanvas2D {
       const source = this.nodePos(link.source);
       const target = this.nodePos(link.target);
       if (!source || !target) continue;
-      const selected = this.selectedEdgeId === link.id;
+      const selected = this.selectedEdgeIds.has(link.id);
       const hovered = !selected && this.hoveredEdgeId === link.id;
       this.ctx.strokeStyle = selected ? "#2563eb" : hovered ? "#0ea5e9" : "#94a3b8";
       this.ctx.lineWidth = 2 / this.ui.camera.zoom;

--- a/packages/mesh-explorer-ui/test/canvasFlow.integration.test.ts
+++ b/packages/mesh-explorer-ui/test/canvasFlow.integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { hitTestEdges, nextEdgeDraft, type CameraState, type Vec2 } from "../src/graphCanvas2d.js";
+import { hitTestEdges, nextEdgeDraft, nextSelectedEdgeIds, type CameraState, type Vec2 } from "../src/graphCanvas2d.js";
 
 describe("canvas flow integration", () => {
   it("click near edge at various zoom levels hits edge", () => {
@@ -22,6 +22,7 @@ describe("canvas flow integration", () => {
       expect(hitTestEdges(links, nodePositions, camera, { x: centerX, y: 8.1 })).toBeNull();
     }
   });
+
   it("creates an edge through start -> end clicks", () => {
     const cursor: Vec2 = { x: 0, y: 0 };
     const start = nextEdgeDraft(null, "n1", cursor);
@@ -34,5 +35,24 @@ describe("canvas flow integration", () => {
     const start = nextEdgeDraft(null, "n1", { x: 0, y: 0 });
     const cancel = nextEdgeDraft(start.edgeDraft ?? null, null, { x: 100, y: 100 });
     expect(cancel.edgeDraft).toBeNull();
+  });
+
+  it("clears selected edge when node is clicked", () => {
+    const selected = nextSelectedEdgeIds(new Set(), { nodeHit: null, edgeHit: "edge-1", shiftKey: false });
+    expect(selected).toEqual(new Set(["edge-1"]));
+
+    const afterNodeClick = nextSelectedEdgeIds(selected, { nodeHit: "n1", edgeHit: null, shiftKey: false });
+    expect(afterNodeClick).toEqual(new Set());
+  });
+
+  it("supports SHIFT multi-edge toggles and clears on background", () => {
+    const selectedA = nextSelectedEdgeIds(new Set(), { nodeHit: null, edgeHit: "edge-a", shiftKey: false });
+    const selectedAB = nextSelectedEdgeIds(selectedA, { nodeHit: null, edgeHit: "edge-b", shiftKey: true });
+    const selectedB = nextSelectedEdgeIds(selectedAB, { nodeHit: null, edgeHit: "edge-a", shiftKey: true });
+    const cleared = nextSelectedEdgeIds(selectedB, { nodeHit: null, edgeHit: null, shiftKey: false });
+
+    expect(selectedAB).toEqual(new Set(["edge-a", "edge-b"]));
+    expect(selectedB).toEqual(new Set(["edge-b"]));
+    expect(cleared).toEqual(new Set());
   });
 });

--- a/packages/mesh-explorer-ui/test/graphCanvas2d.test.ts
+++ b/packages/mesh-explorer-ui/test/graphCanvas2d.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { computeEdgeHitSlopWorld, computeGraphBounds, distancePointToSegment, fitCameraToBounds, hitTestEdge, hitTestEdges, hitTestNode, nextEdgeDraft, screenToWorld, worldToScreen, zoomAtPoint, type CameraState } from "../src/graphCanvas2d.js";
+import { computeEdgeHitSlopWorld, computeGraphBounds, distancePointToSegment, fitCameraToBounds, hitTestEdge, hitTestEdges, hitTestNode, nextEdgeDraft, nextSelectedEdgeIds, screenToWorld, worldToScreen, zoomAtPoint, type CameraState } from "../src/graphCanvas2d.js";
 
 describe("graphCanvas2d transforms", () => {
   it("keeps world point stable under cursor while zooming", () => {
@@ -95,6 +95,24 @@ describe("edge draft state machine", () => {
     const start = nextEdgeDraft(null, "n1", { x: 0, y: 0 }).edgeDraft;
     expect(nextEdgeDraft(start ?? null, "n1", { x: 0, y: 0 }).edgeDraft).toBeNull();
     expect(nextEdgeDraft(start ?? null, null, { x: 0, y: 0 }).edgeDraft).toBeNull();
+  });
+});
+
+describe("edge selection state machine", () => {
+  it("clears selected edges when a node is clicked", () => {
+    const selected = new Set(["edge-1"]);
+    expect(nextSelectedEdgeIds(selected, { nodeHit: "n1", edgeHit: null, shiftKey: false })).toEqual(new Set());
+  });
+
+  it("supports shift toggle for multi-edge selection", () => {
+    const selectedA = nextSelectedEdgeIds(new Set(), { nodeHit: null, edgeHit: "edge-a", shiftKey: false });
+    expect(selectedA).toEqual(new Set(["edge-a"]));
+
+    const selectedAB = nextSelectedEdgeIds(selectedA, { nodeHit: null, edgeHit: "edge-b", shiftKey: true });
+    expect(selectedAB).toEqual(new Set(["edge-a", "edge-b"]));
+
+    const selectedB = nextSelectedEdgeIds(selectedAB, { nodeHit: null, edgeHit: "edge-a", shiftKey: true });
+    expect(selectedB).toEqual(new Set(["edge-b"]));
   });
 });
 


### PR DESCRIPTION
### Motivation
- Ensure node interactions always clear any focused edge selection and add parity with node multi-selection using `Shift` for edges.
- Keep node hit priority unchanged while making edge selection UI-local and able to express multi-selection via Shift.

### Description
- Replace single `selectedEdgeId: string | null` with `selectedEdgeIds: Set<string>` and update rendering to treat an edge as selected when `edgeId ∈ selectedEdgeIds` in `packages/mesh-explorer-ui/src/graphCanvas2d.ts`.
- Add a pure reducer `nextSelectedEdgeIds(current, { nodeHit, edgeHit, shiftKey })` that implements: click edge without `Shift` selects only that edge, `Shift+click` toggles an edge, and clicking a node or background clears the set.
- Clear edge selection on node pointer-down (covers drag-start) and apply the reducer on pointer-up to keep node > edge priority and preserve node multi-selection behavior.
- Update and add unit/integration tests to validate the reducer and flows in `packages/mesh-explorer-ui/test/graphCanvas2d.test.ts` and `packages/mesh-explorer-ui/test/canvasFlow.integration.test.ts`.

### Testing
- Ran `pnpm vitest run packages/mesh-explorer-ui/test/graphCanvas2d.test.ts packages/mesh-explorer-ui/test/canvasFlow.integration.test.ts`; both files passed (2 test files, 20 tests total) with all tests succeeding.
- The added tests exercise: clearing edges on node click, `Shift`-toggle multi-edge selection, background clear, and existing edge hit / edge-draft flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997040dbdc08321a23273f6fd9d8003)