### PR TITLE
feat(ui): dev Layout Panel, warmup modes, and unify connectivity headline

### DIFF
--- a/packages/mesh-explorer-ui/src/graphCanvas2d.ts
+++ b/packages/mesh-explorer-ui/src/graphCanvas2d.ts
@@ -1,4 +1,5 @@
 import type { GraphLink, GraphNode } from "./graphStore.js";
+import type { WarmupMode } from "./ui/layoutSettings.js";
 
 export type Vec2 = { x: number; y: number };
 export type CameraState = { x: number; y: number; zoom: number; minZoom: number; maxZoom: number };
@@ -47,7 +48,40 @@ const SEED_JITTER_RATIO = 0.35;
 const MIN_ZOOM_DENSITY_THRESHOLD = 50;
 const MIN_ZOOM_DENSITY_FLOOR = 0.05;
 const WARMUP_TICKS = 64;
+const SOFT_WARMUP_TICKS_PER_FRAME = 6;
 export const ENABLE_EDGE_HIT_TEST = true;
+
+export type LayoutParams = {
+  chargeStrength: number;
+  linkDistance: number;
+  linkStrength: number;
+  collisionRadius: number;
+  centering: number;
+  alphaTarget: number;
+  alphaDecay: number;
+  velocityDecay: number;
+  minAlpha: number;
+};
+
+export const DEFAULT_LAYOUT_PARAMS: LayoutParams = {
+  chargeStrength: LAYOUT_CHARGE_STRENGTH,
+  linkDistance: LAYOUT_LINK_DISTANCE,
+  linkStrength: LAYOUT_LINK_STRENGTH,
+  collisionRadius: LAYOUT_COLLISION_RADIUS,
+  centering: LAYOUT_CENTERING,
+  alphaTarget: 0,
+  alphaDecay: LAYOUT_ALPHA_DECAY,
+  velocityDecay: 1 - LAYOUT_DAMPING,
+  minAlpha: LAYOUT_MIN_ALPHA
+};
+
+type ForceLayoutOptions = {
+  layoutParams?: Partial<LayoutParams>;
+  warmupMode?: WarmupMode;
+  requestFrame?: (callback: FrameRequestCallback) => number;
+  cancelFrame?: (frameId: number) => void;
+  onSoftWarmupFrame?: () => void;
+};
 
 export function worldToScreen(world: Vec2, camera: CameraState): Vec2 {
   return { x: (world.x - camera.x) * camera.zoom, y: (world.y - camera.y) * camera.zoom };
@@ -210,8 +244,31 @@ export class ForceLayout2D {
   private readonly nodeById = new Map<string, LayoutNode>();
   private links: LayoutLink[] = [];
   private alpha = 0;
+  private params: LayoutParams;
+  private warmupMode: WarmupMode;
+  private softWarmupFrame = 0;
+  private readonly requestFrame: (callback: FrameRequestCallback) => number;
+  private readonly cancelFrame: (frameId: number) => void;
+  private readonly onSoftWarmupFrame?: () => void;
+
+  constructor(options: ForceLayoutOptions = {}) {
+    this.params = { ...DEFAULT_LAYOUT_PARAMS, ...options.layoutParams };
+    this.warmupMode = options.warmupMode ?? "HARD";
+    this.requestFrame = options.requestFrame ?? ((callback) => requestAnimationFrame(callback));
+    this.cancelFrame = options.cancelFrame ?? ((frameId) => cancelAnimationFrame(frameId));
+    this.onSoftWarmupFrame = options.onSoftWarmupFrame;
+  }
+
+  setLayoutParams(next: Partial<LayoutParams>): void {
+    this.params = { ...this.params, ...next };
+  }
+
+  setWarmupMode(mode: WarmupMode): void {
+    this.warmupMode = mode;
+  }
 
   syncGraph(nodes: Array<{ id: string }>, links: LayoutLink[]): void {
+    this.cancelSoftWarmup();
     const nextIds = new Set(nodes.map((node) => node.id));
     for (const id of this.nodeById.keys()) {
       if (!nextIds.has(id)) this.nodeById.delete(id);
@@ -226,7 +283,12 @@ export class ForceLayout2D {
 
     this.links = links.filter((link) => this.nodeById.has(link.source) && this.nodeById.has(link.target));
     this.reheat(0.45);
-    this.tick(WARMUP_TICKS);
+    if (this.warmupMode === "HARD") {
+      this.tick(WARMUP_TICKS);
+    }
+    if (this.warmupMode === "SOFT") {
+      this.scheduleSoftWarmup(WARMUP_TICKS);
+    }
   }
 
   reheat(amount = 0.25): void {
@@ -254,14 +316,19 @@ export class ForceLayout2D {
 
   tick(iterations = 1): void {
     for (let i = 0; i < iterations; i += 1) {
-      if (this.alpha <= LAYOUT_MIN_ALPHA) continue;
+      if (this.alpha <= this.params.minAlpha) continue;
       this.tickOnce();
-      this.alpha *= 1 - LAYOUT_ALPHA_DECAY;
+      this.alpha += (this.params.alphaTarget - this.alpha) * 0.08;
+      this.alpha *= 1 - this.params.alphaDecay;
     }
   }
 
   hasEnergy(): boolean {
-    return this.alpha > LAYOUT_MIN_ALPHA;
+    return this.alpha > this.params.minAlpha;
+  }
+
+  destroy(): void {
+    this.cancelSoftWarmup();
   }
 
   getPositions(): Map<string, Vec2> {
@@ -293,8 +360,8 @@ export class ForceLayout2D {
         const dy = a.y - b.y;
         const distSq = dx * dx + dy * dy + 0.01;
         const dist = Math.sqrt(distSq);
-        const collisionOverlap = LAYOUT_COLLISION_RADIUS * 2 - dist;
-        const force = (LAYOUT_CHARGE_STRENGTH * alpha) / distSq;
+        const collisionOverlap = this.params.collisionRadius * 2 - dist;
+        const force = (this.params.chargeStrength * alpha) / distSq;
         const collisionForce = collisionOverlap > 0 ? (collisionOverlap * 0.35 + 0.001) * alpha : 0;
         const fx = dx * force + (dx / dist) * collisionForce;
         const fy = dy * force + (dy / dist) * collisionForce;
@@ -316,7 +383,7 @@ export class ForceLayout2D {
       const dx = target.x - source.x;
       const dy = target.y - source.y;
       const dist = Math.hypot(dx, dy) || 0.001;
-      const delta = (dist - LAYOUT_LINK_DISTANCE) * LAYOUT_LINK_STRENGTH * alpha;
+      const delta = (dist - this.params.linkDistance) * this.params.linkStrength * alpha;
       const fx = (dx / dist) * delta;
       const fy = (dy / dist) * delta;
       if (source.fx === undefined) {
@@ -331,19 +398,40 @@ export class ForceLayout2D {
 
     for (const node of nodes) {
       if (node.fx !== undefined && node.fy !== undefined) continue;
-      node.vx += (0 - node.x) * LAYOUT_CENTERING * alpha;
-      node.vy += (0 - node.y) * LAYOUT_CENTERING * alpha;
-      node.vx *= LAYOUT_DAMPING;
-      node.vy *= LAYOUT_DAMPING;
+      node.vx += (0 - node.x) * this.params.centering * alpha;
+      node.vy += (0 - node.y) * this.params.centering * alpha;
+      node.vx *= 1 - this.params.velocityDecay;
+      node.vy *= 1 - this.params.velocityDecay;
       node.x += node.vx;
       node.y += node.vy;
     }
   }
+
+  private scheduleSoftWarmup(remainingTicks: number): void {
+    if (remainingTicks <= 0) return;
+    this.softWarmupFrame = this.requestFrame(() => {
+      this.softWarmupFrame = 0;
+      this.tick(Math.min(SOFT_WARMUP_TICKS_PER_FRAME, remainingTicks));
+      this.onSoftWarmupFrame?.();
+      this.scheduleSoftWarmup(remainingTicks - SOFT_WARMUP_TICKS_PER_FRAME);
+    });
+  }
+
+  private cancelSoftWarmup(): void {
+    if (!this.softWarmupFrame) return;
+    this.cancelFrame(this.softWarmupFrame);
+    this.softWarmupFrame = 0;
+  }
 }
+
+export type GraphCanvasOptions = {
+  layoutParams?: Partial<LayoutParams>;
+  warmupMode?: WarmupMode;
+};
 
 export class GraphCanvas2D {
   private readonly ctx: CanvasRenderingContext2D;
-  private readonly layout = new ForceLayout2D();
+  private readonly layout: ForceLayout2D;
   private raf = 0;
   private running = false;
   private pointer = { x: 0, y: 0 };
@@ -356,11 +444,17 @@ export class GraphCanvas2D {
     private readonly canvas: HTMLCanvasElement,
     private readModel: GraphCanvasReadModel,
     private ui: CanvasUiState,
-    private readonly callbacks: GraphCanvasCallbacks
+    private readonly callbacks: GraphCanvasCallbacks,
+    options: GraphCanvasOptions = {}
   ) {
     const ctx = canvas.getContext("2d");
     if (!ctx) throw new Error("2D canvas context unavailable");
     this.ctx = ctx;
+    this.layout = new ForceLayout2D({
+      layoutParams: options.layoutParams,
+      warmupMode: options.warmupMode,
+      onSoftWarmupFrame: () => this.startLoop()
+    });
     this.syncLayoutGraph();
     this.layout.tick(40);
     this.bindEvents();
@@ -378,10 +472,26 @@ export class GraphCanvas2D {
 
   destroy(): void {
     cancelAnimationFrame(this.raf);
+    this.layout.destroy();
   }
 
   getNodePositions(): Map<string, Vec2> {
     return this.layout.getPositions();
+  }
+
+  setLayoutParams(params: Partial<LayoutParams>): void {
+    this.layout.setLayoutParams(params);
+    this.layout.reheat(0.3);
+    this.startLoop();
+  }
+
+  setWarmupMode(mode: WarmupMode): void {
+    this.layout.setWarmupMode(mode);
+  }
+
+  reheatLayout(): void {
+    this.layout.reheat(0.42);
+    this.startLoop();
   }
 
   resize(): void {

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -23,6 +23,8 @@ import {
   type CameraState,
   type CanvasUiState
 } from "./graphCanvas2d.js";
+import { LayoutPanel } from "./ui/LayoutPanel.js";
+import { deriveLayoutParams, loadLayoutUiState, saveLayoutUiState, type LayoutUiState } from "./ui/layoutSettings.js";
 
 type Cursor = { metaSeq: number; graphSeq: number };
 type GraphData = { nodes: GraphNode[]; links: GraphLink[] };
@@ -50,13 +52,14 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
         <label>principal <input id="principal" style="width:100%" value="${escapeHtml(initialPrincipal)}"/></label><br/>
         <button id="connect">Connect</button>
         <hr/>
-        <div id="status">disconnected</div>
-        <div id="connectivity">connectivity: unknown</div>
+        <div id="status">Connectivity: Degraded</div>
+        <div id="transport">transport: disconnected</div>
         <div id="lastCursor">cursor: n/a</div>
         <div id="lastSync">last sync: n/a</div>
         <hr/>
         <button id="addNode">Add node</button>
         <button id="fitGraph" style="margin-left:8px;">Fit</button>
+        <div id="layoutPanelHost"></div>
         <div style="margin-top:8px;padding:8px;border:1px solid #ddd;border-radius:8px;">
           <div><strong>Create link</strong></div>
           <label>type <input id="linkType" style="width:100%" value="related"/></label>
@@ -96,11 +99,14 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   };
 
   let canvasRenderer: GraphCanvas2D | null = null;
+  let layoutUiState: LayoutUiState = loadLayoutUiState();
+
 
   setConnectionStatus("disconnected");
   installConnectivityListeners();
   updateConnectivity("init");
   setupRenderer();
+  mountLayoutPanel();
   persistPrincipal(el.principal.value);
   el.principal.onchange = () => {
     const normalized = normalizePrincipal(el.principal.value);
@@ -315,12 +321,37 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
         onFitRequest: () => {
           fitCameraToCurrentGraph();
         }
+      }, {
+        layoutParams: deriveLayoutParams(layoutUiState.settings),
+        warmupMode: layoutUiState.settings.warmupMode
       });
       setRendererMode("canvas-2d");
     } catch (error) {
       setRendererMode("fallback-json");
       reportDevError(el, `renderer init failed: ${String(error)}`, error);
     }
+  }
+
+  function mountLayoutPanel(): void {
+    const enabled = isLayoutPanelEnabled();
+    new LayoutPanel(el.layoutPanelHost, {
+      enabled,
+      settings: layoutUiState.settings,
+      panel: layoutUiState.panel
+    }, {
+      onSettingsChange: (next) => {
+        layoutUiState = { ...layoutUiState, settings: next };
+        saveLayoutUiState(layoutUiState);
+        canvasRenderer?.setLayoutParams(deriveLayoutParams(next));
+        canvasRenderer?.setWarmupMode(next.warmupMode);
+      },
+      onPanelStateChange: (panel) => {
+        layoutUiState = { ...layoutUiState, panel };
+        saveLayoutUiState(layoutUiState);
+      },
+      onReheat: () => canvasRenderer?.reheatLayout(),
+      onFit: () => fitCameraToCurrentGraph()
+    });
   }
 
   function fitCameraToCurrentGraph(): void {
@@ -353,14 +384,14 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   }
 
   function renderStatus(snapshot: GraphState, nodes: number, links: number): void {
-    el.status.textContent = snapshot.connectionStatus;
-    el.connectivity.textContent = `connectivity: ${connectivityState}`;
+    el.status.textContent = `Connectivity: ${formatConnectivity(connectivityState)}`;
+    el.transport.textContent = `transport: ${snapshot.connectionStatus}`;
     el.lastCursor.textContent = `cursor: ${JSON.stringify(snapshot.cursor)}`;
     el.lastSync.textContent = `last sync: ${snapshot.lastSync}`;
     badgeStats = { nodes, links };
     queueBadgeRender();
     if (!el.principal.value.trim()) {
-      el.status.textContent = `principal required: sending default "${DEFAULT_PRINCIPAL}" via x-mesh-principal`;
+      el.transport.textContent = `transport: principal required, default "${DEFAULT_PRINCIPAL}" via x-mesh-principal`;
     }
   }
 
@@ -452,12 +483,13 @@ type UiElements = {
   linkType: HTMLInputElement;
   linkSelectionHint: HTMLDivElement;
   status: HTMLDivElement;
-  connectivity: HTMLDivElement;
+  transport: HTMLDivElement;
   lastCursor: HTMLDivElement;
   lastSync: HTMLDivElement;
   graphCanvas: HTMLCanvasElement;
   rendererBadge: HTMLDivElement;
   devBanner: HTMLDivElement;
+  layoutPanelHost: HTMLDivElement;
 };
 
 function byId(container: HTMLElement): UiElements {
@@ -471,12 +503,13 @@ function byId(container: HTMLElement): UiElements {
     linkType: container.querySelector("#linkType") as HTMLInputElement,
     linkSelectionHint: container.querySelector("#linkSelectionHint") as HTMLDivElement,
     status: container.querySelector("#status") as HTMLDivElement,
-    connectivity: container.querySelector("#connectivity") as HTMLDivElement,
+    transport: container.querySelector("#transport") as HTMLDivElement,
     lastCursor: container.querySelector("#lastCursor") as HTMLDivElement,
     lastSync: container.querySelector("#lastSync") as HTMLDivElement,
     graphCanvas: container.querySelector("#graphCanvas") as HTMLCanvasElement,
     rendererBadge: container.querySelector("#rendererBadge") as HTMLDivElement,
-    devBanner: container.querySelector("#devBanner") as HTMLDivElement
+    devBanner: container.querySelector("#devBanner") as HTMLDivElement,
+    layoutPanelHost: container.querySelector("#layoutPanelHost") as HTMLDivElement
   };
 }
 
@@ -541,6 +574,22 @@ function isDebugEnabled(): boolean {
     return localStorage.getItem("mesh.debug") === "1";
   } catch {
     return false;
+  }
+}
+
+function formatConnectivity(state: ConnectivityStatus): string {
+  if (state === "online") return "Online";
+  if (state === "offline") return "Offline";
+  return "Degraded";
+}
+
+function isLayoutPanelEnabled(): boolean {
+  const mode = (import.meta as ImportMeta & { env?: { DEV?: boolean } }).env?.DEV;
+  if (mode) return true;
+  try {
+    return localStorage.getItem("mesh.layoutPanel") !== "0";
+  } catch {
+    return true;
   }
 }
 

--- a/packages/mesh-explorer-ui/src/ui/LayoutPanel.ts
+++ b/packages/mesh-explorer-ui/src/ui/LayoutPanel.ts
@@ -1,0 +1,171 @@
+import { applyPreset, serializeLayoutSettings, type DevPanelState, type LayoutPreset, type LayoutSettings, type WarmupMode } from "./layoutSettings.js";
+
+type LayoutPanelCallbacks = {
+  onSettingsChange: (next: LayoutSettings) => void;
+  onPanelStateChange: (next: DevPanelState) => void;
+  onReheat: () => void;
+  onFit: () => void;
+};
+
+type LayoutPanelOptions = {
+  enabled: boolean;
+  settings: LayoutSettings;
+  panel: DevPanelState;
+};
+
+export class LayoutPanel {
+  private readonly root: HTMLDivElement;
+  private readonly panelBody: HTMLDivElement;
+  private settings: LayoutSettings;
+  private panelState: DevPanelState;
+
+  constructor(host: HTMLElement, options: LayoutPanelOptions, private readonly callbacks: LayoutPanelCallbacks) {
+    this.settings = options.settings;
+    this.panelState = options.panel;
+    this.root = document.createElement("div");
+    this.panelBody = document.createElement("div");
+    if (!options.enabled) {
+      this.root.style.display = "none";
+      host.appendChild(this.root);
+      return;
+    }
+
+    this.root.style.marginTop = "10px";
+    this.root.style.border = "1px solid #ddd";
+    this.root.style.borderRadius = "8px";
+    this.root.style.padding = "8px";
+
+    const toggleBtn = document.createElement("button");
+    toggleBtn.textContent = "Layout";
+    toggleBtn.onclick = () => {
+      this.panelState = { open: !this.panelState.open };
+      this.updateOpenState();
+      this.callbacks.onPanelStateChange(this.panelState);
+    };
+    this.root.appendChild(toggleBtn);
+
+    this.panelBody.style.marginTop = "8px";
+    this.root.appendChild(this.panelBody);
+    this.renderControls();
+    this.updateOpenState();
+    host.appendChild(this.root);
+  }
+
+  private renderControls(): void {
+    this.panelBody.innerHTML = "";
+    this.panelBody.appendChild(this.buildSelect("Preset", ["Compact", "Balanced", "Spread", "Snappy"], this.settings.preset, (value) => {
+      this.settings = applyPreset(value as LayoutPreset, this.settings);
+      this.callbacks.onSettingsChange(this.settings);
+      this.renderControls();
+    }));
+
+    this.panelBody.appendChild(this.buildSlider("Repulsion", this.settings.repulsion, 20, 140, 1, (value) => this.updateSettings({ repulsion: value })));
+    this.panelBody.appendChild(this.buildSlider("Edge length", this.settings.edgeLength, 20, 160, 1, (value) => this.updateSettings({ edgeLength: value })));
+    this.panelBody.appendChild(this.buildSlider("Reactivity", this.settings.reactivity, 0, 1, 0.01, (value) => this.updateSettings({ reactivity: value })));
+    this.panelBody.appendChild(this.buildSlider("Collision", this.settings.collision, 8, 56, 1, (value) => this.updateSettings({ collision: value })));
+    this.panelBody.appendChild(this.buildSelect("Warmup", ["OFF", "SOFT", "HARD"], this.settings.warmupMode, (value) => this.updateSettings({ warmupMode: value as WarmupMode })));
+
+    const actions = document.createElement("div");
+    actions.style.display = "flex";
+    actions.style.gap = "6px";
+    actions.style.marginTop = "8px";
+
+    const reheat = document.createElement("button");
+    reheat.textContent = "Reheat";
+    reheat.onclick = () => this.callbacks.onReheat();
+    actions.appendChild(reheat);
+
+    const fit = document.createElement("button");
+    fit.textContent = "Fit";
+    fit.onclick = () => this.callbacks.onFit();
+    actions.appendChild(fit);
+
+    const exportJson = document.createElement("button");
+    exportJson.textContent = "Export JSON";
+    exportJson.onclick = () => this.exportJson();
+    actions.appendChild(exportJson);
+
+    this.panelBody.appendChild(actions);
+  }
+
+  private updateSettings(patch: Partial<LayoutSettings>): void {
+    this.settings = { ...this.settings, ...patch };
+    this.callbacks.onSettingsChange(this.settings);
+  }
+
+  private updateOpenState(): void {
+    this.panelBody.style.display = this.panelState.open ? "block" : "none";
+  }
+
+  private buildSlider(
+    label: string,
+    value: number,
+    min: number,
+    max: number,
+    step: number,
+    onChange: (next: number) => void
+  ): HTMLElement {
+    const row = document.createElement("label");
+    row.style.display = "block";
+    row.style.fontSize = "12px";
+    row.style.marginTop = "6px";
+
+    const valueLabel = document.createElement("span");
+    valueLabel.style.float = "right";
+    valueLabel.textContent = value.toFixed(step < 1 ? 2 : 0);
+
+    const title = document.createElement("span");
+    title.textContent = label;
+    row.appendChild(title);
+    row.appendChild(valueLabel);
+
+    const input = document.createElement("input");
+    input.type = "range";
+    input.min = String(min);
+    input.max = String(max);
+    input.step = String(step);
+    input.value = String(value);
+    input.style.width = "100%";
+    input.oninput = () => {
+      const next = Number(input.value);
+      valueLabel.textContent = next.toFixed(step < 1 ? 2 : 0);
+      onChange(next);
+    };
+    row.appendChild(input);
+    return row;
+  }
+
+  private buildSelect(label: string, options: string[], current: string, onChange: (next: string) => void): HTMLElement {
+    const row = document.createElement("label");
+    row.style.display = "block";
+    row.style.marginTop = "6px";
+    row.style.fontSize = "12px";
+    row.textContent = label;
+
+    const select = document.createElement("select");
+    select.style.width = "100%";
+    for (const option of options) {
+      const node = document.createElement("option");
+      node.value = option;
+      node.textContent = option;
+      if (option === current) node.selected = true;
+      select.appendChild(node);
+    }
+    select.onchange = () => onChange(select.value);
+    row.appendChild(select);
+    return row;
+  }
+
+  private exportJson(): void {
+    const payload = serializeLayoutSettings(this.settings);
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "mesh-layout-settings.json";
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+  }
+}

--- a/packages/mesh-explorer-ui/src/ui/layoutSettings.ts
+++ b/packages/mesh-explorer-ui/src/ui/layoutSettings.ts
@@ -1,0 +1,115 @@
+import type { LayoutParams } from "../graphCanvas2d.js";
+
+export type LayoutPreset = "Compact" | "Balanced" | "Spread" | "Snappy";
+export type WarmupMode = "OFF" | "SOFT" | "HARD";
+
+export type LayoutSettings = {
+  preset: LayoutPreset;
+  repulsion: number;
+  edgeLength: number;
+  reactivity: number;
+  collision: number;
+  warmupMode: WarmupMode;
+};
+
+export type DevPanelState = { open: boolean };
+
+export type LayoutUiState = {
+  settings: LayoutSettings;
+  panel: DevPanelState;
+};
+
+const STORAGE_KEY = "mesh-explorer:layout-ui-state";
+
+const PRESETS: Record<LayoutPreset, Omit<LayoutSettings, "preset">> = {
+  Compact: { repulsion: 48, edgeLength: 48, reactivity: 0.8, collision: 20, warmupMode: "SOFT" },
+  Balanced: { repulsion: 58, edgeLength: 64, reactivity: 0.55, collision: 23, warmupMode: "HARD" },
+  Spread: { repulsion: 82, edgeLength: 92, reactivity: 0.38, collision: 26, warmupMode: "SOFT" },
+  Snappy: { repulsion: 52, edgeLength: 58, reactivity: 0.92, collision: 22, warmupMode: "OFF" }
+};
+
+export function defaultLayoutSettings(): LayoutSettings {
+  return { preset: "Balanced", ...PRESETS.Balanced };
+}
+
+export function defaultLayoutUiState(): LayoutUiState {
+  return { settings: defaultLayoutSettings(), panel: { open: false } };
+}
+
+export function applyPreset(preset: LayoutPreset, base: LayoutSettings): LayoutSettings {
+  const values = PRESETS[preset];
+  return { ...base, preset, ...values };
+}
+
+export function deriveLayoutParams(settings: LayoutSettings): LayoutParams {
+  const reactivity = clamp(settings.reactivity, 0, 1);
+  return {
+    chargeStrength: settings.repulsion,
+    linkDistance: settings.edgeLength,
+    linkStrength: 0.18,
+    collisionRadius: settings.collision,
+    centering: 0.03,
+    alphaTarget: 0.22 * reactivity,
+    alphaDecay: 0.02 + (1 - reactivity) * 0.08,
+    velocityDecay: 0.15 + (1 - reactivity) * 0.25,
+    minAlpha: 0.0005
+  };
+}
+
+export function serializeLayoutSettings(settings: LayoutSettings): LayoutSettings {
+  return {
+    preset: settings.preset,
+    repulsion: settings.repulsion,
+    edgeLength: settings.edgeLength,
+    reactivity: settings.reactivity,
+    collision: settings.collision,
+    warmupMode: settings.warmupMode
+  };
+}
+
+export function loadLayoutUiState(): LayoutUiState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return defaultLayoutUiState();
+    const parsed = JSON.parse(raw) as Partial<LayoutUiState>;
+    const base = defaultLayoutUiState();
+    const settings: Partial<LayoutSettings> = parsed.settings ?? {};
+    return {
+      settings: {
+        preset: asPreset(settings.preset) ?? base.settings.preset,
+        repulsion: asNumber(settings.repulsion) ?? base.settings.repulsion,
+        edgeLength: asNumber(settings.edgeLength) ?? base.settings.edgeLength,
+        reactivity: clamp(asNumber(settings.reactivity) ?? base.settings.reactivity, 0, 1),
+        collision: asNumber(settings.collision) ?? base.settings.collision,
+        warmupMode: asWarmupMode(settings.warmupMode) ?? base.settings.warmupMode
+      },
+      panel: { open: Boolean(parsed.panel?.open) }
+    };
+  } catch {
+    return defaultLayoutUiState();
+  }
+}
+
+export function saveLayoutUiState(state: LayoutUiState): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ settings: serializeLayoutSettings(state.settings), panel: state.panel }));
+  } catch {
+    // ignore localStorage failures
+  }
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function asPreset(value: unknown): LayoutPreset | null {
+  return value === "Compact" || value === "Balanced" || value === "Spread" || value === "Snappy" ? value : null;
+}
+
+function asWarmupMode(value: unknown): WarmupMode | null {
+  return value === "OFF" || value === "SOFT" || value === "HARD" ? value : null;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}

--- a/packages/mesh-explorer-ui/test/graphCanvas2d.test.ts
+++ b/packages/mesh-explorer-ui/test/graphCanvas2d.test.ts
@@ -163,6 +163,59 @@ describe("layout seeding helpers", () => {
   });
 });
 
+
+
+describe("layout warmup modes", () => {
+  it("runs HARD warmup synchronously", () => {
+    const hard = new ForceLayout2D({ warmupMode: "HARD" });
+    const off = new ForceLayout2D({ warmupMode: "OFF" });
+    const nodes = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    const links = [{ source: "a", target: "b" }, { source: "b", target: "c" }];
+
+    hard.syncGraph(nodes, links);
+    off.syncGraph(nodes, links);
+
+    expect(hard.getPositions()).not.toEqual(off.getPositions());
+  });
+
+  it("schedules SOFT warmup through RAF", () => {
+    const queue: FrameRequestCallback[] = [];
+    const layout = new ForceLayout2D({
+      warmupMode: "SOFT",
+      requestFrame: (cb) => {
+        queue.push(cb);
+        return queue.length;
+      },
+      cancelFrame: () => undefined
+    });
+
+    layout.syncGraph([{ id: "a" }, { id: "b" }], [{ source: "a", target: "b" }]);
+    expect(queue.length).toBeGreaterThan(0);
+
+    let safety = 0;
+    while (queue.length > 0 && safety < 20) {
+      const cb = queue.shift()!;
+      cb(16);
+      safety += 1;
+    }
+    expect(safety).toBeGreaterThan(1);
+  });
+
+  it("does not warmup when OFF", () => {
+    const queue: FrameRequestCallback[] = [];
+    const layout = new ForceLayout2D({
+      warmupMode: "OFF",
+      requestFrame: (cb) => {
+        queue.push(cb);
+        return queue.length;
+      },
+      cancelFrame: () => undefined
+    });
+
+    layout.syncGraph([{ id: "a" }, { id: "b" }], [{ source: "a", target: "b" }]);
+    expect(queue).toHaveLength(0);
+  });
+});
 describe("layout engine", () => {
   it("uses deterministic seeded initial positions", () => {
     expect(seededNodePosition("node-a", 20)).toEqual(seededNodePosition("node-a", 20));


### PR DESCRIPTION
### Motivation
- Unifier l’affichage de statut pour éviter que le headline affiche "connected" en contradiction avec le calcul de `connectivity` (online | degraded | offline). 
- Fournir un panneau de contrôle dev-first réutilisable pour piloter et persister les paramètres du layout 2D et le mode de warmup. 
- Permettre d’appliquer les paramètres de layout à chaud et d’offrir des modes de warmup (OFF/SOFT/HARD) testables et non bloquants en dev/product.

### Description
- Remplacement du headline principal par un affichage unique basé sur `connectivity` et promotion de l’état SSE/socket en ligne secondaire `transport` (modifications dans `packages/mesh-explorer-ui/src/index.ts`).
- Ajout d’un store UI-local et modèle structuré (`LayoutSettings`, `WarmupMode`, `DevPanelState`) avec sérialisation partagée via `serializeLayoutSettings()` et persistance dans `localStorage` (`packages/mesh-explorer-ui/src/ui/layoutSettings.ts`).
- Nouveau composant isolé `LayoutPanel` (toggle, presets, sliders repulsion/edge length/reactivity/collision, warmup selector OFF/SOFT/HARD, `Reheat`, `Fit`, `Export JSON`) implémenté dans `packages/mesh-explorer-ui/src/ui/LayoutPanel.ts` et monté depuis l’UI principale.
- Extension du moteur layout : `ForceLayout2D` supporte `LayoutParams`, `setLayoutParams()`, `setWarmupMode()` et trois modes de warmup (`HARD` synchrone, `SOFT` via RAF réparti, `OFF` sans warmup), et la classe `GraphCanvas2D` accepte options de layout et expose `reheatLayout()` pour actions live (`packages/mesh-explorer-ui/src/graphCanvas2d.ts`).
- Intégration : lecture initiale/sauvegarde des settings, dérivation en `LayoutParams` avec `deriveLayoutParams()`, application à chaud au renderer, et bouton d’export qui télécharge `mesh-layout-settings.json` ne contenant que les paramètres pertinents.

### Testing
- Exécution unitaire ciblée : `pnpm -w vitest run packages/mesh-explorer-ui/test/graphCanvas2d.test.ts` — suite passée (27 tests) ✅.
- Build TypeScript du packaging UI : `pnpm --filter @mesh/mesh-explorer-ui build` — build réussi ✅.
- Démarrage local du webapp pour vérification visuelle : `pnpm --dir apps/mesh-explorer-webapp dev --host 0.0.0.0 --port 5173` et capture d’écran de la page (artifact produit) — démarrage et capture réussis ✅.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997516411fc8321a266d3113f91b5a1)