### PR TITLE
Stabilize 2D simulation scheduling, initial fit, and extend layout slider ranges

### DIFF
--- a/packages/mesh-explorer-ui/src/graphCanvas2d.ts
+++ b/packages/mesh-explorer-ui/src/graphCanvas2d.ts
@@ -81,6 +81,7 @@ type ForceLayoutOptions = {
   requestFrame?: (callback: FrameRequestCallback) => number;
   cancelFrame?: (frameId: number) => void;
   onSoftWarmupFrame?: () => void;
+  onTick?: () => void;
 };
 
 export function worldToScreen(world: Vec2, camera: CameraState): Vec2 {
@@ -250,13 +251,25 @@ export class ForceLayout2D {
   private readonly requestFrame: (callback: FrameRequestCallback) => number;
   private readonly cancelFrame: (frameId: number) => void;
   private readonly onSoftWarmupFrame?: () => void;
+  private readonly onTick?: () => void;
+  private simulationFrame = 0;
 
   constructor(options: ForceLayoutOptions = {}) {
     this.params = { ...DEFAULT_LAYOUT_PARAMS, ...options.layoutParams };
     this.warmupMode = options.warmupMode ?? "HARD";
-    this.requestFrame = options.requestFrame ?? ((callback) => requestAnimationFrame(callback));
-    this.cancelFrame = options.cancelFrame ?? ((frameId) => cancelAnimationFrame(frameId));
+    this.requestFrame = options.requestFrame ?? ((callback) => {
+      if (typeof requestAnimationFrame === "function") return requestAnimationFrame(callback);
+      return setTimeout(() => callback(Date.now()), 16) as unknown as number;
+    });
+    this.cancelFrame = options.cancelFrame ?? ((frameId) => {
+      if (typeof cancelAnimationFrame === "function") {
+        cancelAnimationFrame(frameId);
+        return;
+      }
+      clearTimeout(frameId);
+    });
     this.onSoftWarmupFrame = options.onSoftWarmupFrame;
+    this.onTick = options.onTick;
   }
 
   setLayoutParams(next: Partial<LayoutParams>): void {
@@ -289,10 +302,16 @@ export class ForceLayout2D {
     if (this.warmupMode === "SOFT") {
       this.scheduleSoftWarmup(WARMUP_TICKS);
     }
+    this.ensureSimulationLoop();
   }
 
   reheat(amount = 0.25): void {
     this.alpha = Math.max(this.alpha, amount);
+    this.ensureSimulationLoop();
+  }
+
+  restart(): void {
+    this.ensureSimulationLoop();
   }
 
   setPin(nodeId: string, position: Vec2): void {
@@ -329,6 +348,7 @@ export class ForceLayout2D {
 
   destroy(): void {
     this.cancelSoftWarmup();
+    this.cancelSimulationLoop();
   }
 
   getPositions(): Map<string, Vec2> {
@@ -412,6 +432,7 @@ export class ForceLayout2D {
     this.softWarmupFrame = this.requestFrame(() => {
       this.softWarmupFrame = 0;
       this.tick(Math.min(SOFT_WARMUP_TICKS_PER_FRAME, remainingTicks));
+      this.onTick?.();
       this.onSoftWarmupFrame?.();
       this.scheduleSoftWarmup(remainingTicks - SOFT_WARMUP_TICKS_PER_FRAME);
     });
@@ -421,6 +442,23 @@ export class ForceLayout2D {
     if (!this.softWarmupFrame) return;
     this.cancelFrame(this.softWarmupFrame);
     this.softWarmupFrame = 0;
+  }
+
+  private ensureSimulationLoop(): void {
+    if (this.simulationFrame) return;
+    if (!this.hasEnergy()) return;
+    this.simulationFrame = this.requestFrame(() => {
+      this.simulationFrame = 0;
+      this.tick(1);
+      this.onTick?.();
+      if (this.hasEnergy()) this.ensureSimulationLoop();
+    });
+  }
+
+  private cancelSimulationLoop(): void {
+    if (!this.simulationFrame) return;
+    this.cancelFrame(this.simulationFrame);
+    this.simulationFrame = 0;
   }
 }
 
@@ -432,8 +470,7 @@ export type GraphCanvasOptions = {
 export class GraphCanvas2D {
   private readonly ctx: CanvasRenderingContext2D;
   private readonly layout: ForceLayout2D;
-  private raf = 0;
-  private running = false;
+  private renderRaf = 0;
   private pointer = { x: 0, y: 0 };
   private panning = false;
   private draggingNodeIds: string[] = [];
@@ -453,10 +490,10 @@ export class GraphCanvas2D {
     this.layout = new ForceLayout2D({
       layoutParams: options.layoutParams,
       warmupMode: options.warmupMode,
-      onSoftWarmupFrame: () => this.startLoop()
+      onSoftWarmupFrame: () => this.requestRender(),
+      onTick: () => this.requestRender()
     });
     this.syncLayoutGraph();
-    this.layout.tick(40);
     this.bindEvents();
     this.resize();
     this.render();
@@ -466,12 +503,11 @@ export class GraphCanvas2D {
     this.readModel = readModel;
     this.ui = ui;
     this.syncLayoutGraph();
-    this.startLoop();
-    this.render();
+    this.requestRender();
   }
 
   destroy(): void {
-    cancelAnimationFrame(this.raf);
+    if (this.renderRaf) cancelAnimationFrame(this.renderRaf);
     this.layout.destroy();
   }
 
@@ -482,7 +518,8 @@ export class GraphCanvas2D {
   setLayoutParams(params: Partial<LayoutParams>): void {
     this.layout.setLayoutParams(params);
     this.layout.reheat(0.3);
-    this.startLoop();
+    this.layout.restart();
+    this.requestRender();
   }
 
   setWarmupMode(mode: WarmupMode): void {
@@ -491,7 +528,8 @@ export class GraphCanvas2D {
 
   reheatLayout(): void {
     this.layout.reheat(0.42);
-    this.startLoop();
+    this.layout.restart();
+    this.requestRender();
   }
 
   resize(): void {
@@ -519,7 +557,7 @@ export class GraphCanvas2D {
         this.panning = true;
         this.callbacks.onCameraChange?.(this.ui.camera);
         this.canvas.setPointerCapture(event.pointerId);
-        this.startLoop();
+        this.requestRender();
         return;
       }
       if (hit) {
@@ -537,7 +575,7 @@ export class GraphCanvas2D {
           for (const id of this.draggingNodeIds) {
             this.layout.setPin(id, pointerWorld);
           }
-          this.startLoop();
+          this.requestRender();
         }
       } else {
         this.callbacks.onSelectionClear();
@@ -556,7 +594,7 @@ export class GraphCanvas2D {
           y: this.ui.camera.y - event.movementY / this.ui.camera.zoom
         };
         this.callbacks.onCameraChange?.(this.ui.camera);
-        this.startLoop();
+        this.requestRender();
         return;
       }
       if (this.draggingNodeIds.length === 0) {
@@ -564,7 +602,7 @@ export class GraphCanvas2D {
         this.hoveredEdgeId = this.ui.hoveredNodeId
           ? null
           : hitTestEdges(this.readModel.links, this.nodePositions(), this.ui.camera, this.pointer);
-        this.render();
+        this.requestRender();
         return;
       }
 
@@ -572,7 +610,8 @@ export class GraphCanvas2D {
         this.layout.setPin(id, pointerWorld);
       }
       this.layout.reheat(0.3);
-      this.startLoop();
+      this.layout.restart();
+      this.requestRender();
     };
 
     const onPointerUp = (event: PointerEvent) => {
@@ -606,8 +645,7 @@ export class GraphCanvas2D {
           this.callbacks.onEdgeDraftChange(null);
         }
       }
-      this.startLoop();
-      this.render();
+      this.requestRender();
     };
 
     this.canvas.addEventListener("pointerdown", onPointerDown, { passive: false });
@@ -628,7 +666,7 @@ export class GraphCanvas2D {
       const ratio = Math.exp(-event.deltaY * 0.0015);
       this.ui.camera = zoomAtPoint(this.ui.camera, { x: event.offsetX, y: event.offsetY }, this.ui.camera.zoom * ratio);
       this.callbacks.onCameraChange?.(this.ui.camera);
-      this.startLoop();
+      this.requestRender();
     }, { passive: false });
     window.addEventListener("keydown", (event) => {
       if (event.key === "Escape") this.callbacks.onEdgeDraftChange(null);
@@ -637,20 +675,12 @@ export class GraphCanvas2D {
     window.addEventListener("resize", () => this.resize());
   }
 
-  private startLoop(): void {
-    if (this.running) return;
-    this.running = true;
-    const tick = () => {
-      this.layout.tick(1);
+  private requestRender(): void {
+    if (this.renderRaf) return;
+    this.renderRaf = requestAnimationFrame(() => {
+      this.renderRaf = 0;
       this.render();
-      const shouldContinue = this.panning || this.draggingNodeIds.length > 0 || this.layout.hasEnergy();
-      if (this.running && shouldContinue) {
-        this.raf = requestAnimationFrame(tick);
-        return;
-      }
-      this.running = false;
-    };
-    this.raf = requestAnimationFrame(tick);
+    });
   }
 
   private render(): void {

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -119,11 +119,11 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       nodes: Array.from(snapshot.nodesById.values()),
       links: Array.from(snapshot.linksById.values()).filter((link: GraphLink) => snapshot.nodesById.has(link.source) && snapshot.nodesById.has(link.target))
     };
-    if (!hasUserMovedCamera && !autoFitApplied && data.nodes.length > 0) {
-      fitCameraToCurrentGraph();
-      autoFitApplied = true;
-    }
     canvasRenderer?.update({ nodes: data.nodes, links: data.links, selectedNodeIds: snapshot.selectedNodeIds }, uiState);
+    if (!hasUserMovedCamera && !autoFitApplied && data.nodes.length > 0) {
+      const applied = fitCameraToCurrentGraph();
+      if (applied) autoFitApplied = true;
+    }
     updateSelectionUi(snapshot);
     renderStatus(snapshot, data.nodes.length, data.links.length);
   });
@@ -354,10 +354,10 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     });
   }
 
-  function fitCameraToCurrentGraph(): void {
+  function fitCameraToCurrentGraph(): boolean {
     const positioned = Array.from((canvasRenderer?.getNodePositions() ?? new Map()).values()).map((position) => ({ position }));
     const bounds = computeGraphBounds(positioned);
-    if (!bounds) return;
+    if (!bounds) return false;
     const rect = el.graphCanvas.getBoundingClientRect();
     uiState.camera = fitCameraToBounds(bounds, { width: rect.width, height: rect.height }, uiState.camera, 0.12, store.getState().nodesById.size);
     cameraInfo = uiState.camera;
@@ -367,6 +367,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       links: Array.from(store.getState().linksById.values()),
       selectedNodeIds: store.getState().selectedNodeIds
     }, uiState);
+    return true;
   }
 
   function updateSelectionUi(snapshot: GraphState): void {

--- a/packages/mesh-explorer-ui/src/ui/LayoutPanel.ts
+++ b/packages/mesh-explorer-ui/src/ui/LayoutPanel.ts
@@ -1,4 +1,4 @@
-import { applyPreset, serializeLayoutSettings, type DevPanelState, type LayoutPreset, type LayoutSettings, type WarmupMode } from "./layoutSettings.js";
+import { LAYOUT_LIMITS, applyPreset, serializeLayoutSettings, type DevPanelState, type LayoutPreset, type LayoutSettings, type WarmupMode } from "./layoutSettings.js";
 
 type LayoutPanelCallbacks = {
   onSettingsChange: (next: LayoutSettings) => void;
@@ -59,10 +59,10 @@ export class LayoutPanel {
       this.renderControls();
     }));
 
-    this.panelBody.appendChild(this.buildSlider("Repulsion", this.settings.repulsion, 20, 140, 1, (value) => this.updateSettings({ repulsion: value })));
-    this.panelBody.appendChild(this.buildSlider("Edge length", this.settings.edgeLength, 20, 160, 1, (value) => this.updateSettings({ edgeLength: value })));
-    this.panelBody.appendChild(this.buildSlider("Reactivity", this.settings.reactivity, 0, 1, 0.01, (value) => this.updateSettings({ reactivity: value })));
-    this.panelBody.appendChild(this.buildSlider("Collision", this.settings.collision, 8, 56, 1, (value) => this.updateSettings({ collision: value })));
+    this.panelBody.appendChild(this.buildSlider("Repulsion", this.settings.repulsion, LAYOUT_LIMITS.repulsion.min, LAYOUT_LIMITS.repulsion.max, 1, (value) => this.updateSettings({ repulsion: value })));
+    this.panelBody.appendChild(this.buildSlider("Edge length", this.settings.edgeLength, LAYOUT_LIMITS.edgeLength.min, LAYOUT_LIMITS.edgeLength.max, 1, (value) => this.updateSettings({ edgeLength: value })));
+    this.panelBody.appendChild(this.buildSlider("Reactivity", this.settings.reactivity, LAYOUT_LIMITS.reactivity.min, LAYOUT_LIMITS.reactivity.max, 0.01, (value) => this.updateSettings({ reactivity: value })));
+    this.panelBody.appendChild(this.buildSlider("Collision", this.settings.collision, LAYOUT_LIMITS.collision.min, LAYOUT_LIMITS.collision.max, 1, (value) => this.updateSettings({ collision: value })));
     this.panelBody.appendChild(this.buildSelect("Warmup", ["OFF", "SOFT", "HARD"], this.settings.warmupMode, (value) => this.updateSettings({ warmupMode: value as WarmupMode })));
 
     const actions = document.createElement("div");

--- a/packages/mesh-explorer-ui/src/ui/layoutSettings.ts
+++ b/packages/mesh-explorer-ui/src/ui/layoutSettings.ts
@@ -21,11 +21,18 @@ export type LayoutUiState = {
 
 const STORAGE_KEY = "mesh-explorer:layout-ui-state";
 
+export const LAYOUT_LIMITS = {
+  repulsion: { min: -800, max: -5 },
+  edgeLength: { min: 10, max: 420 },
+  reactivity: { min: 0.05, max: 2 },
+  collision: { min: 2, max: 120 }
+} as const;
+
 const PRESETS: Record<LayoutPreset, Omit<LayoutSettings, "preset">> = {
-  Compact: { repulsion: 48, edgeLength: 48, reactivity: 0.8, collision: 20, warmupMode: "SOFT" },
-  Balanced: { repulsion: 58, edgeLength: 64, reactivity: 0.55, collision: 23, warmupMode: "HARD" },
-  Spread: { repulsion: 82, edgeLength: 92, reactivity: 0.38, collision: 26, warmupMode: "SOFT" },
-  Snappy: { repulsion: 52, edgeLength: 58, reactivity: 0.92, collision: 22, warmupMode: "OFF" }
+  Compact: { repulsion: -48, edgeLength: 48, reactivity: 0.8, collision: 20, warmupMode: "SOFT" },
+  Balanced: { repulsion: -58, edgeLength: 64, reactivity: 0.55, collision: 23, warmupMode: "HARD" },
+  Spread: { repulsion: -82, edgeLength: 92, reactivity: 0.38, collision: 26, warmupMode: "SOFT" },
+  Snappy: { repulsion: -52, edgeLength: 58, reactivity: 0.92, collision: 22, warmupMode: "OFF" }
 };
 
 export function defaultLayoutSettings(): LayoutSettings {
@@ -42,16 +49,20 @@ export function applyPreset(preset: LayoutPreset, base: LayoutSettings): LayoutS
 }
 
 export function deriveLayoutParams(settings: LayoutSettings): LayoutParams {
-  const reactivity = clamp(settings.reactivity, 0, 1);
+  const reactivity = clamp(settings.reactivity, LAYOUT_LIMITS.reactivity.min, LAYOUT_LIMITS.reactivity.max);
+  const chargeStrength = clamp(Math.abs(settings.repulsion), Math.abs(LAYOUT_LIMITS.repulsion.max), Math.abs(LAYOUT_LIMITS.repulsion.min));
+  const linkDistance = clamp(settings.edgeLength, LAYOUT_LIMITS.edgeLength.min, LAYOUT_LIMITS.edgeLength.max);
+  const collisionRadius = clamp(settings.collision, LAYOUT_LIMITS.collision.min, LAYOUT_LIMITS.collision.max);
+  const reactivityNormalized = (reactivity - LAYOUT_LIMITS.reactivity.min) / (LAYOUT_LIMITS.reactivity.max - LAYOUT_LIMITS.reactivity.min);
   return {
-    chargeStrength: settings.repulsion,
-    linkDistance: settings.edgeLength,
+    chargeStrength,
+    linkDistance,
     linkStrength: 0.18,
-    collisionRadius: settings.collision,
+    collisionRadius,
     centering: 0.03,
-    alphaTarget: 0.22 * reactivity,
-    alphaDecay: 0.02 + (1 - reactivity) * 0.08,
-    velocityDecay: 0.15 + (1 - reactivity) * 0.25,
+    alphaTarget: 0.04 + reactivityNormalized * 0.24,
+    alphaDecay: 0.095 - reactivityNormalized * 0.075,
+    velocityDecay: 0.36 - reactivityNormalized * 0.24,
     minAlpha: 0.0005
   };
 }
@@ -77,10 +88,10 @@ export function loadLayoutUiState(): LayoutUiState {
     return {
       settings: {
         preset: asPreset(settings.preset) ?? base.settings.preset,
-        repulsion: asNumber(settings.repulsion) ?? base.settings.repulsion,
-        edgeLength: asNumber(settings.edgeLength) ?? base.settings.edgeLength,
-        reactivity: clamp(asNumber(settings.reactivity) ?? base.settings.reactivity, 0, 1),
-        collision: asNumber(settings.collision) ?? base.settings.collision,
+        repulsion: clamp(asNumber(settings.repulsion) ?? base.settings.repulsion, LAYOUT_LIMITS.repulsion.min, LAYOUT_LIMITS.repulsion.max),
+        edgeLength: clamp(asNumber(settings.edgeLength) ?? base.settings.edgeLength, LAYOUT_LIMITS.edgeLength.min, LAYOUT_LIMITS.edgeLength.max),
+        reactivity: clamp(asNumber(settings.reactivity) ?? base.settings.reactivity, LAYOUT_LIMITS.reactivity.min, LAYOUT_LIMITS.reactivity.max),
+        collision: clamp(asNumber(settings.collision) ?? base.settings.collision, LAYOUT_LIMITS.collision.min, LAYOUT_LIMITS.collision.max),
         warmupMode: asWarmupMode(settings.warmupMode) ?? base.settings.warmupMode
       },
       panel: { open: Boolean(parsed.panel?.open) }

--- a/packages/mesh-explorer-ui/test/graphCanvas2d.test.ts
+++ b/packages/mesh-explorer-ui/test/graphCanvas2d.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 import { ForceLayout2D, computeEdgeHitSlopWorld, computeGraphBounds, computeMinZoomEffective, computeSeedRadius, distancePointToSegment, fitCameraToBounds, hitTestEdge, hitTestEdges, hitTestNode, nextEdgeDraft, nextSelectedEdgeIds, screenToWorld, seededNodePosition, worldToScreen, zoomAtPoint, type CameraState } from "../src/graphCanvas2d.js";
+import { LAYOUT_LIMITS, deriveLayoutParams } from "../src/ui/layoutSettings.js";
 
 describe("graphCanvas2d transforms", () => {
   it("keeps world point stable under cursor while zooming", () => {
@@ -201,7 +202,7 @@ describe("layout warmup modes", () => {
     expect(safety).toBeGreaterThan(1);
   });
 
-  it("does not warmup when OFF", () => {
+  it("does not run soft-warmup when OFF", () => {
     const queue: FrameRequestCallback[] = [];
     const layout = new ForceLayout2D({
       warmupMode: "OFF",
@@ -213,7 +214,7 @@ describe("layout warmup modes", () => {
     });
 
     layout.syncGraph([{ id: "a" }, { id: "b" }], [{ source: "a", target: "b" }]);
-    expect(queue).toHaveLength(0);
+    expect(queue).toHaveLength(1);
   });
 });
 describe("layout engine", () => {
@@ -270,3 +271,37 @@ describe("move command removal", () => {
   });
 });
 
+
+
+describe("simulation scheduling", () => {
+  it("does not run a hybrid manual render loop that ticks layout from GraphCanvas2D", () => {
+    const canvasSource = readFileSync(new URL("../src/graphCanvas2d.ts", import.meta.url), "utf8");
+    expect(canvasSource.includes("this.layout.tick(1)")).toBe(false);
+  });
+
+  it("keeps pointermove free from simulation stop-side effects", () => {
+    const canvasSource = readFileSync(new URL("../src/graphCanvas2d.ts", import.meta.url), "utf8");
+    expect(canvasSource.includes("simulation.stop")).toBe(false);
+    expect(canvasSource.includes("alpha(0)")).toBe(false);
+    expect(canvasSource.includes("alphaTarget(0)")).toBe(false);
+  });
+});
+
+describe("layout settings bounds", () => {
+  it("clamps extreme slider values to safe engine bounds", () => {
+    const params = deriveLayoutParams({
+      preset: "Balanced",
+      repulsion: -2000,
+      edgeLength: 5000,
+      reactivity: 4,
+      collision: 0,
+      warmupMode: "HARD"
+    });
+
+    expect(params.chargeStrength).toBe(Math.abs(LAYOUT_LIMITS.repulsion.min));
+    expect(params.linkDistance).toBe(LAYOUT_LIMITS.edgeLength.max);
+    expect(params.collisionRadius).toBe(LAYOUT_LIMITS.collision.min);
+    expect(params.alphaTarget).toBeLessThanOrEqual(0.28);
+    expect(params.velocityDecay).toBeGreaterThanOrEqual(0.12);
+  });
+});


### PR DESCRIPTION
### Motivation
- Eliminer le mode hybride de scheduling (RAF manuel + tick manuel) qui provoquait des arrêts/incohérences de la simulation lors d'événements pointer.
- Rendre les handlers UI (pointermove, pan, hover) sans effets secondaires sur la simulation pour éviter les glitches.
- Étendre les plages des sliders du panneau Layout et s'assurer que le moteur clamp correctement les valeurs extrêmes.
- Corriger le fit initial appliqué au reload pour qu'il s'exécute uniquement lorsque les positions sont valides.

### Description
- Remplacé la boucle RAF manuelle dans `GraphCanvas2D` par un rendu sur demande (`requestRender`) et centralisé l'avancement de la simulation dans `ForceLayout2D` via une boucle interne unique avec callback `onTick` et fallback timer quand `requestAnimationFrame` est absent.
- Rendu le handler `pointermove` side-effect-free (mise à jour hover/camera/edgeDraft + `requestRender()` seulement); les actions modifiant les forces appellent explicitement `reheat()` + `restart()` sur le layout.
- Étendu les plages UI et ajouté des limites moteur centralisées `LAYOUT_LIMITS` (repulsion, edgeLength, reactivity, collision), clampées dans `deriveLayoutParams`; presets ajustés pour la nouvelle convention de repulsion signée.
- Ajusté l'auto-fit de démarrage dans `index.ts` pour appliquer un fit one-shot seulement si des bounds valides existent, et retournant un booléen pour éviter un double-fit prématuré.
- Ajout / mise à jour de tests de non-régression couvrant absence de scheduling hybride, absence d'effets de stop sur pointermove, et clamp des paramètres de layout.
- Fichiers principaux modifiés : `packages/mesh-explorer-ui/src/graphCanvas2d.ts`, `packages/mesh-explorer-ui/src/index.ts`, `packages/mesh-explorer-ui/src/ui/LayoutPanel.ts`, `packages/mesh-explorer-ui/src/ui/layoutSettings.ts`, `packages/mesh-explorer-ui/test/graphCanvas2d.test.ts`.

### Testing
- Exécuté les tests unitaires: `pnpm vitest run packages/mesh-explorer-ui/test/graphCanvas2d.test.ts packages/mesh-explorer-ui/test/canvasFlow.integration.test.ts` — tous les tests sont passés (`36 passed`).
- Build TypeScript du package UI: `pnpm --filter @mesh/mesh-explorer-ui build` — succès (TS compile passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997573dd5b48321a78c302eb4936fb4)