### PR TITLE
Avoid pointermove-triggered reheats; make Reheat effective; add throttled dev logs

### DIFF
--- a/packages/mesh-explorer-ui/src/graphCanvas2d.ts
+++ b/packages/mesh-explorer-ui/src/graphCanvas2d.ts
@@ -462,9 +462,13 @@ export class ForceLayout2D {
   }
 }
 
+export type GraphCanvasDebugLog = (event: string, payload?: Record<string, unknown>, throttleMs?: number) => void;
+
 export type GraphCanvasOptions = {
   layoutParams?: Partial<LayoutParams>;
   warmupMode?: WarmupMode;
+  debugLogsEnabled?: boolean;
+  debugLog?: GraphCanvasDebugLog;
 };
 
 export class GraphCanvas2D {
@@ -476,6 +480,10 @@ export class GraphCanvas2D {
   private draggingNodeIds: string[] = [];
   private hoveredEdgeId: string | null = null;
   private selectedEdgeIds = new Set<string>();
+  private edgeDraftCursorWorldPos: Vec2 | null = null;
+  private topologySignature = "";
+  private debugLogsEnabled = false;
+  private readonly debugLog?: GraphCanvasDebugLog;
 
   constructor(
     private readonly canvas: HTMLCanvasElement,
@@ -487,13 +495,15 @@ export class GraphCanvas2D {
     const ctx = canvas.getContext("2d");
     if (!ctx) throw new Error("2D canvas context unavailable");
     this.ctx = ctx;
+    this.debugLogsEnabled = options.debugLogsEnabled ?? false;
+    this.debugLog = options.debugLog;
     this.layout = new ForceLayout2D({
       layoutParams: options.layoutParams,
       warmupMode: options.warmupMode,
       onSoftWarmupFrame: () => this.requestRender(),
       onTick: () => this.requestRender()
     });
-    this.syncLayoutGraph();
+    this.syncLayoutGraph("init");
     this.bindEvents();
     this.resize();
     this.render();
@@ -502,7 +512,11 @@ export class GraphCanvas2D {
   update(readModel: GraphCanvasReadModel, ui: CanvasUiState): void {
     this.readModel = readModel;
     this.ui = ui;
-    this.syncLayoutGraph();
+    if (!this.ui.edgeDraft) this.edgeDraftCursorWorldPos = null;
+    const nextSignature = this.computeTopologySignature();
+    if (nextSignature !== this.topologySignature) {
+      this.syncLayoutGraph("topology-change");
+    }
     this.requestRender();
   }
 
@@ -517,8 +531,9 @@ export class GraphCanvas2D {
 
   setLayoutParams(params: Partial<LayoutParams>): void {
     this.layout.setLayoutParams(params);
-    this.layout.reheat(0.3);
-    this.layout.restart();
+    this.syncLayoutGraph("layout-params-change");
+    this.emitDebug("layout.reheat", { amount: 0.45, reason: "layout-params-change" });
+    this.emitDebug("layout.restart", { reason: "layout-params-change" });
     this.requestRender();
   }
 
@@ -526,8 +541,14 @@ export class GraphCanvas2D {
     this.layout.setWarmupMode(mode);
   }
 
+  setDebugLogsEnabled(enabled: boolean): void {
+    this.debugLogsEnabled = enabled;
+  }
+
   reheatLayout(): void {
-    this.layout.reheat(0.42);
+    this.emitDebug("layout.reheat", { amount: 0.9, reason: "ui-reheat-button" });
+    this.layout.reheat(0.9);
+    this.emitDebug("layout.restart", { reason: "ui-reheat-button" });
     this.layout.restart();
     this.requestRender();
   }
@@ -541,12 +562,17 @@ export class GraphCanvas2D {
     this.render();
   }
 
-  private syncLayoutGraph(): void {
+  private syncLayoutGraph(reason: string): void {
+    this.topologySignature = this.computeTopologySignature();
+    const nodeCount = this.readModel.nodes.length;
+    const linkCount = this.readModel.links.length;
+    this.emitDebug("layout.syncGraph", { reason, nodeCount, linkCount });
     this.layout.syncGraph(this.readModel.nodes.map((node) => ({ id: node.id })), this.readModel.links.map((link) => ({ source: link.source, target: link.target })));
   }
 
   private bindEvents(): void {
     const onPointerDown = (event: PointerEvent) => {
+      this.emitDebug("ui.pointerdown", { button: event.button, shiftKey: event.shiftKey, ctrlKey: event.ctrlKey, metaKey: event.metaKey, altKey: event.altKey });
       if (event.button === 1) {
         event.preventDefault();
         event.stopPropagation();
@@ -575,6 +601,7 @@ export class GraphCanvas2D {
           for (const id of this.draggingNodeIds) {
             this.layout.setPin(id, pointerWorld);
           }
+          this.emitDebug("ui.drag.start", { draggedCount: this.draggingNodeIds.length });
           this.requestRender();
         }
       } else {
@@ -586,7 +613,7 @@ export class GraphCanvas2D {
     const onPointerMove = (event: PointerEvent) => {
       this.pointer = { x: event.offsetX, y: event.offsetY };
       const pointerWorld = screenToWorld(this.pointer, this.ui.camera);
-      this.callbacks.onEdgeDraftChange(this.ui.edgeDraft ? { ...this.ui.edgeDraft, cursorWorldPos: pointerWorld } : null);
+      if (this.ui.edgeDraft) this.edgeDraftCursorWorldPos = pointerWorld;
       if (this.panning) {
         this.ui.camera = {
           ...this.ui.camera,
@@ -609,18 +636,23 @@ export class GraphCanvas2D {
       for (const id of this.draggingNodeIds) {
         this.layout.setPin(id, pointerWorld);
       }
+      this.emitDebug("layout.reheat", { amount: 0.3, reason: "drag-move" });
       this.layout.reheat(0.3);
+      this.emitDebug("layout.restart", { reason: "drag-move" });
       this.layout.restart();
       this.requestRender();
     };
 
     const onPointerUp = (event: PointerEvent) => {
+      this.emitDebug("ui.pointerup", { button: event.button });
       const wasDragging = this.draggingNodeIds.length > 0;
       if (wasDragging) {
         for (const id of this.draggingNodeIds) {
           this.layout.clearPin(id);
         }
         this.draggingNodeIds = [];
+        this.emitDebug("ui.drag.end", {});
+        this.emitDebug("layout.reheat", { amount: 0.22, reason: "drag-end" });
         this.layout.reheat(0.22);
       }
       if (this.panning) {
@@ -639,9 +671,11 @@ export class GraphCanvas2D {
         this.selectedEdgeIds = nextSelectedEdgeIds(this.selectedEdgeIds, { nodeHit: hit, edgeHit, shiftKey: event.shiftKey });
         if (hit) {
           const next = nextEdgeDraft(this.ui.edgeDraft, hit, pointerWorld);
+          this.edgeDraftCursorWorldPos = next.edgeDraft ? pointerWorld : null;
           this.callbacks.onEdgeDraftChange(next.edgeDraft);
           if (next.commit) this.callbacks.onCreateEdge(next.commit.source, next.commit.target);
         } else if (edgeHit) {
+          this.edgeDraftCursorWorldPos = null;
           this.callbacks.onEdgeDraftChange(null);
         }
       }
@@ -669,7 +703,11 @@ export class GraphCanvas2D {
       this.requestRender();
     }, { passive: false });
     window.addEventListener("keydown", (event) => {
-      if (event.key === "Escape") this.callbacks.onEdgeDraftChange(null);
+      this.emitDebug("ui.keydown", { key: event.key });
+      if (event.key === "Escape") {
+        this.edgeDraftCursorWorldPos = null;
+        this.callbacks.onEdgeDraftChange(null);
+      }
       if (event.key.toLowerCase() === "f") this.callbacks.onFitRequest?.();
     });
     window.addEventListener("resize", () => this.resize());
@@ -737,17 +775,31 @@ export class GraphCanvas2D {
 
     if (this.ui.edgeDraft) {
       const start = positions.get(this.ui.edgeDraft.startNodeId);
+      const draftCursor = this.edgeDraftCursorWorldPos ?? this.ui.edgeDraft.cursorWorldPos;
       if (start) {
         this.ctx.setLineDash([6 / this.ui.camera.zoom, 6 / this.ui.camera.zoom]);
         this.ctx.strokeStyle = "#f59e0b";
         this.ctx.lineWidth = 2 / this.ui.camera.zoom;
         this.ctx.beginPath();
         this.ctx.moveTo(start.x, start.y);
-        this.ctx.lineTo(this.ui.edgeDraft.cursorWorldPos.x, this.ui.edgeDraft.cursorWorldPos.y);
+        this.ctx.lineTo(draftCursor.x, draftCursor.y);
         this.ctx.stroke();
         this.ctx.setLineDash([]);
       }
     }
+  }
+
+  private computeTopologySignature(): string {
+    const nodeIds = this.readModel.nodes.map((node) => node.id).sort();
+    const linkIds = this.readModel.links
+      .map((link) => `${link.id}:${link.source}->${link.target}`)
+      .sort();
+    return `${nodeIds.join("|")}::${linkIds.join("|")}`;
+  }
+
+  private emitDebug(event: string, payload?: Record<string, unknown>, throttleMs?: number): void {
+    if (!this.debugLogsEnabled) return;
+    this.debugLog?.(event, payload, throttleMs);
   }
 
   private positionedNodes(): Array<{ id: string; position: Vec2 }> {

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -100,7 +100,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
 
   let canvasRenderer: GraphCanvas2D | null = null;
   let layoutUiState: LayoutUiState = loadLayoutUiState();
-
+  const debugThrottleByEvent = new Map<string, number>();
 
   setConnectionStatus("disconnected");
   installConnectivityListeners();
@@ -323,7 +323,9 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
         }
       }, {
         layoutParams: deriveLayoutParams(layoutUiState.settings),
-        warmupMode: layoutUiState.settings.warmupMode
+        warmupMode: layoutUiState.settings.warmupMode,
+        debugLogsEnabled: layoutUiState.settings.debugLogs,
+        debugLog: emitUiDebugLog
       });
       setRendererMode("canvas-2d");
     } catch (error) {
@@ -340,17 +342,26 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       panel: layoutUiState.panel
     }, {
       onSettingsChange: (next) => {
+        const previous = layoutUiState.settings;
         layoutUiState = { ...layoutUiState, settings: next };
         saveLayoutUiState(layoutUiState);
+        canvasRenderer?.setDebugLogsEnabled(next.debugLogs);
         canvasRenderer?.setLayoutParams(deriveLayoutParams(next));
         canvasRenderer?.setWarmupMode(next.warmupMode);
+        emitUiDebugLog("settings.change", { previous, next });
       },
       onPanelStateChange: (panel) => {
         layoutUiState = { ...layoutUiState, panel };
         saveLayoutUiState(layoutUiState);
       },
-      onReheat: () => canvasRenderer?.reheatLayout(),
-      onFit: () => fitCameraToCurrentGraph()
+      onReheat: () => {
+        emitUiDebugLog("ui.keydown", { key: "Reheat" });
+        canvasRenderer?.reheatLayout();
+      },
+      onFit: () => {
+        emitUiDebugLog("ui.keydown", { key: "Fit" });
+        fitCameraToCurrentGraph();
+      }
     });
   }
 
@@ -396,6 +407,17 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     }
   }
 
+  function emitUiDebugLog(event: string, payload: Record<string, unknown> = {}, throttleMs = 0): void {
+    if (!layoutUiState.settings.debugLogs) return;
+    const now = Date.now();
+    if (throttleMs > 0) {
+      const last = debugThrottleByEvent.get(event) ?? 0;
+      if (now - last < throttleMs) return;
+      debugThrottleByEvent.set(event, now);
+    }
+    console.debug("[mesh-ui]", { event, t: now, ...payload });
+  }
+
   function setConnectionStatus(next: ConnectionStatus): void {
     store.setConnectionStatus(next);
   }
@@ -410,6 +432,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     if (next !== connectivityState) {
       connectivityState = next;
       renderStatus(store.getState(), store.getState().nodesById.size, store.getState().linksById.size);
+      emitUiDebugLog("connectivity.change", { source, connectivityState, browserConnectivityHint, networkConnectivityHint });
     }
     dbg(`connectivity:${source}`, { browserConnectivityHint, networkConnectivityHint, connectivityState });
   }

--- a/packages/mesh-explorer-ui/src/ui/LayoutPanel.ts
+++ b/packages/mesh-explorer-ui/src/ui/LayoutPanel.ts
@@ -64,6 +64,7 @@ export class LayoutPanel {
     this.panelBody.appendChild(this.buildSlider("Reactivity", this.settings.reactivity, LAYOUT_LIMITS.reactivity.min, LAYOUT_LIMITS.reactivity.max, 0.01, (value) => this.updateSettings({ reactivity: value })));
     this.panelBody.appendChild(this.buildSlider("Collision", this.settings.collision, LAYOUT_LIMITS.collision.min, LAYOUT_LIMITS.collision.max, 1, (value) => this.updateSettings({ collision: value })));
     this.panelBody.appendChild(this.buildSelect("Warmup", ["OFF", "SOFT", "HARD"], this.settings.warmupMode, (value) => this.updateSettings({ warmupMode: value as WarmupMode })));
+    this.panelBody.appendChild(this.buildToggle("Debug logs", this.settings.debugLogs, (checked) => this.updateSettings({ debugLogs: checked })));
 
     const actions = document.createElement("div");
     actions.style.display = "flex";
@@ -153,6 +154,27 @@ export class LayoutPanel {
     }
     select.onchange = () => onChange(select.value);
     row.appendChild(select);
+    return row;
+  }
+
+  private buildToggle(label: string, checked: boolean, onChange: (next: boolean) => void): HTMLElement {
+    const row = document.createElement("label");
+    row.style.display = "flex";
+    row.style.alignItems = "center";
+    row.style.gap = "6px";
+    row.style.marginTop = "8px";
+    row.style.fontSize = "12px";
+
+    const input = document.createElement("input");
+    input.type = "checkbox";
+    input.checked = checked;
+    input.onchange = () => onChange(input.checked);
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    row.appendChild(input);
+    row.appendChild(text);
     return row;
   }
 

--- a/packages/mesh-explorer-ui/src/ui/layoutSettings.ts
+++ b/packages/mesh-explorer-ui/src/ui/layoutSettings.ts
@@ -10,6 +10,7 @@ export type LayoutSettings = {
   reactivity: number;
   collision: number;
   warmupMode: WarmupMode;
+  debugLogs: boolean;
 };
 
 export type DevPanelState = { open: boolean };
@@ -29,10 +30,10 @@ export const LAYOUT_LIMITS = {
 } as const;
 
 const PRESETS: Record<LayoutPreset, Omit<LayoutSettings, "preset">> = {
-  Compact: { repulsion: -48, edgeLength: 48, reactivity: 0.8, collision: 20, warmupMode: "SOFT" },
-  Balanced: { repulsion: -58, edgeLength: 64, reactivity: 0.55, collision: 23, warmupMode: "HARD" },
-  Spread: { repulsion: -82, edgeLength: 92, reactivity: 0.38, collision: 26, warmupMode: "SOFT" },
-  Snappy: { repulsion: -52, edgeLength: 58, reactivity: 0.92, collision: 22, warmupMode: "OFF" }
+  Compact: { repulsion: -48, edgeLength: 48, reactivity: 0.8, collision: 20, warmupMode: "SOFT", debugLogs: false },
+  Balanced: { repulsion: -58, edgeLength: 64, reactivity: 0.55, collision: 23, warmupMode: "HARD", debugLogs: false },
+  Spread: { repulsion: -82, edgeLength: 92, reactivity: 0.38, collision: 26, warmupMode: "SOFT", debugLogs: false },
+  Snappy: { repulsion: -52, edgeLength: 58, reactivity: 0.92, collision: 22, warmupMode: "OFF", debugLogs: false }
 };
 
 export function defaultLayoutSettings(): LayoutSettings {
@@ -74,7 +75,8 @@ export function serializeLayoutSettings(settings: LayoutSettings): LayoutSetting
     edgeLength: settings.edgeLength,
     reactivity: settings.reactivity,
     collision: settings.collision,
-    warmupMode: settings.warmupMode
+    warmupMode: settings.warmupMode,
+    debugLogs: settings.debugLogs
   };
 }
 
@@ -92,7 +94,8 @@ export function loadLayoutUiState(): LayoutUiState {
         edgeLength: clamp(asNumber(settings.edgeLength) ?? base.settings.edgeLength, LAYOUT_LIMITS.edgeLength.min, LAYOUT_LIMITS.edgeLength.max),
         reactivity: clamp(asNumber(settings.reactivity) ?? base.settings.reactivity, LAYOUT_LIMITS.reactivity.min, LAYOUT_LIMITS.reactivity.max),
         collision: clamp(asNumber(settings.collision) ?? base.settings.collision, LAYOUT_LIMITS.collision.min, LAYOUT_LIMITS.collision.max),
-        warmupMode: asWarmupMode(settings.warmupMode) ?? base.settings.warmupMode
+        warmupMode: asWarmupMode(settings.warmupMode) ?? base.settings.warmupMode,
+        debugLogs: typeof settings.debugLogs === "boolean" ? settings.debugLogs : base.settings.debugLogs
       },
       panel: { open: Boolean(parsed.panel?.open) }
     };

--- a/packages/mesh-explorer-ui/test/graphCanvas2d.test.ts
+++ b/packages/mesh-explorer-ui/test/graphCanvas2d.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { ForceLayout2D, computeEdgeHitSlopWorld, computeGraphBounds, computeMinZoomEffective, computeSeedRadius, distancePointToSegment, fitCameraToBounds, hitTestEdge, hitTestEdges, hitTestNode, nextEdgeDraft, nextSelectedEdgeIds, screenToWorld, seededNodePosition, worldToScreen, zoomAtPoint, type CameraState } from "../src/graphCanvas2d.js";
+import { ForceLayout2D, GraphCanvas2D, computeEdgeHitSlopWorld, computeGraphBounds, computeMinZoomEffective, computeSeedRadius, distancePointToSegment, fitCameraToBounds, hitTestEdge, hitTestEdges, hitTestNode, nextEdgeDraft, nextSelectedEdgeIds, screenToWorld, seededNodePosition, worldToScreen, zoomAtPoint, type CameraState } from "../src/graphCanvas2d.js";
 import { LAYOUT_LIMITS, deriveLayoutParams } from "../src/ui/layoutSettings.js";
 
 describe("graphCanvas2d transforms", () => {
@@ -295,7 +295,8 @@ describe("layout settings bounds", () => {
       edgeLength: 5000,
       reactivity: 4,
       collision: 0,
-      warmupMode: "HARD"
+      warmupMode: "HARD",
+      debugLogs: false
     });
 
     expect(params.chargeStrength).toBe(Math.abs(LAYOUT_LIMITS.repulsion.min));
@@ -303,5 +304,150 @@ describe("layout settings bounds", () => {
     expect(params.collisionRadius).toBe(LAYOUT_LIMITS.collision.min);
     expect(params.alphaTarget).toBeLessThanOrEqual(0.28);
     expect(params.velocityDecay).toBeGreaterThanOrEqual(0.12);
+  });
+});
+
+
+describe("GraphCanvas2D topology guards and reheat", () => {
+  const raf = (cb: FrameRequestCallback) => {
+    cb(16);
+    return 1;
+  };
+
+  function createCanvasHarness() {
+    const events = new Map<string, EventListener>();
+    const ctx = {
+      setTransform: () => undefined,
+      clearRect: () => undefined,
+      fillRect: () => undefined,
+      beginPath: () => undefined,
+      moveTo: () => undefined,
+      lineTo: () => undefined,
+      stroke: () => undefined,
+      arc: () => undefined,
+      fill: () => undefined,
+      fillText: () => undefined,
+      setLineDash: () => undefined
+    } as unknown as CanvasRenderingContext2D;
+
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: () => ctx,
+      getBoundingClientRect: () => ({ width: 640, height: 480 }),
+      addEventListener: (name: string, listener: EventListener) => events.set(name, listener),
+      setPointerCapture: () => undefined,
+      hasPointerCapture: () => false,
+      releasePointerCapture: () => undefined
+    } as unknown as HTMLCanvasElement;
+
+    return {
+      canvas,
+      fire(name: string, event: unknown) {
+        events.get(name)?.(event as Event);
+      }
+    };
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("pointermove does not sync or reheat on ui-only hover", () => {
+    vi.stubGlobal("window", {
+      devicePixelRatio: 1,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined
+    });
+    vi.stubGlobal("requestAnimationFrame", raf);
+    vi.stubGlobal("cancelAnimationFrame", () => undefined);
+
+    const syncSpy = vi.spyOn(ForceLayout2D.prototype, "syncGraph");
+    const reheatSpy = vi.spyOn(ForceLayout2D.prototype, "reheat");
+    const { canvas, fire } = createCanvasHarness();
+
+    const renderer = new GraphCanvas2D(canvas, {
+      nodes: [{ id: "n1", label: "N1" }],
+      links: [],
+      selectedNodeIds: new Set()
+    }, {
+      camera: { x: 0, y: 0, zoom: 1, minZoom: 0.2, maxZoom: 4 },
+      hoveredNodeId: null,
+      edgeDraft: null,
+      dragSelectionRect: null
+    }, {
+      onSelectionReplace: () => undefined,
+      onSelectionToggle: () => undefined,
+      onSelectionClear: () => undefined,
+      onEdgeDraftChange: () => undefined,
+      onCreateEdge: () => undefined
+    });
+
+    syncSpy.mockClear();
+    reheatSpy.mockClear();
+    fire("pointermove", { offsetX: 30, offsetY: 20, movementX: 1, movementY: 1 });
+
+    expect(syncSpy).toHaveBeenCalledTimes(0);
+    expect(reheatSpy).toHaveBeenCalledTimes(0);
+    renderer.destroy();
+  });
+
+  it("topology change triggers syncGraph while ui-only update does not", () => {
+    vi.stubGlobal("window", { devicePixelRatio: 1, addEventListener: () => undefined, removeEventListener: () => undefined });
+    vi.stubGlobal("requestAnimationFrame", raf);
+    vi.stubGlobal("cancelAnimationFrame", () => undefined);
+    const syncSpy = vi.spyOn(ForceLayout2D.prototype, "syncGraph");
+    const { canvas } = createCanvasHarness();
+
+    const ui = { camera: { x: 0, y: 0, zoom: 1, minZoom: 0.2, maxZoom: 4 }, hoveredNodeId: null, edgeDraft: null, dragSelectionRect: null };
+    const renderer = new GraphCanvas2D(canvas, { nodes: [{ id: "n1", label: "N1" }], links: [], selectedNodeIds: new Set() }, ui, {
+      onSelectionReplace: () => undefined,
+      onSelectionToggle: () => undefined,
+      onSelectionClear: () => undefined,
+      onEdgeDraftChange: () => undefined,
+      onCreateEdge: () => undefined
+    });
+
+    syncSpy.mockClear();
+    renderer.update({ nodes: [{ id: "n1", label: "N1" }], links: [], selectedNodeIds: new Set() }, { ...ui, hoveredNodeId: "n1" });
+    expect(syncSpy).toHaveBeenCalledTimes(0);
+
+    renderer.update({
+      nodes: [{ id: "n1", label: "N1" }, { id: "n2", label: "N2" }],
+      links: [{ id: "l1", source: "n1", target: "n2", type: "related" }],
+      selectedNodeIds: new Set()
+    }, ui);
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+    renderer.destroy();
+  });
+
+  it("reheatLayout reheats and restarts simulation", () => {
+    vi.stubGlobal("window", { devicePixelRatio: 1, addEventListener: () => undefined, removeEventListener: () => undefined });
+    vi.stubGlobal("requestAnimationFrame", raf);
+    vi.stubGlobal("cancelAnimationFrame", () => undefined);
+    const reheatSpy = vi.spyOn(ForceLayout2D.prototype, "reheat");
+    const restartSpy = vi.spyOn(ForceLayout2D.prototype, "restart");
+    const { canvas } = createCanvasHarness();
+
+    const renderer = new GraphCanvas2D(canvas, { nodes: [{ id: "n1", label: "N1" }], links: [], selectedNodeIds: new Set() }, {
+      camera: { x: 0, y: 0, zoom: 1, minZoom: 0.2, maxZoom: 4 },
+      hoveredNodeId: null,
+      edgeDraft: null,
+      dragSelectionRect: null
+    }, {
+      onSelectionReplace: () => undefined,
+      onSelectionToggle: () => undefined,
+      onSelectionClear: () => undefined,
+      onEdgeDraftChange: () => undefined,
+      onCreateEdge: () => undefined
+    });
+
+    reheatSpy.mockClear();
+    restartSpy.mockClear();
+    renderer.reheatLayout();
+
+    expect(reheatSpy).toHaveBeenCalledWith(0.9);
+    expect(restartSpy).toHaveBeenCalledTimes(1);
+    renderer.destroy();
   });
 });


### PR DESCRIPTION
### Motivation

- Prevent inadvertent simulation reheats/restarts caused by `pointermove` updating the edge-draft cursor through the app/store and triggering `syncGraph()`/layout reheat. 
- Make the `Reheat` action visibly and predictably kick the layout engine. 
- Provide structured, opt-in developer logs for discrete user actions without spamming (throttled).

### Description

- GraphCanvas2D (packages/mesh-explorer-ui/src/graphCanvas2d.ts): store the draft cursor locally (`edgeDraftCursorWorldPos`) and stop emitting `onEdgeDraftChange(...)` on every `pointermove`; use the local cursor when rendering the ghost edge; compute a topology signature and only call `layout.syncGraph(...)` when topology or layout-params change; introduce `emitDebug(...)` hooks and `setDebugLogsEnabled(...)`; make `reheatLayout()` use `reheat(0.9)` + `restart()` for a stronger deterministic kick.
- Index (packages/mesh-explorer-ui/src/index.ts): add `emitUiDebugLog(...)` with per-event throttling, pass UI debug logger into `GraphCanvas2D`, and wire settings changes to toggle canvas debug logging; emit structured logs for key events (settings change, reheat, fit, connectivity change).
- Layout panel & settings (packages/mesh-explorer-ui/src/ui/LayoutPanel.ts & layoutSettings.ts): add a `Debug logs` toggle in the layout panel and persist `debugLogs` in layout UI state and presets.
- Tests (packages/mesh-explorer-ui/test/graphCanvas2d.test.ts): add/adjust tests for the new behavior: ensure `pointermove` does not call `layout.syncGraph`/`reheat`, ensure topology updates trigger `syncGraph`, and verify `reheatLayout()` calls `reheat(0.9)` and `restart()`.

### Testing

- Ran unit tests: `pnpm vitest packages/mesh-explorer-ui/test/graphCanvas2d.test.ts --run`, all tests passed (33 tests). ✅
- Built the UI package: `pnpm --filter @mesh/mesh-explorer-ui build`, TypeScript build succeeded. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997647cafa08321afe141cb52637687)