### PR TITLE
Add graph delete/rename APIs with UI undo/redo and viewport contract

### DIFF
--- a/apps/mesh-graph-server/src/index.ts
+++ b/apps/mesh-graph-server/src/index.ts
@@ -11,6 +11,7 @@ import type { Command, CommandOutcome, Cursor, PrincipalContext } from "@mesh/sh
 
 const GRAPH_SPACE_ID = "mesh-explorer-graph-v1";
 const PRINCIPAL_HEADER = "x-mesh-principal";
+const IDEMPOTENCY_HEADER = "x-idempotency-key";
 const DEBUG_AUTH_ENABLED = process.env.MESH_DEBUG_AUTH === "1";
 const STORE_CACHE = new Map<string, FileBackedLocalEventStore>();
 
@@ -169,7 +170,7 @@ async function handleRequest(
       level: typeof body.level === "number" ? body.level : undefined,
       metadata: typeof body.metadata === "object" && body.metadata !== null ? body.metadata as Record<string, unknown> : undefined
     };
-    const idempotencyKey = typeof body.idempotencyKey === "string" && body.idempotencyKey.trim() ? body.idempotencyKey : randomUUID();
+    const idempotencyKey = readIdempotencyKey(req, body.idempotencyKey);
     const outcome = await submitGraphCommand(deps.gateway, deps.graphSpaceId, principal, idempotencyKey, {
       type: "graph.node.created",
       node
@@ -191,12 +192,51 @@ async function handleRequest(
       type: typeof body.type === "string" && body.type.trim() ? body.type : "related",
       label: typeof body.label === "string" ? body.label : undefined
     };
-    const idempotencyKey = typeof body.idempotencyKey === "string" && body.idempotencyKey.trim() ? body.idempotencyKey : randomUUID();
+    const idempotencyKey = readIdempotencyKey(req, body.idempotencyKey);
     const outcome = await submitGraphCommand(deps.gateway, deps.graphSpaceId, principal, idempotencyKey, {
       type: "graph.link.created",
       link
     });
     writeJson(res, 200, { link, outcome });
+    return;
+  }
+
+  if (req.method === "PATCH" && /^\/graph\/nodes\/[^/]+$/.test(requestUrl.pathname)) {
+    const body = (await readJsonBody(req)) as { label?: unknown; idempotencyKey?: string };
+    if (typeof body.label !== "string") {
+      writeJson(res, 400, { status: "rejected", category: "VALIDATION", reasonCode: "TRANSPORT.INVALID_REQUEST" });
+      return;
+    }
+    const nodeId = decodeURIComponent(requestUrl.pathname.slice("/graph/nodes/".length));
+    const idempotencyKey = readIdempotencyKey(req, body.idempotencyKey);
+    const outcome = await submitGraphCommand(deps.gateway, deps.graphSpaceId, principal, idempotencyKey, {
+      type: "graph.node.label.updated",
+      nodeId,
+      label: body.label
+    });
+    writeJson(res, 200, { outcome, nodeId, label: body.label });
+    return;
+  }
+
+  if (req.method === "DELETE" && /^\/graph\/links\/[^/]+$/.test(requestUrl.pathname)) {
+    const linkId = decodeURIComponent(requestUrl.pathname.slice("/graph/links/".length));
+    const idempotencyKey = readIdempotencyKey(req);
+    const outcome = await submitGraphCommand(deps.gateway, deps.graphSpaceId, principal, idempotencyKey, {
+      type: "graph.link.deleted",
+      linkId
+    });
+    writeJson(res, 200, { outcome, linkId });
+    return;
+  }
+
+  if (req.method === "DELETE" && /^\/graph\/nodes\/[^/]+$/.test(requestUrl.pathname)) {
+    const nodeId = decodeURIComponent(requestUrl.pathname.slice("/graph/nodes/".length));
+    const idempotencyKey = readIdempotencyKey(req);
+    const outcome = await submitGraphCommand(deps.gateway, deps.graphSpaceId, principal, idempotencyKey, {
+      type: "graph.node.deleted",
+      nodeId
+    });
+    writeJson(res, 200, { outcome, nodeId });
     return;
   }
 
@@ -291,6 +331,15 @@ function applyGraphEvent(nodes: Map<string, GraphNode>, links: Map<string, Graph
   }
 }
 
+
+function readIdempotencyKey(req: IncomingMessage, bodyValue?: unknown): string {
+  if (typeof bodyValue === "string" && bodyValue.trim()) return bodyValue;
+  const header = req.headers[IDEMPOTENCY_HEADER];
+  const value = Array.isArray(header) ? header[0] : header;
+  if (typeof value === "string" && value.trim()) return value.trim();
+  return randomUUID();
+}
+
 function parsePrincipal(req: IncomingMessage): PrincipalContext | null {
   const raw = req.headers[PRINCIPAL_HEADER];
   const value = Array.isArray(raw) ? raw[0] : raw;
@@ -313,8 +362,8 @@ function debugAuthLog(req: IncomingMessage, requestUrl: URL): void {
 
 function applyCorsHeaders(res: ServerResponse): void {
   res.setHeader("access-control-allow-origin", "*");
-  res.setHeader("access-control-allow-methods", "GET,POST,OPTIONS");
-  res.setHeader("access-control-allow-headers", "content-type,x-mesh-principal");
+  res.setHeader("access-control-allow-methods", "GET,POST,PATCH,DELETE,OPTIONS");
+  res.setHeader("access-control-allow-headers", "content-type,x-mesh-principal,x-idempotency-key");
 }
 
 function maskForOtherPrincipal(principal: string): Record<string, "mask"> {

--- a/apps/mesh-graph-server/test/graph-mutations.test.ts
+++ b/apps/mesh-graph-server/test/graph-mutations.test.ts
@@ -1,0 +1,55 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { startMeshGraphServer, type MeshGraphServerHandle } from "../src/index";
+
+describe("mesh graph server mutations", () => {
+  const startedServers: MeshGraphServerHandle[] = [];
+
+  afterEach(async () => {
+    await Promise.all(startedServers.splice(0).map((server) => server.close()));
+  });
+
+  it("deletes links, deletes nodes with link cascade, and renames nodes", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "mesh-graph-server-mutations-"));
+    const server = await startMeshGraphServer({ storageDir, port: 0 });
+    startedServers.push(server);
+
+    const headers = { "content-type": "application/json", "x-mesh-principal": "local-dev" };
+    await fetch(`${server.url}/graph/nodes`, { method: "POST", headers, body: JSON.stringify({ id: "A", label: "A" }) });
+    await fetch(`${server.url}/graph/nodes`, { method: "POST", headers, body: JSON.stringify({ id: "B", label: "B" }) });
+    await fetch(`${server.url}/graph/links`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ id: "L1", source: "A", target: "B", type: "related" })
+    });
+
+    const deleteLink = await fetch(`${server.url}/graph/links/L1`, { method: "DELETE", headers });
+    expect(deleteLink.status).toBe(200);
+
+    await fetch(`${server.url}/graph/links`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ id: "L2", source: "A", target: "B", type: "related" })
+    });
+
+    const rename = await fetch(`${server.url}/graph/nodes/A`, {
+      method: "PATCH",
+      headers,
+      body: JSON.stringify({ label: "A-renamed" })
+    });
+    expect(rename.status).toBe(200);
+
+    const deleteNode = await fetch(`${server.url}/graph/nodes/A`, { method: "DELETE", headers });
+    expect(deleteNode.status).toBe(200);
+
+    const viewResponse = await fetch(`${server.url}/graph/view`, { headers });
+    const view = (await viewResponse.json()) as { nodes: Array<{ id: string; label: string }>; links: Array<{ id: string }> };
+
+    expect(view.nodes.find((node) => node.id === "A")).toBeUndefined();
+    expect(view.nodes.find((node) => node.id === "B")).toBeDefined();
+    expect(view.links.find((link) => link.id === "L1")).toBeUndefined();
+    expect(view.links.find((link) => link.id === "L2")).toBeUndefined();
+  });
+});

--- a/apps/mesh-graph-server/test/vitest.config.ts
+++ b/apps/mesh-graph-server/test/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: [resolve(__dirname, "root-route-auth.test.ts")]
+    include: [resolve(__dirname, "root-route-auth.test.ts"), resolve(__dirname, "graph-mutations.test.ts")]
   },
   resolve: {
     alias: {

--- a/docs/mesh-explorer-ui-undo-redo.md
+++ b/docs/mesh-explorer-ui-undo-redo.md
@@ -1,0 +1,7 @@
+# Mesh Explorer UI: Canon vs UI-local layout, Undo/Redo limits
+
+- Graph state is canonical and event-sourced: UI projection applies graph events from sync (`sync:poll` / `sync:subscribe`) via `applyGraphEvents`.
+- 2D layout positions are UI-local only (force layout), never persisted as canonical graph data.
+- Undo/Redo in the UI is implemented with compensating commands (`graph.node.label.updated`, `graph.node.deleted`, `graph.link.deleted`, and recreate commands).
+- Node/link snapshots used by Undo/Redo intentionally exclude viewport positions.
+- Undo determinism depends on explicit IDs for create-node/create-link snapshots. The server accepts explicit `id` payloads on create endpoints.

--- a/packages/mesh-explorer-ui/src/graphCanvas2d.ts
+++ b/packages/mesh-explorer-ui/src/graphCanvas2d.ts
@@ -28,6 +28,9 @@ export type GraphCanvasCallbacks = {
   onSelectionClear: () => void;
   onEdgeDraftChange: (edgeDraft: EdgeDraft | null) => void;
   onCreateEdge: (source: string, target: string) => void;
+  onSelectedEdgeIdsChange?: (ids: string[]) => void;
+  onRequestDelete?: (selection: { kind: "none" } | { kind: "node"; nodeId: string } | { kind: "link"; linkId: string }) => void;
+  onRequestRename?: (nodeId: string) => void;
   onCameraChange?: (camera: CameraState) => void;
   onFitRequest?: () => void;
 };
@@ -669,6 +672,7 @@ export class GraphCanvas2D {
           ? null
           : hitTestEdges(this.readModel.links, this.nodePositions(), this.ui.camera, { x: event.offsetX, y: event.offsetY });
         this.selectedEdgeIds = nextSelectedEdgeIds(this.selectedEdgeIds, { nodeHit: hit, edgeHit, shiftKey: event.shiftKey });
+        this.callbacks.onSelectedEdgeIdsChange?.(Array.from(this.selectedEdgeIds));
         if (hit) {
           const next = nextEdgeDraft(this.ui.edgeDraft, hit, pointerWorld);
           this.edgeDraftCursorWorldPos = next.edgeDraft ? pointerWorld : null;
@@ -707,6 +711,22 @@ export class GraphCanvas2D {
       if (event.key === "Escape") {
         this.edgeDraftCursorWorldPos = null;
         this.callbacks.onEdgeDraftChange(null);
+      }
+      if ((event.key === "Delete" || event.key === "Backspace") && !isTextInputTarget(event.target)) {
+        const selectedNodeId = this.readModel.selectedNodeIds.values().next().value as string | undefined;
+        const selectedLinkId = this.selectedEdgeIds.values().next().value as string | undefined;
+        if (selectedNodeId) {
+          this.callbacks.onRequestDelete?.({ kind: "node", nodeId: selectedNodeId });
+          return;
+        }
+        if (selectedLinkId) {
+          this.callbacks.onRequestDelete?.({ kind: "link", linkId: selectedLinkId });
+          return;
+        }
+      }
+      if (event.key.toLowerCase() === "r" && !isTextInputTarget(event.target)) {
+        const selectedNodeId = this.readModel.selectedNodeIds.values().next().value as string | undefined;
+        if (selectedNodeId) this.callbacks.onRequestRename?.(selectedNodeId);
       }
       if (event.key.toLowerCase() === "f") this.callbacks.onFitRequest?.();
     });
@@ -819,6 +839,12 @@ export class GraphCanvas2D {
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
+}
+
+function isTextInputTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName.toLowerCase();
+  return tag === "input" || tag === "textarea" || target.isContentEditable;
 }
 
 function fnv1a32(value: string): number {

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -19,10 +19,12 @@ import {
 import {
   computeGraphBounds,
   fitCameraToBounds,
-  GraphCanvas2D,
   type CameraState,
   type CanvasUiState
 } from "./graphCanvas2d.js";
+import { CanvasGraphViewport2D } from "./viewport/CanvasGraphViewport2D.js";
+import type { GraphViewportActions, GraphViewportModel, Selection } from "./viewport/graphViewportContract.js";
+import { UndoRedoManager, getIncidentLinks } from "./undoRedo.js";
 import { LayoutPanel } from "./ui/LayoutPanel.js";
 import { deriveLayoutParams, loadLayoutUiState, saveLayoutUiState, type LayoutUiState } from "./ui/layoutSettings.js";
 
@@ -58,6 +60,10 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
         <div id="lastSync">last sync: n/a</div>
         <hr/>
         <button id="addNode">Add node</button>
+        <button id="renameSelected" style="margin-left:8px;">Rename</button>
+        <button id="deleteSelected" style="margin-left:8px;">Delete</button>
+        <button id="undoAction" style="margin-left:8px;">Undo</button>
+        <button id="redoAction" style="margin-left:8px;">Redo</button>
         <button id="fitGraph" style="margin-left:8px;">Fit</button>
         <div id="layoutPanelHost"></div>
         <div style="margin-top:8px;padding:8px;border:1px solid #ddd;border-radius:8px;">
@@ -98,7 +104,9 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     dragSelectionRect: null
   };
 
-  let canvasRenderer: GraphCanvas2D | null = null;
+  let canvasRenderer: CanvasGraphViewport2D | null = null;
+  let selectedLinkIds = new Set<string>();
+  const undoRedo = new UndoRedoManager();
   let layoutUiState: LayoutUiState = loadLayoutUiState();
   const debugThrottleByEvent = new Map<string, number>();
 
@@ -141,6 +149,31 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   };
 
   el.fitGraph.onclick = () => fitCameraToCurrentGraph();
+  el.deleteSelected.onclick = () => {
+    void requestDelete(currentSelection());
+  };
+  el.renameSelected.onclick = () => {
+    const selection = currentSelection();
+    if (selection.kind !== "node") return;
+    void requestRename(selection.nodeId);
+  };
+  el.undoAction.onclick = () => {
+    void undoRedo.undo().catch((error) => reportDevError(el, `undo failed: ${String(error)}`, error));
+  };
+  el.redoAction.onclick = () => {
+    void undoRedo.redo().catch((error) => reportDevError(el, `redo failed: ${String(error)}`, error));
+  };
+  window.addEventListener("keydown", (event) => {
+    if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "z" && !event.shiftKey) {
+      event.preventDefault();
+      void undoRedo.undo().catch((error) => reportDevError(el, `undo failed: ${String(error)}`, error));
+      return;
+    }
+    if ((event.ctrlKey || event.metaKey) && (event.key.toLowerCase() === "y" || (event.key.toLowerCase() === "z" && event.shiftKey))) {
+      event.preventDefault();
+      void undoRedo.redo().catch((error) => reportDevError(el, `redo failed: ${String(error)}`, error));
+    }
+  });
 
   installTestHook(store);
   syncSession += 1;
@@ -270,12 +303,14 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
 
   async function addNode(label: string): Promise<void> {
     try {
+      const idempotencyKey = crypto.randomUUID();
       const response = await meshFetch(`${el.baseUrl.value}/graph/nodes`, {
         method: "POST",
-        headers: headers(el.principal.value),
-        body: JSON.stringify({ label, idempotencyKey: crypto.randomUUID() })
+        headers: headers(el.principal.value, idempotencyKey),
+        body: JSON.stringify({ label, idempotencyKey })
       }, { principal: el.principal.value, transport: "fetch", debugAuth, onNetworkResult: (status) => markNetworkConnectivity(status, "add-node") });
       if (!response.ok) reportDevError(el, `add node failed: ${response.status}`);
+      if (response.ok) undoRedo.clearRedo();
     } catch (error) {
       reportDevError(el, `add node failed: ${String(error)}`, error);
     }
@@ -284,23 +319,133 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   async function createLinkFromDraft(source: string, target: string): Promise<void> {
     const type = el.linkType.value.trim() || "related";
     try {
+      const idempotencyKey = crypto.randomUUID();
       const response = await meshFetch(`${el.baseUrl.value}/graph/links`, {
         method: "POST",
-        headers: headers(el.principal.value),
-        body: JSON.stringify({ source, target, type, idempotencyKey: crypto.randomUUID() })
+        headers: headers(el.principal.value, idempotencyKey),
+        body: JSON.stringify({ source, target, type, idempotencyKey })
       }, { principal: el.principal.value, transport: "fetch", debugAuth, onNetworkResult: (status) => markNetworkConnectivity(status, "create-link") });
       if (!response.ok) reportDevError(el, `create link rejected: ${response.status}`);
+      if (response.ok) undoRedo.clearRedo();
     } catch (error) {
       reportDevError(el, `add link failed: ${String(error)}`, error);
     }
   }
 
+  async function createNodeFromSnapshot(node: GraphNode): Promise<void> {
+    const idempotencyKey = crypto.randomUUID();
+    const response = await meshFetch(`${el.baseUrl.value}/graph/nodes`, {
+      method: "POST",
+      headers: headers(el.principal.value, idempotencyKey),
+      body: JSON.stringify({ ...node, idempotencyKey })
+    }, { principal: el.principal.value, transport: "fetch", debugAuth, onNetworkResult: (status) => markNetworkConnectivity(status, "create-node-snapshot") });
+    if (!response.ok) throw new Error(`create node failed: ${response.status}`);
+  }
+
+  async function createLinkFromSnapshot(link: GraphLink): Promise<void> {
+    const idempotencyKey = crypto.randomUUID();
+    const response = await meshFetch(`${el.baseUrl.value}/graph/links`, {
+      method: "POST",
+      headers: headers(el.principal.value, idempotencyKey),
+      body: JSON.stringify({ ...link, idempotencyKey })
+    }, { principal: el.principal.value, transport: "fetch", debugAuth, onNetworkResult: (status) => markNetworkConnectivity(status, "create-link-snapshot") });
+    if (!response.ok) throw new Error(`create link failed: ${response.status}`);
+  }
+
+  async function deleteLink(linkId: string): Promise<void> {
+    const idempotencyKey = crypto.randomUUID();
+    const response = await meshFetch(`${el.baseUrl.value}/graph/links/${encodeURIComponent(linkId)}`, {
+      method: "DELETE",
+      headers: headers(el.principal.value, idempotencyKey)
+    }, { principal: el.principal.value, transport: "fetch", debugAuth, onNetworkResult: (status) => markNetworkConnectivity(status, "delete-link") });
+    if (!response.ok) throw new Error(`delete link failed: ${response.status}`);
+  }
+
+  async function deleteNode(nodeId: string): Promise<void> {
+    const idempotencyKey = crypto.randomUUID();
+    const response = await meshFetch(`${el.baseUrl.value}/graph/nodes/${encodeURIComponent(nodeId)}`, {
+      method: "DELETE",
+      headers: headers(el.principal.value, idempotencyKey)
+    }, { principal: el.principal.value, transport: "fetch", debugAuth, onNetworkResult: (status) => markNetworkConnectivity(status, "delete-node") });
+    if (!response.ok) throw new Error(`delete node failed: ${response.status}`);
+  }
+
+  async function renameNode(nodeId: string, label: string): Promise<void> {
+    const idempotencyKey = crypto.randomUUID();
+    const response = await meshFetch(`${el.baseUrl.value}/graph/nodes/${encodeURIComponent(nodeId)}`, {
+      method: "PATCH",
+      headers: headers(el.principal.value, idempotencyKey),
+      body: JSON.stringify({ label, idempotencyKey })
+    }, { principal: el.principal.value, transport: "fetch", debugAuth, onNetworkResult: (status) => markNetworkConnectivity(status, "rename-node") });
+    if (!response.ok) throw new Error(`rename node failed: ${response.status}`);
+  }
+
+  function currentSelection(): Selection {
+    const selectedNodeId = store.getState().selectedNodeIds.values().next().value as string | undefined;
+    const selectedLinkId = selectedLinkIds.values().next().value as string | undefined;
+    if (selectedNodeId) return { kind: "node", nodeId: selectedNodeId };
+    if (selectedLinkId) return { kind: "link", linkId: selectedLinkId };
+    return { kind: "none" };
+  }
+
+  async function requestDelete(selection: Selection): Promise<void> {
+    try {
+      if (selection.kind === "link") {
+        const link = store.getState().linksById.get(selection.linkId);
+        if (!link) return;
+        await undoRedo.recordDeleteLink(link, { renameNode, deleteLink, deleteNode, createNodeFromSnapshot, createLinkFromSnapshot });
+        return;
+      }
+      if (selection.kind === "node") {
+        const node = store.getState().nodesById.get(selection.nodeId);
+        if (!node) return;
+        const incidentLinks = getIncidentLinks(store.getState(), selection.nodeId);
+        await undoRedo.recordDeleteNode(node, incidentLinks, { renameNode, deleteLink, deleteNode, createNodeFromSnapshot, createLinkFromSnapshot });
+      }
+    } catch (error) {
+      reportDevError(el, `delete failed: ${String(error)}`, error);
+    }
+  }
+
+  async function requestRename(nodeId: string): Promise<void> {
+    const node = store.getState().nodesById.get(nodeId);
+    if (!node) return;
+    const nextLabel = prompt("Node label", node.label)?.trim();
+    if (!nextLabel || nextLabel === node.label) return;
+    try {
+      await undoRedo.recordRename(nodeId, node.label, nextLabel, { renameNode, deleteLink, deleteNode, createNodeFromSnapshot, createLinkFromSnapshot });
+    } catch (error) {
+      reportDevError(el, `rename failed: ${String(error)}`, error);
+    }
+  }
+
   function setupRenderer(): void {
     try {
-      canvasRenderer = new GraphCanvas2D(el.graphCanvas, { nodes: [], links: [], selectedNodeIds: new Set() }, uiState, {
-        onSelectionReplace: (ids) => store.replaceSelection(ids),
-        onSelectionToggle: (id) => store.toggleSelectNode(id),
+      const viewportActions: GraphViewportActions = {
+        onSelect: () => undefined,
+        onRequestDelete: (selection) => {
+          void requestDelete(selection);
+        },
+        onRequestRename: (nodeId) => {
+          void requestRename(nodeId);
+        },
+        onCreateLink: (source, target) => {
+          void createLinkFromDraft(source, target);
+        }
+      };
+      const initialModel: GraphViewportModel = { nodes: [], links: [], selectedNodeIds: new Set() };
+      canvasRenderer = new CanvasGraphViewport2D(el.graphCanvas, {
+        model: initialModel,
+        actions: viewportActions,
+        options: { connectivity: "degraded", debug: layoutUiState.settings.debugLogs },
+        uiState,
+        camera: cameraInfo,
+        onSelectionReplaceNodeIds: (ids) => store.replaceSelection(ids),
+        onSelectionToggleNodeId: (id) => store.toggleSelectNode(id),
         onSelectionClear: () => store.clearSelection(),
+        onSelectedLinkIdsChange: (ids) => {
+          selectedLinkIds = new Set(ids);
+        },
         onEdgeDraftChange: (edgeDraft) => {
           uiState.edgeDraft = edgeDraft;
           updateSelectionUi(store.getState());
@@ -310,9 +455,6 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
             selectedNodeIds: store.getState().selectedNodeIds
           }, uiState);
         },
-        onCreateEdge: (source, target) => {
-          void createLinkFromDraft(source, target);
-        },
         onCameraChange: (camera) => {
           hasUserMovedCamera = true;
           cameraInfo = camera;
@@ -320,8 +462,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
         },
         onFitRequest: () => {
           fitCameraToCurrentGraph();
-        }
-      }, {
+        },
         layoutParams: deriveLayoutParams(layoutUiState.settings),
         warmupMode: layoutUiState.settings.warmupMode,
         debugLogsEnabled: layoutUiState.settings.debugLogs,
@@ -356,7 +497,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       },
       onReheat: () => {
         emitUiDebugLog("ui.keydown", { key: "Reheat" });
-        canvasRenderer?.reheatLayout();
+        canvasRenderer?.reheat();
       },
       onFit: () => {
         emitUiDebugLog("ui.keydown", { key: "Fit" });
@@ -504,6 +645,10 @@ type UiElements = {
   connect: HTMLButtonElement;
   addNode: HTMLButtonElement;
   fitGraph: HTMLButtonElement;
+  renameSelected: HTMLButtonElement;
+  deleteSelected: HTMLButtonElement;
+  undoAction: HTMLButtonElement;
+  redoAction: HTMLButtonElement;
   linkType: HTMLInputElement;
   linkSelectionHint: HTMLDivElement;
   status: HTMLDivElement;
@@ -524,6 +669,10 @@ function byId(container: HTMLElement): UiElements {
     connect: container.querySelector("#connect") as HTMLButtonElement,
     addNode: container.querySelector("#addNode") as HTMLButtonElement,
     fitGraph: container.querySelector("#fitGraph") as HTMLButtonElement,
+    renameSelected: container.querySelector("#renameSelected") as HTMLButtonElement,
+    deleteSelected: container.querySelector("#deleteSelected") as HTMLButtonElement,
+    undoAction: container.querySelector("#undoAction") as HTMLButtonElement,
+    redoAction: container.querySelector("#redoAction") as HTMLButtonElement,
     linkType: container.querySelector("#linkType") as HTMLInputElement,
     linkSelectionHint: container.querySelector("#linkSelectionHint") as HTMLDivElement,
     status: container.querySelector("#status") as HTMLDivElement,
@@ -537,11 +686,13 @@ function byId(container: HTMLElement): UiElements {
   };
 }
 
-function headers(principal: string): HeadersInit {
-  return {
+function headers(principal: string, idempotencyKey?: string): HeadersInit {
+  const next: Record<string, string> = {
     "content-type": "application/json",
     "x-mesh-principal": normalizePrincipal(principal)
   };
+  if (idempotencyKey) next["x-idempotency-key"] = idempotencyKey;
+  return next;
 }
 
 type MeshFetchMeta = {

--- a/packages/mesh-explorer-ui/src/undoRedo.ts
+++ b/packages/mesh-explorer-ui/src/undoRedo.ts
@@ -1,0 +1,91 @@
+import type { GraphLink, GraphNode, GraphState } from "./graphStore.js";
+
+type UndoKind = "rename" | "deleteLink" | "deleteNode";
+
+type UndoItem = {
+  kind: UndoKind;
+  undo: () => Promise<void>;
+  redo: () => Promise<void>;
+};
+
+export type UndoRedoActions = {
+  renameNode: (nodeId: string, label: string) => Promise<void>;
+  deleteLink: (linkId: string) => Promise<void>;
+  deleteNode: (nodeId: string) => Promise<void>;
+  createNodeFromSnapshot: (node: GraphNode) => Promise<void>;
+  createLinkFromSnapshot: (link: GraphLink) => Promise<void>;
+};
+
+export class UndoRedoManager {
+  private undoStack: UndoItem[] = [];
+  private redoStack: UndoItem[] = [];
+
+  canUndo(): boolean {
+    return this.undoStack.length > 0;
+  }
+
+  canRedo(): boolean {
+    return this.redoStack.length > 0;
+  }
+
+  clearRedo(): void {
+    this.redoStack = [];
+  }
+
+  async recordRename(nodeId: string, labelBefore: string, labelAfter: string, actions: UndoRedoActions): Promise<void> {
+    await actions.renameNode(nodeId, labelAfter);
+    this.push({
+      kind: "rename",
+      undo: async () => actions.renameNode(nodeId, labelBefore),
+      redo: async () => actions.renameNode(nodeId, labelAfter)
+    });
+  }
+
+  async recordDeleteLink(link: GraphLink, actions: UndoRedoActions): Promise<void> {
+    await actions.deleteLink(link.id);
+    this.push({
+      kind: "deleteLink",
+      undo: async () => actions.createLinkFromSnapshot(link),
+      redo: async () => actions.deleteLink(link.id)
+    });
+  }
+
+  async recordDeleteNode(node: GraphNode, incidentLinks: GraphLink[], actions: UndoRedoActions): Promise<void> {
+    await actions.deleteNode(node.id);
+    this.push({
+      kind: "deleteNode",
+      undo: async () => {
+        await actions.createNodeFromSnapshot(node);
+        for (const link of incidentLinks) {
+          await actions.createLinkFromSnapshot(link);
+        }
+      },
+      redo: async () => actions.deleteNode(node.id)
+    });
+  }
+
+  async undo(): Promise<void> {
+    const item = this.undoStack.at(-1);
+    if (!item) return;
+    await item.undo();
+    this.undoStack = this.undoStack.slice(0, -1);
+    this.redoStack.push(item);
+  }
+
+  async redo(): Promise<void> {
+    const item = this.redoStack.at(-1);
+    if (!item) return;
+    await item.redo();
+    this.redoStack = this.redoStack.slice(0, -1);
+    this.undoStack.push(item);
+  }
+
+  private push(item: UndoItem): void {
+    this.undoStack.push(item);
+    this.redoStack = [];
+  }
+}
+
+export function getIncidentLinks(state: GraphState, nodeId: string): GraphLink[] {
+  return Array.from(state.linksById.values()).filter((link) => link.source === nodeId || link.target === nodeId);
+}

--- a/packages/mesh-explorer-ui/src/viewport/CanvasGraphViewport2D.ts
+++ b/packages/mesh-explorer-ui/src/viewport/CanvasGraphViewport2D.ts
@@ -1,0 +1,122 @@
+import {
+  GraphCanvas2D,
+  type CameraState,
+  type CanvasUiState,
+  type EdgeDraft,
+  type LayoutParams,
+  type Vec2
+} from "../graphCanvas2d.js";
+import type { GraphCanvasReadModel } from "../graphCanvas2d.js";
+import type { GraphViewportActions, GraphViewportHandle, GraphViewportModel, GraphViewportOptions, Selection } from "./graphViewportContract.js";
+
+export type CanvasGraphViewport2DOptions = {
+  model: GraphViewportModel;
+  actions: GraphViewportActions;
+  options: GraphViewportOptions;
+  uiState: CanvasUiState;
+  camera: CameraState;
+  onSelectionReplaceNodeIds: (ids: string[]) => void;
+  onSelectionToggleNodeId: (id: string) => void;
+  onSelectionClear: () => void;
+  onSelectedLinkIdsChange: (ids: string[]) => void;
+  onEdgeDraftChange: (edgeDraft: EdgeDraft | null) => void;
+  onCameraChange: (camera: CameraState) => void;
+  onFitRequest: () => void;
+  layoutParams: Partial<LayoutParams>;
+  warmupMode: "OFF" | "SOFT" | "HARD";
+  debugLogsEnabled: boolean;
+  debugLog: (event: string, payload?: Record<string, unknown>, throttleMs?: number) => void;
+};
+
+export class CanvasGraphViewport2D implements GraphViewportHandle {
+  private readonly renderer: GraphCanvas2D;
+
+  constructor(private readonly canvas: HTMLCanvasElement, private readonly config: CanvasGraphViewport2DOptions) {
+    this.renderer = new GraphCanvas2D(
+      canvas,
+      toReadModel(config.model),
+      config.uiState,
+      {
+        onSelectionReplace: (ids) => {
+          config.onSelectionReplaceNodeIds(ids);
+          config.actions.onSelect(ids[0] ? { kind: "node", nodeId: ids[0] } : { kind: "none" });
+        },
+        onSelectionToggle: (id) => {
+          config.onSelectionToggleNodeId(id);
+          config.actions.onSelect({ kind: "node", nodeId: id });
+        },
+        onSelectionClear: () => {
+          config.onSelectionClear();
+          config.actions.onSelect({ kind: "none" });
+        },
+        onSelectedEdgeIdsChange: (ids) => {
+          config.onSelectedLinkIdsChange(ids);
+          config.actions.onSelect(ids[0] ? { kind: "link", linkId: ids[0] } : { kind: "none" });
+        },
+        onEdgeDraftChange: config.onEdgeDraftChange,
+        onCreateEdge: (source, target) => config.actions.onCreateLink?.(source, target),
+        onCameraChange: config.onCameraChange,
+        onFitRequest: config.onFitRequest,
+        onRequestDelete: (selection) => config.actions.onRequestDelete(toSelection(selection)),
+        onRequestRename: (nodeId) => config.actions.onRequestRename(nodeId)
+      },
+      {
+        layoutParams: config.layoutParams,
+        warmupMode: config.warmupMode,
+        debugLogsEnabled: config.debugLogsEnabled,
+        debugLog: config.debugLog
+      }
+    );
+  }
+
+  update(model: GraphViewportModel, uiState: CanvasUiState): void {
+    this.renderer.update(toReadModel(model), uiState);
+  }
+
+  destroy(): void {
+    this.renderer.destroy();
+  }
+
+  resize(): void {
+    this.renderer.resize();
+  }
+
+  setLayoutParams(params: Partial<LayoutParams>): void {
+    this.renderer.setLayoutParams(params);
+  }
+
+  setWarmupMode(mode: "OFF" | "SOFT" | "HARD"): void {
+    this.renderer.setWarmupMode(mode);
+  }
+
+  setDebugLogsEnabled(enabled: boolean): void {
+    this.renderer.setDebugLogsEnabled(enabled);
+  }
+
+  getNodePositions(): Map<string, Vec2> {
+    return this.renderer.getNodePositions();
+  }
+
+  fit(): void {
+    this.config.onFitRequest();
+  }
+
+  reheat(alpha = 0.9): void {
+    this.renderer.reheatLayout();
+    if (alpha < 0.9) this.renderer.reheatLayout();
+  }
+}
+
+function toReadModel(model: GraphViewportModel): GraphCanvasReadModel {
+  return {
+    nodes: model.nodes,
+    links: model.links,
+    selectedNodeIds: model.selectedNodeIds ?? new Set()
+  };
+}
+
+function toSelection(selection: { kind: "none" } | { kind: "node"; nodeId: string } | { kind: "link"; linkId: string }): Selection {
+  if (selection.kind === "node") return { kind: "node", nodeId: selection.nodeId };
+  if (selection.kind === "link") return { kind: "link", linkId: selection.linkId };
+  return { kind: "none" };
+}

--- a/packages/mesh-explorer-ui/src/viewport/graphViewportContract.ts
+++ b/packages/mesh-explorer-ui/src/viewport/graphViewportContract.ts
@@ -1,0 +1,55 @@
+export type GraphId = string;
+
+export type ViewNode = {
+  id: GraphId;
+  label: string;
+  x?: number;
+  y?: number;
+  z?: number;
+};
+
+export type ViewLink = {
+  id: GraphId;
+  source: GraphId;
+  target: GraphId;
+  type: string;
+  label?: string;
+};
+
+export type Selection =
+  | { kind: "none" }
+  | { kind: "node"; nodeId: GraphId }
+  | { kind: "link"; linkId: GraphId };
+
+export type Connectivity = "online" | "degraded" | "offline";
+
+export type GraphViewportModel = {
+  nodes: ViewNode[];
+  links: ViewLink[];
+  selectedNodeIds?: Set<GraphId>;
+};
+
+export type GraphViewportActions = {
+  onSelect(sel: Selection): void;
+  onRequestDelete(sel: Selection): void;
+  onRequestRename(nodeId: GraphId): void;
+  onCreateLink?(sourceId: GraphId, targetId: GraphId): void;
+};
+
+export type GraphViewportOptions = {
+  connectivity: Connectivity;
+  debug?: boolean;
+  layout?: {
+    repulsion?: number;
+    edgeLength?: number;
+    collision?: number;
+    reactivity?: number;
+    warmupMode?: "off" | "soft" | "hard";
+  };
+};
+
+export type GraphViewportHandle = {
+  fit(): void;
+  reheat(alpha?: number): void;
+  exportLayoutJSON?(): unknown;
+};

--- a/packages/mesh-explorer-ui/test/undoRedo.test.ts
+++ b/packages/mesh-explorer-ui/test/undoRedo.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import { UndoRedoManager } from "../src/undoRedo.js";
+
+const makeActions = () => ({
+  renameNode: vi.fn(async () => undefined),
+  deleteLink: vi.fn(async () => undefined),
+  deleteNode: vi.fn(async () => undefined),
+  createNodeFromSnapshot: vi.fn(async () => undefined),
+  createLinkFromSnapshot: vi.fn(async () => undefined)
+});
+
+describe("undo redo manager", () => {
+  it("supports rename undo/redo", async () => {
+    const manager = new UndoRedoManager();
+    const actions = makeActions();
+
+    await manager.recordRename("n1", "before", "after", actions);
+    await manager.undo();
+    await manager.redo();
+
+    expect(actions.renameNode).toHaveBeenNthCalledWith(1, "n1", "after");
+    expect(actions.renameNode).toHaveBeenNthCalledWith(2, "n1", "before");
+    expect(actions.renameNode).toHaveBeenNthCalledWith(3, "n1", "after");
+  });
+
+  it("supports delete link undo/redo", async () => {
+    const manager = new UndoRedoManager();
+    const actions = makeActions();
+    const link = { id: "l1", source: "a", target: "b", type: "related" };
+
+    await manager.recordDeleteLink(link, actions);
+    await manager.undo();
+    await manager.redo();
+
+    expect(actions.deleteLink).toHaveBeenNthCalledWith(1, "l1");
+    expect(actions.createLinkFromSnapshot).toHaveBeenNthCalledWith(1, link);
+    expect(actions.deleteLink).toHaveBeenNthCalledWith(2, "l1");
+  });
+
+  it("supports delete node undo/redo with incident links", async () => {
+    const manager = new UndoRedoManager();
+    const actions = makeActions();
+    const node = { id: "a", label: "A" };
+    const links = [{ id: "l2", source: "a", target: "b", type: "related" }];
+
+    await manager.recordDeleteNode(node, links, actions);
+    await manager.undo();
+    await manager.redo();
+
+    expect(actions.deleteNode).toHaveBeenNthCalledWith(1, "a");
+    expect(actions.createNodeFromSnapshot).toHaveBeenNthCalledWith(1, node);
+    expect(actions.createLinkFromSnapshot).toHaveBeenNthCalledWith(1, links[0]);
+    expect(actions.deleteNode).toHaveBeenNthCalledWith(2, "a");
+  });
+});

--- a/tests/e2e/mesh-explorer-ui-store.spec.ts
+++ b/tests/e2e/mesh-explorer-ui-store.spec.ts
@@ -16,4 +16,28 @@ describe("mesh explorer ui store", () => {
     unsubscribe();
     expect(observed).toBeGreaterThanOrEqual(3);
   });
+
+  it("applies rename, deleteLink and deleteNode cascade", () => {
+    const store = createGraphStore();
+    store.applyGraphEvents([
+      { type: "graph.node.created", node: { id: "A", label: "A" } },
+      { type: "graph.node.created", node: { id: "B", label: "B" } },
+      { type: "graph.link.created", link: { id: "L", source: "A", target: "B", type: "related" } }
+    ]);
+
+    store.applyGraphEvents([{ type: "graph.node.label.updated", nodeId: "A", label: "A2" }]);
+    expect(store.getState().nodesById.get("A")?.label).toBe("A2");
+
+    store.applyGraphEvents([{ type: "graph.link.deleted", linkId: "L" }]);
+    expect(store.getState().linksById.has("L")).toBe(false);
+
+    store.applyGraphEvents([
+      { type: "graph.link.created", link: { id: "L2", source: "A", target: "B", type: "related" } },
+      { type: "graph.node.deleted", nodeId: "A" }
+    ]);
+
+    expect(store.getState().nodesById.has("A")).toBe(false);
+    expect(store.getState().linksById.has("L2")).toBe(false);
+  });
+
 });


### PR DESCRIPTION
### Motivation
- Provide canonical server endpoints for node rename and delete, and link delete, so UI can submit canonical mutations reliably via the command submission flow.\
- Support idempotent client commands via a unified idempotency key transport and CORS updates.\
- Offer basic Undo/Redo for canonical mutations through compensating commands and minimal snapshots to improve UX without persisting UI-local layout.\
- Decouple app logic from renderer implementation by introducing a `GraphViewport` contract so the viewport engine (2D/3D) can be swapped later.\

### Description
- Server: added `PATCH /graph/nodes/:nodeId`, `DELETE /graph/links/:linkId`, and `DELETE /graph/nodes/:nodeId` in `apps/mesh-graph-server/src/index.ts`, submitting canonical events (`graph.node.label.updated`, `graph.link.deleted`, `graph.node.deleted`) via `submitGraphCommand(...)`, and added `readIdempotencyKey(...)` to accept `x-idempotency-key` (header or body fallback); updated CORS to allow `PATCH`/`DELETE` and `x-idempotency-key`.\
- UI: added actions and transport wiring in `packages/mesh-explorer-ui/src/index.ts` for `renameNode`, `deleteLink`, `deleteNode`, plus helpers `createNodeFromSnapshot`/`createLinkFromSnapshot`; all requests include idempotency keys and do not mutate local projection directly (state updates arrive via `store.applyGraphEvents`).\
- Undo/Redo: new minimal manager `packages/mesh-explorer-ui/src/undoRedo.ts` implementing compensating commands for `rename`, `deleteLink`, and `deleteNode` (node undo restores incident links from a snapshot); helper `getIncidentLinks` captures incident links before destructive commands.\
- Viewport contract and adapter: added `packages/mesh-explorer-ui/src/viewport/graphViewportContract.ts` and a Canvas adapter `CanvasGraphViewport2D` that wraps the existing `GraphCanvas2D`, exposing `GraphViewportModel`, `GraphViewportActions`, and `GraphViewportHandle` so the app no longer depends directly on renderer internals.\
- Renderer integration: extended `GraphCanvas2D` callbacks to report selected edge IDs and to surface delete/rename intents from keyboard shortcuts (Delete/Backspace and `r`) so UI action layer can handle them.\
- Tests and docs: added server mutation test `apps/mesh-graph-server/test/graph-mutations.test.ts`, undo/redo unit tests `packages/mesh-explorer-ui/test/undoRedo.test.ts`, and store event-application test update `tests/e2e/mesh-explorer-ui-store.spec.ts`; added developer note `docs/mesh-explorer-ui-undo-redo.md` documenting canonical vs UI-local layout and Undo limits.\

### Testing
- Built UI: ran `pnpm --filter @mesh/mesh-explorer-ui build` (succeeded).\
- Server tests: ran `pnpm --dir apps/mesh-graph-server exec vitest run -c test/vitest.config.ts` and included the new `graph-mutations.test.ts` (all server tests passed).\
- UI unit/e2e tests: ran `pnpm vitest run tests/e2e/mesh-explorer-ui-store.spec.ts packages/mesh-explorer-ui/test/undoRedo.test.ts` (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69976dbc38208321b0ae2cc84396e1fe)