### PR TITLE
Add dev graph IO: Export / Import / Clear controls and graph IO helpers

### DIFF
--- a/apps/mesh-graph-server/test/graph-mutations.test.ts
+++ b/apps/mesh-graph-server/test/graph-mutations.test.ts
@@ -52,4 +52,25 @@ describe("mesh graph server mutations", () => {
     expect(view.links.find((link) => link.id === "L1")).toBeUndefined();
     expect(view.links.find((link) => link.id === "L2")).toBeUndefined();
   });
+
+  it("keeps explicit ids for node/link create payloads", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "mesh-graph-server-create-id-"));
+    const server = await startMeshGraphServer({ storageDir, port: 0 });
+    startedServers.push(server);
+
+    const headers = { "content-type": "application/json", "x-mesh-principal": "local-dev" };
+    await fetch(`${server.url}/graph/nodes`, { method: "POST", headers, body: JSON.stringify({ id: "Node-Explicit", label: "Node" }) });
+    await fetch(`${server.url}/graph/nodes`, { method: "POST", headers, body: JSON.stringify({ id: "Node-Target", label: "Target" }) });
+    await fetch(`${server.url}/graph/links`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ id: "Link-Explicit", source: "Node-Explicit", target: "Node-Target", type: "related" })
+    });
+
+    const viewResponse = await fetch(`${server.url}/graph/view`, { headers });
+    const view = (await viewResponse.json()) as { nodes: Array<{ id: string }>; links: Array<{ id: string }> };
+
+    expect(view.nodes.some((node) => node.id === "Node-Explicit")).toBe(true);
+    expect(view.links.some((link) => link.id === "Link-Explicit")).toBe(true);
+  });
 });

--- a/docs/mesh-explorer-graph-devtools.md
+++ b/docs/mesh-explorer-graph-devtools.md
@@ -1,0 +1,17 @@
+# Mesh Explorer Graph Devtools JSON (v1)
+
+`Export Graph` produit un payload JSON canonique minimal (sans layout UI local):
+
+```json
+{
+  "version": 1,
+  "nodes": [{ "id": "A", "label": "Alpha", "level": 1, "metadata": { "env": "dev" } }],
+  "links": [{ "id": "L1", "source": "A", "target": "B", "type": "related", "label": "depends-on" }]
+}
+```
+
+Limites:
+
+- Le format n'embarque pas les positions/zoom/layout (données UI-locales).
+- `Import Graph` exécute les créations en ordre strict: nodes puis links.
+- `Clear Graph` supprime les nodes une par une via API canonique; les links incidentes sont supprimées par cascade des reducers de projection.

--- a/packages/mesh-explorer-ui/src/devtools/graphIo.ts
+++ b/packages/mesh-explorer-ui/src/devtools/graphIo.ts
@@ -1,0 +1,95 @@
+import type { GraphLink, GraphNode, GraphState } from "../graphStore.js";
+
+export type ExportedGraphNode = {
+  id: string;
+  label: string;
+  level?: number;
+  metadata?: Record<string, unknown>;
+};
+
+export type ExportedGraphLink = {
+  id: string;
+  source: string;
+  target: string;
+  type: string;
+  label?: string;
+};
+
+export type ExportedGraphV1 = {
+  version: 1;
+  nodes: ExportedGraphNode[];
+  links: ExportedGraphLink[];
+};
+
+export function exportGraphFromState(state: Pick<GraphState, "nodesById" | "linksById">): ExportedGraphV1 {
+  const nodes: ExportedGraphNode[] = Array.from(state.nodesById.values()).map((node: GraphNode) => ({
+    id: node.id,
+    label: node.label,
+    level: node.level,
+    metadata: node.metadata
+  }));
+
+  const links: ExportedGraphLink[] = Array.from(state.linksById.values())
+    .filter((link: GraphLink) => state.nodesById.has(link.source) && state.nodesById.has(link.target))
+    .map((link: GraphLink) => ({
+      id: link.id,
+      source: link.source,
+      target: link.target,
+      type: link.type,
+      label: link.label
+    }));
+
+  return { version: 1, nodes, links };
+}
+
+export function parseExportedGraph(raw: unknown): ExportedGraphV1 {
+  if (!isRecord(raw) || raw.version !== 1 || !Array.isArray(raw.nodes) || !Array.isArray(raw.links)) {
+    throw new Error("Invalid graph export payload: expected { version: 1, nodes: [], links: [] }");
+  }
+
+  const nodes = raw.nodes.map((node, index) => parseNode(node, index));
+  const nodeIds = new Set(nodes.map((node) => node.id));
+  const links = raw.links.map((link, index) => parseLink(link, index, nodeIds));
+  return { version: 1, nodes, links };
+}
+
+function parseNode(raw: unknown, index: number): ExportedGraphNode {
+  if (!isRecord(raw) || typeof raw.id !== "string" || typeof raw.label !== "string") {
+    throw new Error(`Invalid node at index ${index}`);
+  }
+  if (raw.level !== undefined && typeof raw.level !== "number") {
+    throw new Error(`Invalid node.level at index ${index}`);
+  }
+  if (raw.metadata !== undefined && !isRecord(raw.metadata)) {
+    throw new Error(`Invalid node.metadata at index ${index}`);
+  }
+  return {
+    id: raw.id,
+    label: raw.label,
+    level: raw.level,
+    metadata: raw.metadata as Record<string, unknown> | undefined
+  };
+}
+
+function parseLink(raw: unknown, index: number, nodeIds: Set<string>): ExportedGraphLink {
+  if (!isRecord(raw) || typeof raw.id !== "string" || typeof raw.source !== "string" || typeof raw.target !== "string" || typeof raw.type !== "string") {
+    throw new Error(`Invalid link at index ${index}`);
+  }
+  if (raw.label !== undefined && typeof raw.label !== "string") {
+    throw new Error(`Invalid link.label at index ${index}`);
+  }
+  if (!nodeIds.has(raw.source) || !nodeIds.has(raw.target)) {
+    throw new Error(`Link at index ${index} references unknown node`);
+  }
+  return {
+    id: raw.id,
+    source: raw.source,
+    target: raw.target,
+    type: raw.type,
+    label: raw.label
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -27,6 +27,7 @@ import type { GraphViewportActions, GraphViewportModel, Selection } from "./view
 import { UndoRedoManager, getIncidentLinks } from "./undoRedo.js";
 import { LayoutPanel } from "./ui/LayoutPanel.js";
 import { deriveLayoutParams, loadLayoutUiState, saveLayoutUiState, type LayoutUiState } from "./ui/layoutSettings.js";
+import { exportGraphFromState, parseExportedGraph, type ExportedGraphV1 } from "./devtools/graphIo.js";
 
 type Cursor = { metaSeq: number; graphSeq: number };
 type GraphData = { nodes: GraphNode[]; links: GraphLink[] };
@@ -380,6 +381,32 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     if (!response.ok) throw new Error(`rename node failed: ${response.status}`);
   }
 
+  function exportGraph(): ExportedGraphV1 {
+    return exportGraphFromState(store.getState());
+  }
+
+  async function importGraph(data: ExportedGraphV1): Promise<void> {
+    for (let index = 0; index < data.nodes.length; index += 1) {
+      const node = data.nodes[index];
+      reportDevInfo(el, `importing nodes ${index + 1}/${data.nodes.length}`);
+      await createNodeFromSnapshot(node);
+    }
+
+    for (let index = 0; index < data.links.length; index += 1) {
+      const link = data.links[index];
+      reportDevInfo(el, `importing links ${index + 1}/${data.links.length}`);
+      await createLinkFromSnapshot(link);
+    }
+  }
+
+  async function clearGraph(): Promise<void> {
+    const nodeIds = Array.from(store.getState().nodesById.keys());
+    for (let index = 0; index < nodeIds.length; index += 1) {
+      reportDevInfo(el, `clearing ${index + 1}/${nodeIds.length}`);
+      await deleteNode(nodeIds[index]);
+    }
+  }
+
   function currentSelection(): Selection {
     const selectedNodeId = store.getState().selectedNodeIds.values().next().value as string | undefined;
     const selectedLinkId = selectedLinkIds.values().next().value as string | undefined;
@@ -502,6 +529,46 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       onFit: () => {
         emitUiDebugLog("ui.keydown", { key: "Fit" });
         fitCameraToCurrentGraph();
+      },
+      onExportGraph: async () => {
+        try {
+          const payload = exportGraph();
+          const json = JSON.stringify(payload, null, 2);
+          const blob = new Blob([json], { type: "application/json" });
+          const url = URL.createObjectURL(blob);
+          const link = document.createElement("a");
+          link.href = url;
+          link.download = "mesh-graph.json";
+          document.body.appendChild(link);
+          link.click();
+          link.remove();
+          URL.revokeObjectURL(url);
+          if (navigator.clipboard?.writeText) {
+            await navigator.clipboard.writeText(json);
+          }
+          reportDevInfo(el, `graph exported (${payload.nodes.length} nodes, ${payload.links.length} links)`);
+        } catch (error) {
+          reportDevError(el, `graph export failed: ${String(error)}`, error);
+        }
+      },
+      onImportGraph: (file) => {
+        void (async () => {
+          try {
+            reportDevInfo(el, `reading ${file.name}...`);
+            const raw = await file.text();
+            const parsed = parseExportedGraph(JSON.parse(raw));
+            await importGraph(parsed);
+            reportDevInfo(el, `graph imported (${parsed.nodes.length} nodes, ${parsed.links.length} links)`);
+          } catch (error) {
+            reportDevError(el, `graph import failed: ${String(error)}`, error);
+          }
+        })();
+      },
+      onClearGraph: () => {
+        if (!window.confirm("Are you sure you want to clear the graph?")) return;
+        void clearGraph()
+          .then(() => reportDevInfo(el, "graph cleared"))
+          .catch((error) => reportDevError(el, `graph clear failed: ${String(error)}`, error));
       }
     });
   }
@@ -877,6 +944,13 @@ function asGraphEvent(value: unknown): GraphEvent | null {
 
 function reportDevError(el: Pick<UiElements, "devBanner">, message: string, error?: unknown): void {
   console.error("[mesh-explorer]", message, error);
+  if (!isDebugEnabled()) return;
+  el.devBanner.style.display = "block";
+  el.devBanner.textContent = message;
+}
+
+function reportDevInfo(el: Pick<UiElements, "devBanner">, message: string): void {
+  console.info("[mesh-explorer]", message);
   if (!isDebugEnabled()) return;
   el.devBanner.style.display = "block";
   el.devBanner.textContent = message;

--- a/packages/mesh-explorer-ui/src/ui/LayoutPanel.ts
+++ b/packages/mesh-explorer-ui/src/ui/LayoutPanel.ts
@@ -5,6 +5,9 @@ type LayoutPanelCallbacks = {
   onPanelStateChange: (next: DevPanelState) => void;
   onReheat: () => void;
   onFit: () => void;
+  onExportGraph: () => void;
+  onImportGraph: (file: File) => void;
+  onClearGraph: () => void;
 };
 
 type LayoutPanelOptions = {
@@ -87,6 +90,40 @@ export class LayoutPanel {
     actions.appendChild(exportJson);
 
     this.panelBody.appendChild(actions);
+
+    const graphActions = document.createElement("div");
+    graphActions.style.display = "flex";
+    graphActions.style.gap = "6px";
+    graphActions.style.marginTop = "8px";
+    graphActions.style.flexWrap = "wrap";
+
+    const exportGraph = document.createElement("button");
+    exportGraph.textContent = "Export Graph";
+    exportGraph.onclick = () => this.callbacks.onExportGraph();
+    graphActions.appendChild(exportGraph);
+
+    const importGraph = document.createElement("button");
+    importGraph.textContent = "Import Graph";
+    const importInput = document.createElement("input");
+    importInput.type = "file";
+    importInput.accept = "application/json";
+    importInput.style.display = "none";
+    importInput.onchange = () => {
+      const [file] = Array.from(importInput.files ?? []);
+      if (!file) return;
+      this.callbacks.onImportGraph(file);
+      importInput.value = "";
+    };
+    importGraph.onclick = () => importInput.click();
+    graphActions.appendChild(importGraph);
+    graphActions.appendChild(importInput);
+
+    const clearGraph = document.createElement("button");
+    clearGraph.textContent = "Clear Graph";
+    clearGraph.onclick = () => this.callbacks.onClearGraph();
+    graphActions.appendChild(clearGraph);
+
+    this.panelBody.appendChild(graphActions);
   }
 
   private updateSettings(patch: Partial<LayoutSettings>): void {

--- a/packages/mesh-explorer-ui/test/graphIo.test.ts
+++ b/packages/mesh-explorer-ui/test/graphIo.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { exportGraphFromState, parseExportedGraph } from "../src/devtools/graphIo.js";
+
+describe("graph io", () => {
+  it("serializes minimal graph payload from state", () => {
+    const payload = exportGraphFromState({
+      nodesById: new Map([
+        ["n1", { id: "n1", label: "Alpha", level: 1, metadata: { env: "test" } }],
+        ["n2", { id: "n2", label: "Beta" }]
+      ]),
+      linksById: new Map([
+        ["l1", { id: "l1", source: "n1", target: "n2", type: "related", label: "edge" }]
+      ])
+    });
+
+    expect(payload).toEqual({
+      version: 1,
+      nodes: [
+        { id: "n1", label: "Alpha", level: 1, metadata: { env: "test" } },
+        { id: "n2", label: "Beta", level: undefined, metadata: undefined }
+      ],
+      links: [
+        { id: "l1", source: "n1", target: "n2", type: "related", label: "edge" }
+      ]
+    });
+  });
+
+  it("rejects links referencing unknown nodes", () => {
+    expect(() => parseExportedGraph({
+      version: 1,
+      nodes: [{ id: "n1", label: "Alpha" }],
+      links: [{ id: "l1", source: "n1", target: "n2", type: "related" }]
+    })).toThrow(/references unknown node/);
+  });
+});


### PR DESCRIPTION
### Motivation
- Manual testing of graph mutations (delete/rename/undo/redo) is tedious without deterministic reset and reproducible scenarios, so dev-first tools to clear, export and import the canonical graph are required.
- The tools must operate via canonical endpoints (`/graph/*`), keep UI projection-driven state, and avoid exporting UI-local layout positions.

### Description
- Added three dev controls to the Layout panel: `Export Graph`, `Import Graph` (file picker), and `Clear Graph`, and wired new callbacks in `LayoutPanel`. (packages/mesh-explorer-ui/src/ui/LayoutPanel.ts)
- Implemented `packages/mesh-explorer-ui/src/devtools/graphIo.ts` defining `ExportedGraphV1`, a serializer `exportGraphFromState`, and a validated parser `parseExportedGraph` for the v1 JSON format.
- Implemented runtime actions in the UI (`exportGraph`, `importGraph`, `clearGraph`) that use the projection store and only call canonical endpoints (`POST /graph/nodes`, `POST /graph/links`, `DELETE /graph/nodes/:id`) through existing create/delete helpers so projection sync remains the source of truth. (packages/mesh-explorer-ui/src/index.ts)
- Added lightweight status/progress messages displayed in the existing dev banner and a small developer doc describing the format and limitations. (docs/mesh-explorer-graph-devtools.md)
- Added unit tests for graph IO serialization and validation, and an integration test ensuring explicit `id` values in create payloads are preserved by the server. (packages/mesh-explorer-ui/test/graphIo.test.ts, apps/mesh-graph-server/test/graph-mutations.test.ts)

### Testing
- Ran TypeScript build for the UI with `pnpm --filter @mesh/mesh-explorer-ui build` and the build succeeded.
- Ran unit tests `pnpm vitest run packages/mesh-explorer-ui/test/graphIo.test.ts` and they passed (2 tests).
- Built the graph server with `pnpm --filter @mesh/graph-server build` and ran server tests with `pnpm vitest run --config apps/mesh-graph-server/test/vitest.config.ts apps/mesh-graph-server/test/graph-mutations.test.ts`, and both tests passed (2 tests).
- Note: an initial combined vitest run failed due to a test environment resolution issue for server tests, but rerunning the server tests with the server config passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998452599cc8321b76759a27e4a4f04)