### PR TITLE
Mesh Explorer UX: fit timing/reset, spawn shortcuts, multi-delete, parallel-link curvature, undo reset

### DIFF
--- a/packages/mesh-explorer-ui/src/deleteSelection.ts
+++ b/packages/mesh-explorer-ui/src/deleteSelection.ts
@@ -1,0 +1,23 @@
+import type { GraphState } from "./graphStore.js";
+
+export type MultiDeletePlan = {
+  nodeIds: string[];
+  linkIds: string[];
+};
+
+export function buildMultiDeletePlan(state: Pick<GraphState, "selectedNodeIds" | "linksById">, selectedLinkIds: Set<string>): MultiDeletePlan {
+  const nodeIds = Array.from(state.selectedNodeIds).sort((left, right) => left.localeCompare(right));
+  const selectedLinksStable = Array.from(selectedLinkIds).sort((left, right) => left.localeCompare(right));
+  if (nodeIds.length === 0) {
+    return { nodeIds: [], linkIds: selectedLinksStable };
+  }
+
+  const selectedNodeSet = new Set(nodeIds);
+  const linkIds = selectedLinksStable.filter((linkId) => {
+    const link = state.linksById.get(linkId);
+    if (!link) return false;
+    return !selectedNodeSet.has(link.source) && !selectedNodeSet.has(link.target);
+  });
+
+  return { nodeIds, linkIds };
+}

--- a/packages/mesh-explorer-ui/src/graphCanvas2d.ts
+++ b/packages/mesh-explorer-ui/src/graphCanvas2d.ts
@@ -9,9 +9,11 @@ type LayoutNode = { id: string; x: number; y: number; vx: number; vy: number; fx
 
 type LayoutLink = { source: string; target: string };
 
+export type CanvasLink = { id: string; source: string; target: string; type?: string; curvature?: number };
+
 export type GraphCanvasReadModel = {
   nodes: GraphNode[];
-  links: GraphLink[];
+  links: CanvasLink[];
   selectedNodeIds: Set<string>;
 };
 
@@ -142,7 +144,7 @@ export function computeEdgeHitSlopWorld(camera: CameraState): number {
 }
 
 export function hitTestEdges(
-  links: Array<{ id: string; source: string; target: string }>,
+  links: Array<{ id: string; source: string; target: string; curvature?: number }>,
   nodePositions: Map<string, Vec2>,
   camera: CameraState,
   screenPoint: Vec2
@@ -155,11 +157,78 @@ export function hitTestEdges(
     const aWorld = nodePositions.get(link.source);
     const bWorld = nodePositions.get(link.target);
     if (!aWorld || !bWorld) continue;
+    if (Math.abs(link.curvature ?? 0) > 0.0001) {
+      const curvedHit = hitTestCurvedEdge(worldPoint, aWorld, bWorld, link.curvature ?? 0, edgeSlopWorld);
+      if (curvedHit) return link.id;
+      continue;
+    }
     if (hitTestEdge(worldPoint, { aWorld, bWorld }, edgeSlopWorld)) {
       return link.id;
     }
   }
   return null;
+}
+
+function hitTestCurvedEdge(worldPoint: Vec2, source: Vec2, target: Vec2, curvature: number, edgeSlopWorld: number): boolean {
+  const control = getCurvedControlPoint(source, target, curvature);
+  const segments = 12;
+  let prev = source;
+  for (let i = 1; i <= segments; i += 1) {
+    const t = i / segments;
+    const point = quadraticBezierPoint(source, control, target, t);
+    if (distancePointToSegment(worldPoint, prev, point) <= edgeSlopWorld) return true;
+    prev = point;
+  }
+  return false;
+}
+
+function quadraticBezierPoint(a: Vec2, c: Vec2, b: Vec2, t: number): Vec2 {
+  const mt = 1 - t;
+  const x = mt * mt * a.x + 2 * mt * t * c.x + t * t * b.x;
+  const y = mt * mt * a.y + 2 * mt * t * c.y + t * t * b.y;
+  return { x, y };
+}
+
+export function computeParallelLinkCurvatures(links: CanvasLink[], curvatureStep = 0.15): Map<string, number> {
+  const grouped = new Map<string, CanvasLink[]>();
+  for (const link of links) {
+    const a = link.source < link.target ? link.source : link.target;
+    const b = link.source < link.target ? link.target : link.source;
+    const key = `${a}|${b}|${link.type ?? ""}`;
+    const group = grouped.get(key);
+    if (group) {
+      group.push(link);
+    } else {
+      grouped.set(key, [link]);
+    }
+  }
+
+  const output = new Map<string, number>();
+  for (const group of grouped.values()) {
+    const sorted = [...group].sort((left, right) => left.id.localeCompare(right.id));
+    const center = (sorted.length - 1) / 2;
+    for (let index = 0; index < sorted.length; index += 1) {
+      const link = sorted[index]!;
+      const base = (index - center) * curvatureStep;
+      const directionSign = link.source.localeCompare(link.target) <= 0 ? 1 : -1;
+      output.set(link.id, base * directionSign);
+    }
+  }
+  return output;
+}
+
+function getCurvedControlPoint(source: Vec2, target: Vec2, curvature: number): Vec2 {
+  const midX = (source.x + target.x) / 2;
+  const midY = (source.y + target.y) / 2;
+  const dx = target.x - source.x;
+  const dy = target.y - source.y;
+  const length = Math.hypot(dx, dy) || 1;
+  const nx = -dy / length;
+  const ny = dx / length;
+  return {
+    x: midX + nx * length * curvature,
+    y: midY + ny * length * curvature
+  };
 }
 
 export function computeGraphBounds(nodes: Array<{ position: Vec2 }>): { minX: number; minY: number; maxX: number; maxY: number } | null {
@@ -336,6 +405,18 @@ export class ForceLayout2D {
     delete node.fy;
   }
 
+  seedNodePosition(nodeId: string, position: Vec2): void {
+    const node = this.nodeById.get(nodeId);
+    if (!node) return;
+    delete node.fx;
+    delete node.fy;
+    node.x = position.x;
+    node.y = position.y;
+    node.vx = 0;
+    node.vy = 0;
+    this.reheat(0.35);
+  }
+
   tick(iterations = 1): void {
     for (let i = 0; i < iterations; i += 1) {
       if (this.alpha <= this.params.minAlpha) continue;
@@ -479,6 +560,8 @@ export class GraphCanvas2D {
   private readonly layout: ForceLayout2D;
   private renderRaf = 0;
   private pointer = { x: 0, y: 0 };
+  private pointerInsideCanvas = false;
+  private lastPointerScreenPos: Vec2 | null = null;
   private panning = false;
   private draggingNodeIds: string[] = [];
   private hoveredEdgeId: string | null = null;
@@ -548,6 +631,34 @@ export class GraphCanvas2D {
     this.debugLogsEnabled = enabled;
   }
 
+  seedNodePosition(nodeId: string, position: Vec2): void {
+    this.layout.seedNodePosition(nodeId, position);
+    this.requestRender();
+  }
+
+  getPreferredSpawnWorldPos(): Vec2 {
+    const pointerPos = this.getLastPointerWorldPos();
+    return pointerPos ?? this.getViewCenterWorldPos();
+  }
+
+  getLastPointerWorldPos(): Vec2 | null {
+    if (!this.pointerInsideCanvas || !this.lastPointerScreenPos) return null;
+    return screenToWorld(this.lastPointerScreenPos, this.ui.camera);
+  }
+
+  getViewCenterWorldPos(): Vec2 {
+    const rect = this.canvas.getBoundingClientRect();
+    return screenToWorld({ x: rect.width / 2, y: rect.height / 2 }, this.ui.camera);
+  }
+
+  nudgeZoomOut(factor = 0.96): void {
+    const rect = this.canvas.getBoundingClientRect();
+    const center = { x: rect.width / 2, y: rect.height / 2 };
+    this.ui.camera = zoomAtPoint(this.ui.camera, center, this.ui.camera.zoom * factor);
+    this.callbacks.onCameraChange?.(this.ui.camera);
+    this.requestRender();
+  }
+
   reheatLayout(): void {
     this.emitDebug("layout.reheat", { amount: 0.9, reason: "ui-reheat-button" });
     this.layout.reheat(0.9);
@@ -581,6 +692,8 @@ export class GraphCanvas2D {
         event.stopPropagation();
       }
       this.pointer = { x: event.offsetX, y: event.offsetY };
+      this.pointerInsideCanvas = true;
+      this.lastPointerScreenPos = { ...this.pointer };
       const hit = hitTestNode(this.positionedNodes(), this.ui.camera, this.pointer);
       if (event.button === 1 || event.ctrlKey || event.metaKey || event.altKey) {
         this.panning = true;
@@ -615,6 +728,8 @@ export class GraphCanvas2D {
 
     const onPointerMove = (event: PointerEvent) => {
       this.pointer = { x: event.offsetX, y: event.offsetY };
+      this.pointerInsideCanvas = true;
+      this.lastPointerScreenPos = { ...this.pointer };
       const pointerWorld = screenToWorld(this.pointer, this.ui.camera);
       if (this.ui.edgeDraft) this.edgeDraftCursorWorldPos = pointerWorld;
       if (this.panning) {
@@ -689,6 +804,9 @@ export class GraphCanvas2D {
     this.canvas.addEventListener("pointerdown", onPointerDown, { passive: false });
     this.canvas.addEventListener("pointermove", onPointerMove);
     this.canvas.addEventListener("pointerup", onPointerUp);
+    this.canvas.addEventListener("pointerleave", () => {
+      this.pointerInsideCanvas = false;
+    });
     this.canvas.addEventListener("pointercancel", onPointerUp);
     this.canvas.addEventListener("mousedown", (event) => {
       if (event.button === 1) {
@@ -770,7 +888,12 @@ export class GraphCanvas2D {
       this.ctx.lineWidth = 2 / this.ui.camera.zoom;
       this.ctx.beginPath();
       this.ctx.moveTo(source.x, source.y);
-      this.ctx.lineTo(target.x, target.y);
+      if (Math.abs(link.curvature ?? 0) > 0.0001) {
+        const control = getCurvedControlPoint(source, target, link.curvature ?? 0);
+        this.ctx.quadraticCurveTo(control.x, control.y, target.x, target.y);
+      } else {
+        this.ctx.lineTo(target.x, target.y);
+      }
       this.ctx.stroke();
     }
 

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -18,6 +18,7 @@ import {
 } from "./syncConfig.js";
 import {
   computeGraphBounds,
+  computeParallelLinkCurvatures,
   fitCameraToBounds,
   type CameraState,
   type CanvasUiState
@@ -28,6 +29,7 @@ import { UndoRedoManager, getIncidentLinks } from "./undoRedo.js";
 import { LayoutPanel } from "./ui/LayoutPanel.js";
 import { deriveLayoutParams, loadLayoutUiState, saveLayoutUiState, type LayoutUiState } from "./ui/layoutSettings.js";
 import { exportGraphFromState, parseExportedGraph, type ExportedGraphV1 } from "./devtools/graphIo.js";
+import { buildMultiDeletePlan } from "./deleteSelection.js";
 
 type Cursor = { metaSeq: number; graphSeq: number };
 type GraphData = { nodes: GraphNode[]; links: GraphLink[] };
@@ -91,6 +93,8 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   let activeAbort: AbortController | null = null;
   let hasUserMovedCamera = false;
   let autoFitApplied = false;
+  let autoFitRaf = 0;
+  let previousNodeCount = 0;
   let cameraInfo: CameraState = { x: -280, y: -180, zoom: 1, minZoom: 0.08, maxZoom: 3.5 };
   let browserConnectivityHint: ConnectivityStatus = navigator.onLine ? "online" : "offline";
   let networkConnectivityHint: ConnectivityStatus = "degraded";
@@ -107,6 +111,8 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
 
   let canvasRenderer: CanvasGraphViewport2D | null = null;
   let selectedLinkIds = new Set<string>();
+  let previousNodeIds = new Set<string>();
+  const pendingSpawnSeeds: Array<{ x: number; y: number }> = [];
   const undoRedo = new UndoRedoManager();
   let layoutUiState: LayoutUiState = loadLayoutUiState();
   const debugThrottleByEvent = new Map<string, number>();
@@ -128,11 +134,16 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       nodes: Array.from(snapshot.nodesById.values()),
       links: Array.from(snapshot.linksById.values()).filter((link: GraphLink) => snapshot.nodesById.has(link.source) && snapshot.nodesById.has(link.target))
     };
-    canvasRenderer?.update({ nodes: data.nodes, links: data.links, selectedNodeIds: snapshot.selectedNodeIds }, uiState);
-    if (!hasUserMovedCamera && !autoFitApplied && data.nodes.length > 0) {
-      const applied = fitCameraToCurrentGraph();
-      if (applied) autoFitApplied = true;
+    const curvatureByLinkId = computeParallelLinkCurvatures(data.links);
+    const viewLinks = data.links.map((link) => ({ ...link, curvature: curvatureByLinkId.get(link.id) ?? 0 }));
+    selectedLinkIds = new Set(Array.from(selectedLinkIds).filter((id) => snapshot.linksById.has(id)));
+    applyPendingSpawnSeeds(snapshot.nodesById);
+    canvasRenderer?.update({ nodes: data.nodes, links: viewLinks, selectedNodeIds: snapshot.selectedNodeIds }, uiState);
+    const transitionedToNonEmpty = previousNodeCount === 0 && data.nodes.length > 0;
+    if (!hasUserMovedCamera && !autoFitApplied && (transitionedToNonEmpty || data.nodes.length > 0)) {
+      scheduleAutoFit();
     }
+    previousNodeCount = data.nodes.length;
     updateSelectionUi(snapshot);
     renderStatus(snapshot, data.nodes.length, data.links.length);
   });
@@ -143,15 +154,12 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   };
 
   el.addNode.onclick = () => {
-    const label = prompt("Node label", "new node") ?? "";
-    if (!label) return;
-    dbg("add-node:submit", { label });
-    void addNode(label);
+    void promptAndCreateNode();
   };
 
   el.fitGraph.onclick = () => fitCameraToCurrentGraph();
   el.deleteSelected.onclick = () => {
-    void requestDelete(currentSelection());
+    void requestDelete();
   };
   el.renameSelected.onclick = () => {
     const selection = currentSelection();
@@ -173,6 +181,19 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     if ((event.ctrlKey || event.metaKey) && (event.key.toLowerCase() === "y" || (event.key.toLowerCase() === "z" && event.shiftKey))) {
       event.preventDefault();
       void undoRedo.redo().catch((error) => reportDevError(el, `redo failed: ${String(error)}`, error));
+      return;
+    }
+    if (isTextInputTarget(event.target)) return;
+    if (event.repeat) return;
+    if (event.ctrlKey || event.metaKey || event.altKey) return;
+    if (event.key === "n" && event.shiftKey) {
+      event.preventDefault();
+      void addNode(nextAutoNodeLabel(), { seedPosition: preferredSpawnWorldPos(), zoomOutFactor: 0.96 });
+      return;
+    }
+    if (event.key === "n" && !event.shiftKey) {
+      event.preventDefault();
+      void promptAndCreateNode(preferredSpawnWorldPos());
     }
   });
 
@@ -302,7 +323,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     }
   }
 
-  async function addNode(label: string): Promise<void> {
+  async function addNode(label: string, opts: { seedPosition?: { x: number; y: number }; zoomOutFactor?: number } = {}): Promise<void> {
     try {
       const idempotencyKey = crypto.randomUUID();
       const response = await meshFetch(`${el.baseUrl.value}/graph/nodes`, {
@@ -311,9 +332,75 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
         body: JSON.stringify({ label, idempotencyKey })
       }, { principal: el.principal.value, transport: "fetch", debugAuth, onNetworkResult: (status) => markNetworkConnectivity(status, "add-node") });
       if (!response.ok) reportDevError(el, `add node failed: ${response.status}`);
-      if (response.ok) undoRedo.clearRedo();
+      if (response.ok) {
+        if (opts.seedPosition) pendingSpawnSeeds.push(opts.seedPosition);
+        if (opts.zoomOutFactor) canvasRenderer?.nudgeZoomOut(opts.zoomOutFactor);
+        undoRedo.clearRedo();
+      }
     } catch (error) {
       reportDevError(el, `add node failed: ${String(error)}`, error);
+    }
+  }
+
+  async function promptAndCreateNode(seedPosition?: { x: number; y: number }): Promise<void> {
+    const label = prompt("Node label", "new node") ?? "";
+    if (!label) return;
+    dbg("add-node:submit", { label });
+    await addNode(label, { seedPosition });
+  }
+
+  function preferredSpawnWorldPos(): { x: number; y: number } {
+    if (canvasRenderer) return canvasRenderer.getPreferredSpawnWorldPos();
+    const rect = el.graphCanvas.getBoundingClientRect();
+    return {
+      x: cameraInfo.x + rect.width / (2 * cameraInfo.zoom),
+      y: cameraInfo.y + rect.height / (2 * cameraInfo.zoom)
+    };
+  }
+
+  function nextAutoNodeLabel(): string {
+    const used = new Set<number>();
+    for (const node of store.getState().nodesById.values()) {
+      const match = /^Node\s+(\d+)$/.exec(node.label.trim());
+      if (match) used.add(Number.parseInt(match[1]!, 10));
+    }
+    let index = 1;
+    while (used.has(index)) index += 1;
+    return `Node ${index}`;
+  }
+
+  function applyPendingSpawnSeeds(nodesById: Map<string, GraphNode>): void {
+    const nextNodeIds = new Set(nodesById.keys());
+    const addedNodeIds = Array.from(nextNodeIds).filter((id) => !previousNodeIds.has(id)).sort((left, right) => left.localeCompare(right));
+    for (const nodeId of addedNodeIds) {
+      const seed = pendingSpawnSeeds.shift();
+      if (!seed) break;
+      canvasRenderer?.seedNodePosition(nodeId, seed);
+    }
+    previousNodeIds = nextNodeIds;
+  }
+
+  function scheduleAutoFit(): void {
+    if (autoFitApplied || hasUserMovedCamera || autoFitRaf !== 0) return;
+    autoFitRaf = requestAnimationFrame(() => {
+      autoFitRaf = 0;
+      requestAnimationFrame(() => {
+        if (autoFitApplied || hasUserMovedCamera || store.getState().nodesById.size === 0) return;
+        const applied = fitCameraToCurrentGraph();
+        if (applied) autoFitApplied = true;
+      });
+    });
+  }
+
+  function resetAutoFitState(): void {
+    autoFitApplied = false;
+    hasUserMovedCamera = false;
+    previousNodeCount = 0;
+    pendingSpawnSeeds.length = 0;
+    previousNodeIds = new Set(store.getState().nodesById.keys());
+    if (autoFitRaf !== 0) {
+      cancelAnimationFrame(autoFitRaf);
+      autoFitRaf = 0;
     }
   }
 
@@ -386,6 +473,8 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   }
 
   async function importGraph(data: ExportedGraphV1): Promise<void> {
+    undoRedo.reset();
+    resetAutoFitState();
     for (let index = 0; index < data.nodes.length; index += 1) {
       const node = data.nodes[index];
       reportDevInfo(el, `importing nodes ${index + 1}/${data.nodes.length}`);
@@ -400,6 +489,8 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   }
 
   async function clearGraph(): Promise<void> {
+    undoRedo.reset();
+    resetAutoFitState();
     const nodeIds = Array.from(store.getState().nodesById.keys());
     for (let index = 0; index < nodeIds.length; index += 1) {
       reportDevInfo(el, `clearing ${index + 1}/${nodeIds.length}`);
@@ -415,20 +506,27 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     return { kind: "none" };
   }
 
-  async function requestDelete(selection: Selection): Promise<void> {
+  async function requestDelete(_selection?: Selection): Promise<void> {
     try {
-      if (selection.kind === "link") {
-        const link = store.getState().linksById.get(selection.linkId);
-        if (!link) return;
-        await undoRedo.recordDeleteLink(link, { renameNode, deleteLink, deleteNode, createNodeFromSnapshot, createLinkFromSnapshot });
-        return;
+      const state = store.getState();
+      const plan = buildMultiDeletePlan(state, selectedLinkIds);
+      if (plan.nodeIds.length === 0 && plan.linkIds.length === 0) return;
+
+      for (const nodeId of plan.nodeIds) {
+        const currentNode = store.getState().nodesById.get(nodeId);
+        if (!currentNode) continue;
+        const incidentLinks = getIncidentLinks(store.getState(), nodeId);
+        await undoRedo.recordDeleteNode(currentNode, incidentLinks, { renameNode, deleteLink, deleteNode, createNodeFromSnapshot, createLinkFromSnapshot });
       }
-      if (selection.kind === "node") {
-        const node = store.getState().nodesById.get(selection.nodeId);
-        if (!node) return;
-        const incidentLinks = getIncidentLinks(store.getState(), selection.nodeId);
-        await undoRedo.recordDeleteNode(node, incidentLinks, { renameNode, deleteLink, deleteNode, createNodeFromSnapshot, createLinkFromSnapshot });
+
+      for (const linkId of plan.linkIds) {
+        const currentLink = store.getState().linksById.get(linkId);
+        if (!currentLink) continue;
+        await undoRedo.recordDeleteLink(currentLink, { renameNode, deleteLink, deleteNode, createNodeFromSnapshot, createLinkFromSnapshot });
       }
+
+      store.clearSelection();
+      selectedLinkIds = new Set();
     } catch (error) {
       reportDevError(el, `delete failed: ${String(error)}`, error);
     }
@@ -484,6 +582,10 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
         },
         onCameraChange: (camera) => {
           hasUserMovedCamera = true;
+          if (autoFitRaf !== 0) {
+            cancelAnimationFrame(autoFitRaf);
+            autoFitRaf = 0;
+          }
           cameraInfo = camera;
           queueBadgeRender();
         },
@@ -997,6 +1099,13 @@ function readCursorFromTxBundles(txBundles: SyncTxBundle[]): number | null {
 
 function cursorEq(a: Cursor, b: Cursor): boolean {
   return a.metaSeq === b.metaSeq && a.graphSeq === b.graphSeq;
+}
+
+
+function isTextInputTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName.toLowerCase();
+  return tag === "input" || tag === "textarea" || target.isContentEditable;
 }
 
 async function wait(ms: number): Promise<void> {

--- a/packages/mesh-explorer-ui/src/undoRedo.ts
+++ b/packages/mesh-explorer-ui/src/undoRedo.ts
@@ -32,6 +32,15 @@ export class UndoRedoManager {
     this.redoStack = [];
   }
 
+  reset(): void {
+    this.undoStack = [];
+    this.redoStack = [];
+  }
+
+  debugStackSizes(): { undo: number; redo: number } {
+    return { undo: this.undoStack.length, redo: this.redoStack.length };
+  }
+
   async recordRename(nodeId: string, labelBefore: string, labelAfter: string, actions: UndoRedoActions): Promise<void> {
     await actions.renameNode(nodeId, labelAfter);
     this.push({

--- a/packages/mesh-explorer-ui/src/viewport/CanvasGraphViewport2D.ts
+++ b/packages/mesh-explorer-ui/src/viewport/CanvasGraphViewport2D.ts
@@ -105,6 +105,19 @@ export class CanvasGraphViewport2D implements GraphViewportHandle {
     this.renderer.reheatLayout();
     if (alpha < 0.9) this.renderer.reheatLayout();
   }
+
+  getPreferredSpawnWorldPos(): Vec2 {
+    return this.renderer.getPreferredSpawnWorldPos();
+  }
+
+  seedNodePosition(nodeId: string, position: Vec2): void {
+    this.renderer.seedNodePosition(nodeId, position);
+  }
+
+  nudgeZoomOut(factor = 0.96): void {
+    this.renderer.nudgeZoomOut(factor);
+  }
+
 }
 
 function toReadModel(model: GraphViewportModel): GraphCanvasReadModel {

--- a/packages/mesh-explorer-ui/src/viewport/graphViewportContract.ts
+++ b/packages/mesh-explorer-ui/src/viewport/graphViewportContract.ts
@@ -14,6 +14,7 @@ export type ViewLink = {
   target: GraphId;
   type: string;
   label?: string;
+  curvature?: number;
 };
 
 export type Selection =
@@ -51,5 +52,8 @@ export type GraphViewportOptions = {
 export type GraphViewportHandle = {
   fit(): void;
   reheat(alpha?: number): void;
+  getPreferredSpawnWorldPos(): { x: number; y: number };
+  seedNodePosition(nodeId: GraphId, position: { x: number; y: number }): void;
+  nudgeZoomOut(factor?: number): void;
   exportLayoutJSON?(): unknown;
 };

--- a/packages/mesh-explorer-ui/test/deleteSelection.test.ts
+++ b/packages/mesh-explorer-ui/test/deleteSelection.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { buildMultiDeletePlan } from "../src/deleteSelection.js";
+
+describe("buildMultiDeletePlan", () => {
+  it("returns node-only deletions in stable order", () => {
+    const plan = buildMultiDeletePlan({
+      selectedNodeIds: new Set(["n2", "n1"]),
+      linksById: new Map([
+        ["l1", { id: "l1", source: "n1", target: "n2", type: "related" }]
+      ])
+    }, new Set());
+
+    expect(plan).toEqual({ nodeIds: ["n1", "n2"], linkIds: [] });
+  });
+
+  it("drops selected links already removed by selected-node cascade", () => {
+    const plan = buildMultiDeletePlan({
+      selectedNodeIds: new Set(["n1", "n2"]),
+      linksById: new Map([
+        ["l1", { id: "l1", source: "n1", target: "n2", type: "related" }],
+        ["l2", { id: "l2", source: "n3", target: "n4", type: "related" }]
+      ])
+    }, new Set(["l2", "l1"]));
+
+    expect(plan).toEqual({ nodeIds: ["n1", "n2"], linkIds: ["l2"] });
+  });
+});

--- a/packages/mesh-explorer-ui/test/graphCanvas2d.test.ts
+++ b/packages/mesh-explorer-ui/test/graphCanvas2d.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { ForceLayout2D, GraphCanvas2D, computeEdgeHitSlopWorld, computeGraphBounds, computeMinZoomEffective, computeSeedRadius, distancePointToSegment, fitCameraToBounds, hitTestEdge, hitTestEdges, hitTestNode, nextEdgeDraft, nextSelectedEdgeIds, screenToWorld, seededNodePosition, worldToScreen, zoomAtPoint, type CameraState } from "../src/graphCanvas2d.js";
+import { ForceLayout2D, GraphCanvas2D, computeEdgeHitSlopWorld, computeGraphBounds, computeMinZoomEffective, computeParallelLinkCurvatures, computeSeedRadius, distancePointToSegment, fitCameraToBounds, hitTestEdge, hitTestEdges, hitTestNode, nextEdgeDraft, nextSelectedEdgeIds, screenToWorld, seededNodePosition, worldToScreen, zoomAtPoint, type CameraState } from "../src/graphCanvas2d.js";
 import { LAYOUT_LIMITS, deriveLayoutParams } from "../src/ui/layoutSettings.js";
 
 describe("graphCanvas2d transforms", () => {
@@ -449,5 +449,20 @@ describe("GraphCanvas2D topology guards and reheat", () => {
     expect(reheatSpy).toHaveBeenCalledWith(0.9);
     expect(restartSpy).toHaveBeenCalledTimes(1);
     renderer.destroy();
+  });
+});
+
+
+describe("parallel link curvature", () => {
+  it("assigns distinct curvature values for parallel links", () => {
+    const curvatureById = computeParallelLinkCurvatures([
+      { id: "l1", source: "a", target: "b", type: "related" },
+      { id: "l2", source: "a", target: "b", type: "related" },
+      { id: "l3", source: "a", target: "b", type: "related" }
+    ]);
+
+    const values = ["l1", "l2", "l3"].map((id) => curvatureById.get(id));
+    expect(new Set(values).size).toBe(3);
+    expect(values.some((value) => Math.abs(value ?? 0) > 0)).toBe(true);
   });
 });

--- a/packages/mesh-explorer-ui/test/undoRedo.test.ts
+++ b/packages/mesh-explorer-ui/test/undoRedo.test.ts
@@ -52,4 +52,15 @@ describe("undo redo manager", () => {
     expect(actions.createLinkFromSnapshot).toHaveBeenNthCalledWith(1, links[0]);
     expect(actions.deleteNode).toHaveBeenNthCalledWith(2, "a");
   });
+
+  it("resets undo/redo stacks", async () => {
+    const manager = new UndoRedoManager();
+    const actions = makeActions();
+
+    await manager.recordRename("n1", "before", "after", actions);
+    await manager.undo();
+    manager.reset();
+
+    expect(manager.debugStackSizes()).toEqual({ undo: 0, redo: 0 });
+  });
 });


### PR DESCRIPTION
### Motivation

- Fix an initial auto-fit timing/regression after `clearGraph()`/`importGraph()` and improve UX when adding nodes (small camera nudge instead of full fit).
- Provide keyboard-driven node creation (`n` / `Shift+n`) that seeds new nodes at the pointer or viewport center without pinning or persisting coordinates.
- Support multi-selection deletion semantics (nodes first, then remaining links) and ensure undo/redo is coherent after graph resets.
- Visually separate parallel links in the canvas renderer using a UI-only `curvature` value.

### Description

- Viewport contract and canvas: extended `GraphViewportHandle` with `getPreferredSpawnWorldPos()`, `seedNodePosition(nodeId, position)`, and `nudgeZoomOut(factor)` and implemented corresponding methods in `CanvasGraphViewport2D` and `GraphCanvas2D` to expose pointer-aware spawn position and zoom nudge behavior.
- Spawn & keyboard flow: added global shortcuts and logic in `mountMeshExplorerUi` so `n` opens a prompt and `Shift+n` creates an auto-labeled node (`Node 1`, `Node 2`, …); creation accepts UI-only `seedPosition` and an optional `zoomOutFactor` and enqueues seed positions to be applied when the server-synced node appears (no pin, no canonical x/y persistence).
- Auto-fit reset & scheduling: reset auto-fit state on `clearGraph()` and `importGraph()` and schedule a deferred auto-fit (double `requestAnimationFrame`) when the graph transitions empty→non-empty, avoiding stale bounds/timing issues.
- Multi-delete: added `buildMultiDeletePlan()` to compute stable deletion order, updated `requestDelete()` to delete selected nodes in stable order then remaining selected links, and added tests for the planner behavior.
- Undo/redo reset: added `reset()` to `UndoRedoManager` and call it on `clearGraph()`/`importGraph()` so old history is invalidated after graph resets.
- Parallel links: added `computeParallelLinkCurvatures()` to assign `curvature` per link group, extended read model to carry `curvature`, updated canvas renderer to draw quadratic bezier curves and added a curved-edge hit tester, keeping curvature UI-only.
- Tests & helpers: added `deleteSelection.ts` planner and tests, extended `graphCanvas2d` tests to assert curvature values, and added undo/redo stack-reset tests.

### Testing

- Ran unit tests with `pnpm vitest --run packages/mesh-explorer-ui/test/undoRedo.test.ts packages/mesh-explorer-ui/test/deleteSelection.test.ts packages/mesh-explorer-ui/test/graphCanvas2d.test.ts` and all tests passed (3 files, 40 tests total — green).
- Built the UI package with `pnpm -C packages/mesh-explorer-ui build` (TypeScript compile) which succeeded.
- Executed an automated browser run that exercises `Shift+N` spawn flows and captured a screenshot artifact to validate pointer/center spawn behavior (playwright run completed and produced a screenshot).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998ac4fc51c8321a7d88b0210edc625)