### PR TITLE
Fix post-merge Mesh Explorer regressions (refresh, spawn, selection, cinematic fit, leaks)

### DIFF
--- a/packages/mesh-explorer-ui/src/graphCanvas2d.ts
+++ b/packages/mesh-explorer-ui/src/graphCanvas2d.ts
@@ -297,6 +297,24 @@ export function nextSelectedEdgeIds(
   return new Set();
 }
 
+export function getPreferredSpawnWorldPos(params: {
+  lastPointerClientPos: Vec2 | null;
+  canvasRect: Pick<DOMRectReadOnly, "left" | "top" | "width" | "height">;
+  camera: CameraState;
+}): Vec2 {
+  const { lastPointerClientPos, canvasRect, camera } = params;
+  if (lastPointerClientPos) {
+    const inCanvas = lastPointerClientPos.x >= canvasRect.left
+      && lastPointerClientPos.x <= canvasRect.left + canvasRect.width
+      && lastPointerClientPos.y >= canvasRect.top
+      && lastPointerClientPos.y <= canvasRect.top + canvasRect.height;
+    if (inCanvas) {
+      return screenToWorld({ x: lastPointerClientPos.x - canvasRect.left, y: lastPointerClientPos.y - canvasRect.top }, camera);
+    }
+  }
+  return screenToWorld({ x: canvasRect.width / 2, y: canvasRect.height / 2 }, camera);
+}
+
 export function computeSeedRadius(nodeCount: number): number {
   return SEED_BASE * Math.sqrt(Math.max(1, nodeCount));
 }
@@ -556,13 +574,20 @@ export type GraphCanvasOptions = {
   debugLog?: GraphCanvasDebugLog;
 };
 
+const graphCanvasDevMetrics = {
+  activeCanvasInstances: 0,
+  activeResizeObservers: 0
+};
+
 export class GraphCanvas2D {
   private readonly ctx: CanvasRenderingContext2D;
   private readonly layout: ForceLayout2D;
   private renderRaf = 0;
   private pointer = { x: 0, y: 0 };
   private pointerInsideCanvas = false;
-  private lastPointerScreenPos: Vec2 | null = null;
+  private lastPointerClientPos: Vec2 | null = null;
+  private pendingDragNodeIds: string[] = [];
+  private pointerDownScreenPos: Vec2 | null = null;
   private panning = false;
   private draggingNodeIds: string[] = [];
   private hoveredEdgeId: string | null = null;
@@ -571,6 +596,7 @@ export class GraphCanvas2D {
   private debugLogsEnabled = false;
   private readonly debugLog?: GraphCanvasDebugLog;
   private resizeObserver: ResizeObserver | null = null;
+  private cleanupFns: Array<() => void> = [];
 
   constructor(
     private readonly canvas: HTMLCanvasElement,
@@ -590,6 +616,8 @@ export class GraphCanvas2D {
       onSoftWarmupFrame: () => this.requestRender(),
       onTick: () => this.requestRender()
     });
+    graphCanvasDevMetrics.activeCanvasInstances += 1;
+    (window as Window & { __meshCanvasStats?: () => unknown }).__meshCanvasStats = () => ({ ...graphCanvasDevMetrics });
     this.syncLayoutGraph("init");
     this.bindEvents();
     this.resize();
@@ -609,8 +637,15 @@ export class GraphCanvas2D {
 
   destroy(): void {
     if (this.renderRaf) cancelAnimationFrame(this.renderRaf);
-    this.resizeObserver?.disconnect();
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+      this.resizeObserver = null;
+      graphCanvasDevMetrics.activeResizeObservers = Math.max(0, graphCanvasDevMetrics.activeResizeObservers - 1);
+    }
+    for (const cleanup of this.cleanupFns) cleanup();
+    this.cleanupFns.length = 0;
     this.layout.destroy();
+    graphCanvasDevMetrics.activeCanvasInstances = Math.max(0, graphCanvasDevMetrics.activeCanvasInstances - 1);
   }
 
   getNodePositions(): Map<string, Vec2> {
@@ -639,13 +674,14 @@ export class GraphCanvas2D {
   }
 
   getPreferredSpawnWorldPos(): Vec2 {
-    const pointerPos = this.getLastPointerWorldPos();
-    return pointerPos ?? this.getViewCenterWorldPos();
+    const rect = this.canvas.getBoundingClientRect();
+    return getPreferredSpawnWorldPos({ lastPointerClientPos: this.lastPointerClientPos, canvasRect: rect, camera: this.ui.camera });
   }
 
   getLastPointerWorldPos(): Vec2 | null {
-    if (!this.pointerInsideCanvas || !this.lastPointerScreenPos) return null;
-    return screenToWorld(this.lastPointerScreenPos, this.ui.camera);
+    if (!this.pointerInsideCanvas || !this.lastPointerClientPos) return null;
+    const rect = this.canvas.getBoundingClientRect();
+    return screenToWorld({ x: this.lastPointerClientPos.x - rect.left, y: this.lastPointerClientPos.y - rect.top }, this.ui.camera);
   }
 
   getViewCenterWorldPos(): Vec2 {
@@ -658,6 +694,17 @@ export class GraphCanvas2D {
     const center = { x: rect.width / 2, y: rect.height / 2 };
     this.ui.camera = zoomAtPoint(this.ui.camera, center, this.ui.camera.zoom * factor);
     this.callbacks.onCameraChange?.(this.ui.camera);
+    this.requestRender();
+  }
+
+  clearTransientUiState(): void {
+    this.edgeDraftCursorWorldPos = null;
+    this.pendingDragNodeIds = [];
+    this.draggingNodeIds = [];
+    this.pointerDownScreenPos = null;
+    this.ui.hoveredNodeId = null;
+    this.ui.edgeDraft = null;
+    this.callbacks.onEdgeDraftChange(null);
     this.requestRender();
   }
 
@@ -695,8 +742,12 @@ export class GraphCanvas2D {
       }
       this.pointer = { x: event.offsetX, y: event.offsetY };
       this.pointerInsideCanvas = true;
-      this.lastPointerScreenPos = { ...this.pointer };
+      this.lastPointerClientPos = { x: event.clientX, y: event.clientY };
+      this.pointerDownScreenPos = { ...this.pointer };
       const hit = hitTestNode(this.positionedNodes(), this.ui.camera, this.pointer);
+      const edgeHit = hit
+        ? null
+        : hitTestEdges(this.readModel.links, this.nodePositions(), this.ui.camera, this.pointer);
       if (event.button === 1 || event.altKey) {
         this.panning = true;
         this.callbacks.onCameraChange?.(this.ui.camera);
@@ -714,16 +765,11 @@ export class GraphCanvas2D {
 
         if (this.readModel.selectedNodeIds.has(hit) || !event.shiftKey) {
           const selected = this.readModel.selectedNodeIds.has(hit) ? this.readModel.selectedNodeIds : new Set([hit]);
-          this.draggingNodeIds = Array.from(selected);
-          const pointerWorld = screenToWorld(this.pointer, this.ui.camera);
-          for (const id of this.draggingNodeIds) {
-            this.layout.setPin(id, pointerWorld);
-          }
-          this.emitDebug("ui.drag.start", { draggedCount: this.draggingNodeIds.length });
-          this.requestRender();
+          this.pendingDragNodeIds = Array.from(selected);
         }
       } else {
-        this.callbacks.onSelectionClear();
+        this.pendingDragNodeIds = [];
+        if (!edgeHit) this.callbacks.onSelectionClear();
       }
       this.canvas.setPointerCapture(event.pointerId);
     };
@@ -731,7 +777,7 @@ export class GraphCanvas2D {
     const onPointerMove = (event: PointerEvent) => {
       this.pointer = { x: event.offsetX, y: event.offsetY };
       this.pointerInsideCanvas = true;
-      this.lastPointerScreenPos = { ...this.pointer };
+      this.lastPointerClientPos = { x: event.clientX, y: event.clientY };
       const pointerWorld = screenToWorld(this.pointer, this.ui.camera);
       if (this.ui.edgeDraft) this.edgeDraftCursorWorldPos = pointerWorld;
       if (this.panning) {
@@ -743,6 +789,14 @@ export class GraphCanvas2D {
         this.callbacks.onCameraChange?.(this.ui.camera);
         this.requestRender();
         return;
+      }
+      const movement = this.pointerDownScreenPos
+        ? Math.hypot(this.pointer.x - this.pointerDownScreenPos.x, this.pointer.y - this.pointerDownScreenPos.y)
+        : 0;
+      if (this.draggingNodeIds.length === 0 && this.pendingDragNodeIds.length > 0 && movement > 3) {
+        this.draggingNodeIds = [...this.pendingDragNodeIds];
+        for (const id of this.draggingNodeIds) this.layout.setPin(id, pointerWorld);
+        this.emitDebug("ui.drag.start", { draggedCount: this.draggingNodeIds.length });
       }
       if (this.draggingNodeIds.length === 0) {
         this.ui.hoveredNodeId = hitTestNode(this.positionedNodes(), this.ui.camera, this.pointer);
@@ -766,6 +820,8 @@ export class GraphCanvas2D {
     const onPointerUp = (event: PointerEvent) => {
       this.emitDebug("ui.pointerup", { button: event.button });
       const wasDragging = this.draggingNodeIds.length > 0;
+      this.pendingDragNodeIds = [];
+      this.pointerDownScreenPos = null;
       if (wasDragging) {
         for (const id of this.draggingNodeIds) {
           this.layout.clearPin(id);
@@ -818,29 +874,41 @@ export class GraphCanvas2D {
     };
 
     this.canvas.addEventListener("pointerdown", onPointerDown, { passive: false });
+    this.cleanupFns.push(() => this.canvas.removeEventListener("pointerdown", onPointerDown));
     this.canvas.addEventListener("pointermove", onPointerMove);
+    this.cleanupFns.push(() => this.canvas.removeEventListener("pointermove", onPointerMove));
     this.canvas.addEventListener("pointerup", onPointerUp);
-    this.canvas.addEventListener("pointerleave", () => {
+    this.cleanupFns.push(() => this.canvas.removeEventListener("pointerup", onPointerUp));
+    const onPointerLeave = () => {
       this.pointerInsideCanvas = false;
-    });
+    };
+    this.canvas.addEventListener("pointerleave", onPointerLeave);
+    this.cleanupFns.push(() => this.canvas.removeEventListener("pointerleave", onPointerLeave));
     this.canvas.addEventListener("pointercancel", onPointerUp);
-    this.canvas.addEventListener("mousedown", (event) => {
+    this.cleanupFns.push(() => this.canvas.removeEventListener("pointercancel", onPointerUp));
+    const onMouseDown = (event: MouseEvent) => {
       if (event.button === 1) {
         event.preventDefault();
         event.stopPropagation();
       }
-    }, { passive: false });
-    this.canvas.addEventListener("auxclick", (event) => {
+    };
+    this.canvas.addEventListener("mousedown", onMouseDown, { passive: false });
+    this.cleanupFns.push(() => this.canvas.removeEventListener("mousedown", onMouseDown));
+    const onAuxClick = (event: MouseEvent) => {
       if (event.button === 1) event.preventDefault();
-    }, { passive: false });
-    this.canvas.addEventListener("wheel", (event) => {
+    };
+    this.canvas.addEventListener("auxclick", onAuxClick, { passive: false });
+    this.cleanupFns.push(() => this.canvas.removeEventListener("auxclick", onAuxClick));
+    const onWheel = (event: WheelEvent) => {
       event.preventDefault();
       const ratio = Math.exp(-event.deltaY * 0.0015);
       this.ui.camera = zoomAtPoint(this.ui.camera, { x: event.offsetX, y: event.offsetY }, this.ui.camera.zoom * ratio);
       this.callbacks.onCameraChange?.(this.ui.camera);
       this.requestRender();
-    }, { passive: false });
-    window.addEventListener("keydown", (event) => {
+    };
+    this.canvas.addEventListener("wheel", onWheel, { passive: false });
+    this.cleanupFns.push(() => this.canvas.removeEventListener("wheel", onWheel));
+    const onKeyDown = (event: KeyboardEvent) => {
       this.emitDebug("ui.keydown", { key: event.key });
       if (event.key === "Escape") {
         this.edgeDraftCursorWorldPos = null;
@@ -863,13 +931,18 @@ export class GraphCanvas2D {
         if (selectedNodeId) this.callbacks.onRequestRename?.(selectedNodeId);
       }
       if (event.key.toLowerCase() === "f") this.callbacks.onFitRequest?.();
-    });
+    };
+    window.addEventListener("keydown", onKeyDown);
+    this.cleanupFns.push(() => window.removeEventListener("keydown", onKeyDown));
     const host = this.canvas.parentElement;
     if (host && typeof ResizeObserver !== "undefined") {
       this.resizeObserver = new ResizeObserver(() => this.resize());
       this.resizeObserver.observe(host);
+      graphCanvasDevMetrics.activeResizeObservers += 1;
     } else {
-      window.addEventListener("resize", () => this.resize());
+      const onResize = () => this.resize();
+      window.addEventListener("resize", onResize);
+      this.cleanupFns.push(() => window.removeEventListener("resize", onResize));
     }
   }
 

--- a/packages/mesh-explorer-ui/src/graphStore.ts
+++ b/packages/mesh-explorer-ui/src/graphStore.ts
@@ -32,6 +32,7 @@ export type GraphStore = {
   replaceSelection: (ids: string[]) => void;
   replaceLinkSelection: (ids: string[]) => void;
   clearSelection: () => void;
+  resetProjection: () => void;
 };
 
 export function createGraphStore(): GraphStore {
@@ -143,6 +144,16 @@ export function createGraphStore(): GraphStore {
     },
     clearSelection() {
       emit({ ...state, selectedNodeIds: new Set(), selectedLinkIds: new Set() });
+    },
+    resetProjection() {
+      emit({
+        ...state,
+        nodesById: new Map(),
+        linksById: new Map(),
+        selectedNodeIds: new Set(),
+        selectedLinkIds: new Set(),
+        cursor: { metaSeq: 0, graphSeq: 0 }
+      });
     }
   };
 }

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -105,6 +105,9 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   let connectivityState: ConnectivityStatus = "degraded";
   let badgeStats = { nodes: 0, links: 0 };
   let badgeRaf = 0;
+  let lastTopologySignature = "";
+  let lastCurvatureByLinkId = new Map<string, number>();
+  let activeSyncSubscriptions = 0;
 
   const uiState: CanvasUiState = {
     camera: cameraInfo,
@@ -137,7 +140,12 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       nodes: Array.from(snapshot.nodesById.values()),
       links: Array.from(snapshot.linksById.values()).filter((link: GraphLink) => snapshot.nodesById.has(link.source) && snapshot.nodesById.has(link.target))
     };
-    const curvatureByLinkId = computeParallelLinkCurvatures(data.links);
+    const topologySignature = `${Array.from(snapshot.nodesById.keys()).sort().join("|")}::${data.links.map((link) => `${link.id}:${link.source}:${link.target}:${link.type ?? ""}`).sort().join("|")}`;
+    if (topologySignature !== lastTopologySignature) {
+      lastCurvatureByLinkId = computeParallelLinkCurvatures(data.links);
+      lastTopologySignature = topologySignature;
+    }
+    const curvatureByLinkId = lastCurvatureByLinkId;
     const viewLinks = data.links.map((link) => ({ ...link, curvature: curvatureByLinkId.get(link.id) ?? 0 }));
     applyPendingSpawnSeeds(snapshot.nodesById);
     canvasRenderer?.update({ nodes: data.nodes, links: viewLinks, selectedNodeIds: snapshot.selectedNodeIds, selectedLinkIds: snapshot.selectedLinkIds }, uiState);
@@ -208,6 +216,9 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
 
   async function connectAndSync(sessionId: number): Promise<void> {
     activeAbort = rotateAbortController(activeAbort);
+    store.resetProjection();
+    canvasRenderer?.clearTransientUiState();
+    resetAutoFitState();
     setConnectionStatus("connecting");
     const normalizedPrincipal = normalizePrincipal(el.principal.value);
     const storageKey = cursorStorageKey(normalizedPrincipal, el.graphSpaceId.value);
@@ -232,61 +243,69 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     void subscribeLoop(sessionId, activeAbort.signal);
 
     async function subscribeLoop(activeSessionId: number, signal: AbortSignal): Promise<void> {
+      activeSyncSubscriptions += 1;
       let retryDelayMs = SUBSCRIBE_RETRY_DELAY_MS;
       let lastSubscribeErrorLogAt = 0;
-      while (activeSessionId === syncSession) {
-        try {
-          const url = `${el.baseUrl.value}/v1/${encodeURIComponent(el.graphSpaceId.value)}/sync:subscribe?from=${store.getState().cursor.graphSeq}`;
-          const response = await meshFetch(url, { headers: headers(normalizedPrincipal), signal }, {
-            principal: normalizedPrincipal,
-            transport: "fetch-sse",
-            debugAuth,
-            onNetworkResult: (status) => markNetworkConnectivity(status, "sse-subscribe")
-          });
-          if (!response.body) {
-            markNetworkConnectivity("degraded", "sse-empty-body");
-            setConnectionStatus("reconnecting");
-            await wait(retryDelayMs);
-            continue;
-          }
-          markNetworkConnectivity("online", "sse-connected");
-          setConnectionStatus("connected");
-          retryDelayMs = SUBSCRIBE_RETRY_DELAY_MS;
-          for await (const data of parseSse(response.body)) {
-            if (activeSessionId !== syncSession) return;
-            if (data.kind === "heartbeat") continue;
-            if (data.kind === "txBundles") {
-              const txBundles = data.txBundlesVisible ?? [];
-              const cursorFromBundles = readCursorFromTxBundles(txBundles);
-              if (cursorFromBundles !== null) {
-                const next = { ...store.getState().cursor, graphSeq: cursorFromBundles };
-                const advanced = applyCursorIfAdvanced(storageKey, next, "sse");
-                if (advanced) {
-                  store.applyGraphEvents(extractGraphEventsFromTxBundles(txBundles));
+      try {
+        while (activeSessionId === syncSession) {
+          try {
+            const url = `${el.baseUrl.value}/v1/${encodeURIComponent(el.graphSpaceId.value)}/sync:subscribe?from=${store.getState().cursor.graphSeq}`;
+            const response = await meshFetch(url, { headers: headers(normalizedPrincipal), signal }, {
+              principal: normalizedPrincipal,
+              transport: "fetch-sse",
+              debugAuth,
+              onNetworkResult: (status) => markNetworkConnectivity(status, "sse-subscribe")
+            });
+            if (!response.body) {
+              markNetworkConnectivity("degraded", "sse-empty-body");
+              setConnectionStatus("reconnecting");
+              await wait(retryDelayMs);
+              continue;
+            }
+            markNetworkConnectivity("online", "sse-connected");
+            setConnectionStatus("connected");
+            retryDelayMs = SUBSCRIBE_RETRY_DELAY_MS;
+            for await (const data of parseSse(response.body)) {
+              if (activeSessionId !== syncSession) return;
+              if (data.kind === "heartbeat") continue;
+              if (data.kind === "txBundles") {
+                const txBundles = data.txBundlesVisible ?? [];
+                const cursorFromBundles = readCursorFromTxBundles(txBundles);
+                if (cursorFromBundles !== null) {
+                  const next = { ...store.getState().cursor, graphSeq: cursorFromBundles };
+                  const advanced = applyCursorIfAdvanced(storageKey, next, "sse");
+                  if (advanced) {
+                    store.applyGraphEvents(extractGraphEventsFromTxBundles(txBundles));
+                    setLastSyncNow();
+                  }
+                  continue;
+                }
+                const events = extractGraphEventsFromTxBundles(txBundles);
+                if (events.length > 0) {
+                  store.applyGraphEvents(events);
                   setLastSyncNow();
                 }
-                continue;
               }
-              store.applyGraphEvents(extractGraphEventsFromTxBundles(txBundles));
-              setLastSyncNow();
             }
-          }
-          if (activeSessionId === syncSession) {
-            markNetworkConnectivity("degraded", "sse-ended");
+            if (activeSessionId === syncSession) {
+              markNetworkConnectivity("degraded", "sse-ended");
+              setConnectionStatus("reconnecting");
+            }
+          } catch (error) {
+            if (signal.aborted) return;
+            markNetworkConnectivity("offline", "sse-error");
             setConnectionStatus("reconnecting");
+            const now = Date.now();
+            const shouldLog = verboseSyncErrors || now - lastSubscribeErrorLogAt >= SUBSCRIBE_ERROR_LOG_THROTTLE_MS;
+            if (shouldLog) {
+              reportDevError(el, `sync subscribe failed: ${String(error)}`, error);
+              lastSubscribeErrorLogAt = now;
+            }
+            await wait(retryDelayMs);
           }
-        } catch (error) {
-          if (signal.aborted) return;
-          markNetworkConnectivity("offline", "sse-error");
-          setConnectionStatus("reconnecting");
-          const now = Date.now();
-          const shouldLog = verboseSyncErrors || now - lastSubscribeErrorLogAt >= SUBSCRIBE_ERROR_LOG_THROTTLE_MS;
-          if (shouldLog) {
-            reportDevError(el, `sync subscribe failed: ${String(error)}`, error);
-            lastSubscribeErrorLogAt = now;
-          }
-          await wait(retryDelayMs);
         }
+      } finally {
+        activeSyncSubscriptions = Math.max(0, activeSyncSubscriptions - 1);
       }
     }
 
@@ -309,12 +328,13 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
           markNetworkConnectivity("online", "poll-success");
           const graphEvents = (payload.graph ?? []).map((entry) => asGraphEvent(entry.payload)).filter((event): event is GraphEvent => event !== null);
           const nextCursor = payload.cursorAfter ?? cursor;
-          graphEventsApplied += graphEvents.length;
-          store.applyGraphEvents(graphEvents);
-          if (graphEvents.length > 0) setLastSyncNow();
-
           const nextMonotonic = nextMonotonicCursor(cursor, nextCursor);
           const cursorUnchanged = cursorEq(nextMonotonic, cursor);
+          if (!cursorUnchanged && graphEvents.length > 0) {
+            graphEventsApplied += graphEvents.length;
+            store.applyGraphEvents(graphEvents);
+            setLastSyncNow();
+          }
           cursor = nextMonotonic;
           if ((payload.meta?.length ?? 0) === 0 && (payload.graph?.length ?? 0) === 0 || cursorUnchanged) break;
         }
@@ -340,7 +360,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   }
 
   async function promptAndCreateNode(seedPosition?: { x: number; y: number }): Promise<void> {
-    const label = prompt("Node label", "new node") ?? "";
+    const label = prompt("Node label", nextAutoNodeLabel()) ?? "";
     if (!label) return;
     dbg("add-node:submit", { label });
     await addNode(label, { seedPosition });
@@ -407,8 +427,9 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     const now = performance.now();
     const minIntervalMs = 1000 / Math.max(1, layoutUiState.settings.cinematicFitRate);
     if (now - importLastProgressiveFitAt < minIntervalMs) return;
-    importLastProgressiveFitAt = now;
-    fitCameraToCurrentGraph({ markAutoFitApplied: false });
+    const before = uiState.camera.zoom;
+    const applied = fitCameraToCurrentGraph({ markAutoFitApplied: false, maxZoom: before });
+    if (applied) importLastProgressiveFitAt = now;
   }
 
   async function createLinkFromDraft(source: string, target: string): Promise<void> {
@@ -725,7 +746,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     });
   }
 
-  function fitCameraToCurrentGraph(options: { markAutoFitApplied?: boolean } = {}): boolean {
+  function fitCameraToCurrentGraph(options: { markAutoFitApplied?: boolean; maxZoom?: number } = {}): boolean {
     const positioned = Array.from((canvasRenderer?.getNodePositions() ?? new Map()).values()).map((position) => ({ position }));
     const bounds = computeGraphBounds(positioned);
     if (!bounds) return false;
@@ -734,7 +755,8 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     if (!Number.isFinite(boundsWidth) || !Number.isFinite(boundsHeight) || boundsWidth < 1 || boundsHeight < 1) return false;
     const rect = el.graphCanvas.getBoundingClientRect();
     if (!Number.isFinite(rect.width) || !Number.isFinite(rect.height) || rect.width < 2 || rect.height < 2) return false;
-    uiState.camera = fitCameraToBounds(bounds, { width: rect.width, height: rect.height }, uiState.camera, 0.12, store.getState().nodesById.size);
+    const nextCamera = fitCameraToBounds(bounds, { width: rect.width, height: rect.height }, uiState.camera, 0.12, store.getState().nodesById.size);
+    uiState.camera = options.maxZoom !== undefined && nextCamera.zoom > options.maxZoom ? { ...nextCamera, zoom: options.maxZoom } : nextCamera;
     if (options.markAutoFitApplied) autoFitApplied = true;
     cameraInfo = uiState.camera;
     queueBadgeRender();
@@ -767,6 +789,11 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     el.transport.textContent = `transport: ${snapshot.connectionStatus}`;
     el.lastCursor.textContent = `cursor: ${JSON.stringify(snapshot.cursor)}`;
     el.lastSync.textContent = `last sync: ${snapshot.lastSync}`;
+    (window as Window & { __meshRuntimeStats?: unknown }).__meshRuntimeStats = {
+      activeSyncSubscriptions,
+      activeCinematicFitRafs: autoFitRaf !== 0 ? 1 : 0,
+      isImporting
+    };
     badgeStats = { nodes, links };
     queueBadgeRender();
     if (!el.principal.value.trim()) {
@@ -1131,10 +1158,14 @@ function installTestHook(store: GraphStore): void {
     },
     dump() {
       const state = store.getState();
+      const canvasStats = (window as Window & { __meshCanvasStats?: () => unknown }).__meshCanvasStats?.();
+      const runtimeStats = (window as Window & { __meshRuntimeStats?: unknown }).__meshRuntimeStats;
       return {
         cursor: state.cursor,
         nodesCount: state.nodesById.size,
-        linksCount: state.linksById.size
+        linksCount: state.linksById.size,
+        canvasStats,
+        runtimeStats
       };
     },
     logs: [],

--- a/packages/mesh-explorer-ui/src/viewport/CanvasGraphViewport2D.ts
+++ b/packages/mesh-explorer-ui/src/viewport/CanvasGraphViewport2D.ts
@@ -118,6 +118,10 @@ export class CanvasGraphViewport2D implements GraphViewportHandle {
     this.renderer.nudgeZoomOut(factor);
   }
 
+  clearTransientUiState(): void {
+    this.renderer.clearTransientUiState();
+  }
+
 }
 
 function toReadModel(model: GraphViewportModel): GraphCanvasReadModel {

--- a/packages/mesh-explorer-ui/test/graphCanvas2d.test.ts
+++ b/packages/mesh-explorer-ui/test/graphCanvas2d.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { ForceLayout2D, GraphCanvas2D, computeEdgeHitSlopWorld, computeGraphBounds, computeMinZoomEffective, computeParallelLinkCurvatures, computeSeedRadius, distancePointToSegment, fitCameraToBounds, hitTestEdge, hitTestEdges, hitTestNode, nextEdgeDraft, nextSelectedEdgeIds, screenToWorld, seededNodePosition, worldToScreen, zoomAtPoint, type CameraState } from "../src/graphCanvas2d.js";
+import { ForceLayout2D, GraphCanvas2D, computeEdgeHitSlopWorld, computeGraphBounds, computeMinZoomEffective, computeParallelLinkCurvatures, computeSeedRadius, distancePointToSegment, fitCameraToBounds, getPreferredSpawnWorldPos, hitTestEdge, hitTestEdges, hitTestNode, nextEdgeDraft, nextSelectedEdgeIds, screenToWorld, seededNodePosition, worldToScreen, zoomAtPoint, type CameraState } from "../src/graphCanvas2d.js";
 import { LAYOUT_LIMITS, deriveLayoutParams } from "../src/ui/layoutSettings.js";
 
 describe("graphCanvas2d transforms", () => {
@@ -115,6 +115,34 @@ describe("edge selection state machine", () => {
 
     const selectedB = nextSelectedEdgeIds(selectedAB, { nodeHit: null, edgeHit: "edge-a", shiftKey: true, toggleKey: false });
     expect(selectedB).toEqual(new Set(["edge-b"]));
+  });
+
+  it("supports ctrl/cmd toggle for multi-edge selection", () => {
+    const selectedA = nextSelectedEdgeIds(new Set(), { nodeHit: null, edgeHit: "edge-a", shiftKey: false, toggleKey: false });
+    const selectedAB = nextSelectedEdgeIds(selectedA, { nodeHit: null, edgeHit: "edge-b", shiftKey: false, toggleKey: true });
+    expect(selectedAB).toEqual(new Set(["edge-a", "edge-b"]));
+  });
+});
+
+describe("spawn position helper", () => {
+  it("uses pointer world position when pointer is inside canvas bounds", () => {
+    const camera: CameraState = { x: 50, y: 30, zoom: 2, minZoom: 0.2, maxZoom: 4 };
+    const pos = getPreferredSpawnWorldPos({
+      lastPointerClientPos: { x: 160, y: 120 },
+      canvasRect: { left: 100, top: 100, width: 400, height: 300 },
+      camera
+    });
+    expect(pos).toEqual({ x: 80, y: 40 });
+  });
+
+  it("falls back to viewport center when pointer is outside canvas bounds", () => {
+    const camera: CameraState = { x: 10, y: -20, zoom: 2, minZoom: 0.2, maxZoom: 4 };
+    const pos = getPreferredSpawnWorldPos({
+      lastPointerClientPos: { x: 20, y: 20 },
+      canvasRect: { left: 100, top: 100, width: 400, height: 300 },
+      camera
+    });
+    expect(pos).toEqual({ x: 110, y: 55 });
   });
 });
 
@@ -338,6 +366,7 @@ describe("GraphCanvas2D topology guards and reheat", () => {
       getContext: () => ctx,
       getBoundingClientRect: () => ({ width: 640, height: 480 }),
       addEventListener: (name: string, listener: EventListener) => events.set(name, listener),
+      removeEventListener: () => undefined,
       setPointerCapture: () => undefined,
       hasPointerCapture: () => false,
       releasePointerCapture: () => undefined
@@ -451,6 +480,38 @@ describe("GraphCanvas2D topology guards and reheat", () => {
     expect(reheatSpy).toHaveBeenCalledWith(0.9);
     expect(restartSpy).toHaveBeenCalledTimes(1);
     renderer.destroy();
+  });
+
+  it("keeps active canvas metrics stable across repeated init/destroy cycles", () => {
+    const win = {
+      devicePixelRatio: 1,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined
+    } as unknown as Window;
+    vi.stubGlobal("window", win);
+    vi.stubGlobal("requestAnimationFrame", raf);
+    vi.stubGlobal("cancelAnimationFrame", () => undefined);
+
+    const ui = {
+      camera: { x: 0, y: 0, zoom: 1, minZoom: 0.2, maxZoom: 4 },
+      hoveredNodeId: null,
+      edgeDraft: null,
+      dragSelectionRect: null
+    };
+    for (let i = 0; i < 3; i += 1) {
+      const { canvas } = createCanvasHarness();
+      const renderer = new GraphCanvas2D(canvas, { nodes: [{ id: `n${i}`, label: "N" }], links: [], selectedNodeIds: new Set(), selectedLinkIds: new Set() }, ui, {
+        onSelectionReplace: () => undefined,
+        onSelectionToggle: () => undefined,
+        onSelectionClear: () => undefined,
+        onEdgeDraftChange: () => undefined,
+        onCreateEdge: () => undefined
+      });
+      renderer.destroy();
+    }
+    const stats = (window as Window & { __meshCanvasStats?: () => { activeCanvasInstances: number; activeResizeObservers: number } }).__meshCanvasStats?.();
+    expect(stats?.activeCanvasInstances ?? 0).toBe(0);
+    expect(stats?.activeResizeObservers ?? 0).toBe(0);
   });
 });
 


### PR DESCRIPTION
### Motivation
- Several post-merge changes produced visible regressions: flicker on reload (multiple transient graph states), CPU/time leaks after repeated import/clear, spawn position off-cursor, broken ctrl/cmd multi-select and link-draft flow, cinematic fit oscillation during import, and missing auto-naming on node creation.
- The intent is to restore correct UX semantics (no masking/hiding of rendering) while keeping the new features and removing sources of stale-state updates and resource leaks.

### Description
- Reset projection state at sync bootstrap by exposing `resetProjection()` in the store and clearing transient renderer UI state before replay/subscribe to avoid showing stale graphs on reload.
- Harden sync idempotency so poll/replay and SSE subscription only apply graph events when cursors advance, and avoid re-applying empty bundles; add a guarded subscription lifecycle counter to help detect subscription leaks.
- Compute parallel-link curvatures only when topology changes by tracking a topology signature (nodes+links) to avoid O(E) recomputation on UI-only updates.
- Fix spawn-under-cursor by recording last pointer client coordinates in the canvas renderer and adding `getPreferredSpawnWorldPos()` which converts client→world when pointer is in-canvas, otherwise falling back to viewport center; both Shift+N and the Add button use the same helper.
- Auto-name prompt default updated to `Node {k}` (shared heuristic with Shift+N); cinematic progressive-fit now enforces monotonic zoom-out during import by capping fit zoom via a `maxZoom` guard.
- Restore correct multi-selection behavior: ctrl/cmd toggles work for edges, node clicks no longer inject position mutations, and a small click-vs-drag movement threshold prevents accidental pinning/moving of nodes during simple clicks; edge-draft logic preserved.
- Add robust lifecycle cleanup for canvas/window listeners and ResizeObserver, expose lightweight dev metrics (`activeCanvasInstances`, `activeResizeObservers`, `activeSyncSubscriptions`, `activeCinematicFitRafs`) and `clearTransientUiState()` on the viewport handle to aid diagnostics and prevent leaks.
- Tests updated/added to cover spawn preference, ctrl/cmd edge selection toggle and active-canvas metrics across init/destroy cycles.

### Testing
- Ran unit/integration tests with `pnpm vitest run packages/mesh-explorer-ui/test/graphCanvas2d.test.ts packages/mesh-explorer-ui/test/canvasFlow.integration.test.ts packages/mesh-explorer-ui/test/bootstrapCursor.test.ts` and all tests passed (53 tests total passed).
- Built the UI package with `pnpm --filter @mesh/mesh-explorer-ui build` which succeeded without TypeScript errors.
- Launched the dev webapp and verified rendering sanity via an automated Playwright screenshot (`apps/mesh-explorer-webapp dev` + screenshot), used as visual verification of the fixes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ab3cccbc83219d0f7fce436040d7)