### PR TITLE
Fix fork cursor bootstrap and recover from 410 cursor_too_old

### DIFF
--- a/apps/mesh-graph-server/src/index.ts
+++ b/apps/mesh-graph-server/src/index.ts
@@ -425,8 +425,8 @@ async function handleRequest(
     }
     await deps.refreshProjectHead(newProjectId);
     const forked = deps.catalog.projects[newProjectId]!;
-    forked.minReadableCursor = { ...snapshot.cursor };
     forked.headCursor = await newContext.store.getCursorHead(newProjectId);
+    forked.minReadableCursor = boundedMinReadableCursor(snapshot.cursor, forked.headCursor);
     await saveCatalog(deps.catalogPath, deps.catalog);
     await deps.createSnapshot(newProjectId, `fork:${snapshot.snapshotId}`);
     writeJson(res, 200, { newProjectId });
@@ -586,6 +586,13 @@ function parseCursor(raw: string | null): Cursor {
 
 function isCursorTooOld(requested: Cursor, minReadable: Cursor): boolean {
   return requested.metaSeq < minReadable.metaSeq || requested.graphSeq < minReadable.graphSeq;
+}
+
+function boundedMinReadableCursor(minReadable: Cursor, head: Cursor): Cursor {
+  return {
+    metaSeq: Math.max(0, Math.min(minReadable.metaSeq, head.metaSeq)),
+    graphSeq: Math.max(0, Math.min(minReadable.graphSeq, head.graphSeq))
+  };
 }
 
 async function streamSubscribe(

--- a/apps/mesh-graph-server/test/projects-snapshots-retention.test.ts
+++ b/apps/mesh-graph-server/test/projects-snapshots-retention.test.ts
@@ -51,6 +51,51 @@ describe("projects + snapshots + retention", () => {
 
 
 
+
+  it("keeps fork cursors consistent and allows subscribe from head", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "mesh-graph-server-fork-invariant-"));
+    const server = await startMeshGraphServer({ storageDir, port: 0 });
+    startedServers.push(server);
+
+    for (let idx = 0; idx < 4; idx += 1) {
+      await fetch(`${server.url}/v1/${server.graphSpaceId}/graph:nodes`, { method: "POST", headers, body: JSON.stringify({ id: `F-${idx}`, label: `F-${idx}` }) });
+      await fetch(`${server.url}/v1/${server.graphSpaceId}/snapshots:create`, { method: "POST", headers, body: JSON.stringify({ label: `f-${idx}` }) });
+    }
+
+    await fetch(`${server.url}/v1/${server.graphSpaceId}/retention`, {
+      method: "PATCH",
+      headers,
+      body: JSON.stringify({ maxEvents: 1, minSnapshotsToKeep: 1, snapshotEveryNEvents: 1, snapshotEverySeconds: 1, mode: "delete" })
+    });
+    await fetch(`${server.url}/v1/${server.graphSpaceId}/history:purge`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ dryRun: false })
+    });
+
+    const snapshots = await fetch(`${server.url}/v1/${server.graphSpaceId}/snapshots`, { headers });
+    const latest = ((await snapshots.json()) as Array<{ snapshotId: string }>)[0];
+    expect(latest?.snapshotId).toBeTruthy();
+
+    const forkResponse = await fetch(`${server.url}/v1/${server.graphSpaceId}/snapshots/${latest!.snapshotId}:fork`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ newProjectId: "fork-invariant" })
+    });
+    expect(forkResponse.status).toBe(200);
+
+    const projects = await fetch(`${server.url}/v1/projects`, { headers });
+    const forked = ((await projects.json()) as Array<{ projectId: string; headCursor: { graphSeq: number }; minReadableCursor: { graphSeq: number } }>)
+      .find((entry) => entry.projectId === "fork-invariant");
+
+    expect(forked).toBeDefined();
+    expect(forked!.minReadableCursor.graphSeq).toBeGreaterThanOrEqual(0);
+    expect(forked!.headCursor.graphSeq).toBeGreaterThanOrEqual(forked!.minReadableCursor.graphSeq);
+
+    const subscribe = await fetch(`${server.url}/v1/fork-invariant/sync:subscribe?from=${forked!.headCursor.graphSeq}`, { headers });
+    expect(subscribe.status).toBe(200);
+  });
+
   it("creates repeated auto snapshots when head crosses multiple thresholds", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "mesh-graph-server-auto-snapshots-"));
     const server = await startMeshGraphServer({ storageDir, port: 0 });

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -46,6 +46,17 @@ type SyncPollPayload = {
   cursorAfter?: Cursor;
 };
 
+type CursorTooOldPayload = {
+  kind?: string;
+  minReadableCursor?: Cursor;
+  recommendedSnapshotId?: string;
+};
+
+type SnapshotPayloadResponse = {
+  payload?: { nodes?: GraphNode[]; links?: GraphLink[] };
+  cursor?: Cursor;
+};
+
 export function mountMeshExplorerUi(container: HTMLElement): void {
   const initialPrincipal = readInitialPrincipal();
   container.innerHTML = `
@@ -364,15 +375,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     void subscribeLoop(sessionId, activeAbort.signal);
 
 
-    async function bootstrapFromSnapshot(principalValue: string): Promise<Cursor> {
-      const response = await meshFetch(`${el.baseUrl.value}/v1/${encodeURIComponent(el.graphSpaceId.value)}/graph:snapshot`, { headers: headers(principalValue) }, {
-        principal: principalValue,
-        transport: "fetch",
-        debugAuth,
-        onNetworkResult: (status) => markNetworkConnectivity(status, "snapshot-bootstrap")
-      });
-      if (!response.ok) return { metaSeq: 0, graphSeq: 0 };
-      const snapshot = (await response.json()) as { payload?: { nodes?: GraphNode[]; links?: GraphLink[] }; cursor?: Cursor };
+    function applySnapshot(snapshot: SnapshotPayloadResponse): Cursor {
       const nodes = snapshot.payload?.nodes ?? [];
       const links = snapshot.payload?.links ?? [];
       store.resetProjection();
@@ -381,6 +384,53 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       const cursor = snapshot.cursor ?? { metaSeq: 0, graphSeq: 0 };
       store.setCursor(cursor);
       return cursor;
+    }
+
+    async function bootstrapFromSnapshot(principalValue: string): Promise<Cursor> {
+      const response = await meshFetch(`${el.baseUrl.value}/v1/${encodeURIComponent(el.graphSpaceId.value)}/graph:snapshot`, { headers: headers(principalValue) }, {
+        principal: principalValue,
+        transport: "fetch",
+        debugAuth,
+        onNetworkResult: (status) => markNetworkConnectivity(status, "snapshot-bootstrap")
+      });
+      if (!response.ok) return { metaSeq: 0, graphSeq: 0 };
+      return applySnapshot((await response.json()) as SnapshotPayloadResponse);
+    }
+
+    async function recoverFromCursorTooOld(payload: CursorTooOldPayload, signal: AbortSignal): Promise<Cursor | null> {
+      const minReadable = payload.minReadableCursor ?? { metaSeq: 0, graphSeq: 0 };
+      const snapshotPath = payload.recommendedSnapshotId
+        ? `/v1/${encodeURIComponent(el.graphSpaceId.value)}/snapshots/${encodeURIComponent(payload.recommendedSnapshotId)}`
+        : `/v1/${encodeURIComponent(el.graphSpaceId.value)}/graph:snapshot`;
+      emitUiDebugLog("sync.subscribe.cursor_too_old", {
+        from: store.getState().cursor,
+        minReadable,
+        recommendedSnapshotId: payload.recommendedSnapshotId ?? null,
+        snapshotPath
+      });
+      console.info("[mesh-ui] sync subscribe cursor_too_old; re-bootstraping", {
+        graphSpaceId: el.graphSpaceId.value,
+        from: store.getState().cursor,
+        minReadable,
+        recommendedSnapshotId: payload.recommendedSnapshotId ?? null
+      });
+      const response = await meshFetch(`${el.baseUrl.value}${snapshotPath}`, { headers: headers(normalizedPrincipal), signal }, {
+        principal: normalizedPrincipal,
+        transport: "fetch",
+        debugAuth,
+        onNetworkResult: (status) => markNetworkConnectivity(status, "snapshot-recover")
+      });
+      if (!response.ok) {
+        reportDevError(el, `snapshot recover failed: ${response.status}`);
+        return null;
+      }
+      const recoveredCursor = applySnapshot((await response.json()) as SnapshotPayloadResponse);
+      const recoveryCursor = compareCursor(recoveredCursor, minReadable) >= 0 ? recoveredCursor : minReadable;
+      store.setCursor(recoveryCursor);
+      persistCursorSafely(storageKey, recoveryCursor, (key, value) => localStorage.setItem(key, value));
+      markNetworkConnectivity("online", "sse-cursor-too-old-recovered");
+      setConnectionStatus("connected");
+      return recoveryCursor;
     }
 
     async function subscribeLoop(activeSessionId: number, signal: AbortSignal): Promise<void> {
@@ -397,6 +447,20 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
               debugAuth,
               onNetworkResult: (status) => markNetworkConnectivity(status, "sse-subscribe")
             });
+            if (response.status === 410) {
+              const payload = (await response.json()) as CursorTooOldPayload;
+              if (payload.kind === "cursor_too_old") {
+                setConnectionStatus("reconnecting");
+                const recovered = await recoverFromCursorTooOld(payload, signal);
+                if (recovered) continue;
+              }
+            }
+            if (!response.ok) {
+              markNetworkConnectivity("degraded", "sse-non-ok");
+              setConnectionStatus("reconnecting");
+              await wait(retryDelayMs);
+              continue;
+            }
             if (!response.body) {
               markNetworkConnectivity("degraded", "sse-empty-body");
               setConnectionStatus("reconnecting");

--- a/tests/e2e/mesh-explorer-sync-materialization.spec.ts
+++ b/tests/e2e/mesh-explorer-sync-materialization.spec.ts
@@ -56,6 +56,55 @@ describe("mesh explorer sync materialization", { timeout: 30_000 }, () => {
     expect(links[0]).toMatchObject({ source: nodeIds[0], target: nodeIds[1], type: "depends" });
   });
 
+
+
+  it("recovers after fork when subscribe responds cursor_too_old", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "mesh-graph-ui-fork-recovery-"));
+    cleanups.push(async () => rm(storageDir, { recursive: true, force: true }));
+
+    const server: MeshGraphServerHandle = await startMeshGraphServer({ storageDir, port: 0 });
+    cleanups.push(async () => server.close());
+
+    for (let idx = 0; idx < 4; idx += 1) {
+      await createNode(server.url, "alice", `fork-src-${idx}`);
+      await fetch(`${server.url}/v1/${server.graphSpaceId}/snapshots:create`, { method: "POST", headers: headers("alice"), body: JSON.stringify({ label: `s-${idx}` }) });
+    }
+
+    await fetch(`${server.url}/v1/${server.graphSpaceId}/retention`, {
+      method: "PATCH",
+      headers: headers("alice"),
+      body: JSON.stringify({ maxEvents: 1, minSnapshotsToKeep: 1, snapshotEveryNEvents: 1, snapshotEverySeconds: 1, mode: "delete" })
+    });
+    await fetch(`${server.url}/v1/${server.graphSpaceId}/history:purge`, { method: "POST", headers: headers("alice"), body: JSON.stringify({ dryRun: false }) });
+
+    const snapshots = await fetch(`${server.url}/v1/${server.graphSpaceId}/snapshots`, { headers: headers("alice") });
+    const latest = ((await snapshots.json()) as Array<{ snapshotId: string }>)[0];
+    expect(latest?.snapshotId).toBeTruthy();
+
+    const forkResponse = await fetch(`${server.url}/v1/${server.graphSpaceId}/snapshots/${latest!.snapshotId}:fork`, {
+      method: "POST",
+      headers: headers("alice"),
+      body: JSON.stringify({ newProjectId: "fork-recover-p1" })
+    });
+    const forkedProject = (await forkResponse.json()) as { newProjectId: string };
+
+    const staleSubscribe = await fetch(`${server.url}/v1/${forkedProject.newProjectId}/sync:subscribe?from=0`, { headers: headers("alice") });
+    expect(staleSubscribe.status).toBe(410);
+    const tooOld = (await staleSubscribe.json()) as { kind: string; minReadableCursor: Cursor; recommendedSnapshotId?: string };
+    expect(tooOld.kind).toBe("cursor_too_old");
+
+    const snapshotUrl = tooOld.recommendedSnapshotId
+      ? `${server.url}/v1/${forkedProject.newProjectId}/snapshots/${tooOld.recommendedSnapshotId}`
+      : `${server.url}/v1/${forkedProject.newProjectId}/graph:snapshot`;
+    const snapshot = await fetch(snapshotUrl, { headers: headers("alice") });
+    const snapshotBody = (await snapshot.json()) as { payload: { nodes: Array<{ id: string }>; links: Array<{ id: string }> }; cursor: Cursor };
+
+    const resumeFrom = Math.max(snapshotBody.cursor.graphSeq, tooOld.minReadableCursor.graphSeq);
+    const recoveredSubscribe = await fetch(`${server.url}/v1/${forkedProject.newProjectId}/sync:subscribe?from=${resumeFrom}`, { headers: headers("alice") });
+    expect(recoveredSubscribe.ok).toBe(true);
+    expect(snapshotBody.payload.nodes.length).toBeGreaterThan(0);
+  });
+
   it("reload bootstrap rebuilds nodes/links before subscribe", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "mesh-graph-ui-"));
     cleanups.push(async () => rm(storageDir, { recursive: true, force: true }));


### PR DESCRIPTION
### Motivation
- Prevent the web UI from entering an infinite degraded retry loop when `sync:subscribe` returns HTTP 410 `cursor_too_old` and ensure forked projects never end up with `minReadableCursor > headCursor` after seeding from a snapshot.

### Description
- Client: handle `sync:subscribe` 410 `cursor_too_old` by fetching the recommended snapshot (or latest), applying it to the local store, persisting the recovered cursor, logging the recovery, and resubscribing from the recovered cursor instead of retrying the stale `from` forever.
- Server: add `boundedMinReadableCursor` and use it during fork/bootstrap so the forked project's `minReadableCursor` is clamped to the fork `headCursor`, enforcing `0 <= minReadable <= head` after seeding.
- Tests: add an integration e2e test that forks, observes a stale `sync:subscribe` 410, validates snapshot-based recovery, and a server test that forks from a purged lineage and asserts `head >= minReadable` and that subscribing from head does not return 410.
- Small API fix: update client use of `persistCursorSafely` with the correct 3-arg signature when persisting recovered cursor.

### Testing
- Ran a full TypeScript build with `pnpm -r build` which completed successfully.
- Ran the targeted test suites with `pnpm vitest run tests/e2e/mesh-explorer-sync-materialization.spec.ts apps/mesh-graph-server/test/projects-snapshots-retention.test.ts` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a140e768c83219713322c22f0cdf3)