### PR TITLE
Fix server policy form hydration on load and project switch

### DIFF
--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -30,6 +30,11 @@ import { LayoutPanel } from "./ui/LayoutPanel.js";
 import { deriveLayoutParams, loadLayoutUiState, saveLayoutUiState, type LayoutUiState } from "./ui/layoutSettings.js";
 import { exportGraphFromState, parseExportedGraph, type ExportedGraphV1 } from "./devtools/graphIo.js";
 import { buildMultiDeletePlan } from "./deleteSelection.js";
+import {
+  createPolicyHydrationController,
+  toEffectiveRetentionPolicy,
+  type RetentionPolicy
+} from "./policyHydration.js";
 
 type Cursor = { metaSeq: number; graphSeq: number };
 type GraphData = { nodes: GraphNode[]; links: GraphLink[] };
@@ -72,11 +77,11 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
           <button id="projectsRefresh">Refresh projects</button>
           <button id="projectCreate" style="margin-left:8px;">Create project</button>
           <div id="projectsList" style="margin-top:6px;font-size:12px;max-height:100px;overflow:auto;"></div>
-          <label>ttlSeconds <input id="policyTtl" style="width:100%" type="number" value="86400"/></label>
-          <label>maxEvents <input id="policyMaxEvents" style="width:100%" type="number" value="20000"/></label>
-          <label>snapshotEveryNEvents <input id="policyEveryN" style="width:100%" type="number" value="500"/></label>
-          <label>snapshotEverySeconds <input id="policyEverySeconds" style="width:100%" type="number" value="300"/></label>
-          <label>minSnapshotsToKeep <input id="policyMinSnapshots" style="width:100%" type="number" value="3"/></label>
+          <label>ttlSeconds <input id="policyTtl" style="width:100%" type="number"/></label>
+          <label>maxEvents <input id="policyMaxEvents" style="width:100%" type="number"/></label>
+          <label>snapshotEveryNEvents <input id="policyEveryN" style="width:100%" type="number"/></label>
+          <label>snapshotEverySeconds <input id="policyEverySeconds" style="width:100%" type="number"/></label>
+          <label>minSnapshotsToKeep <input id="policyMinSnapshots" style="width:100%" type="number"/></label>
           <button id="policySave">Save policy</button>
           <button id="snapshotCreate" style="margin-left:8px;">Create snapshot</button>
           <button id="snapshotList" style="margin-left:8px;">List snapshots</button>
@@ -149,6 +154,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   let previousNodeIds = new Set<string>();
   const pendingSpawnSeeds: Array<{ x: number; y: number }> = [];
   const undoRedo = new UndoRedoManager();
+  const policyHydration = createPolicyHydrationController(fetchEffectivePolicy);
   let layoutUiState: LayoutUiState = loadLayoutUiState();
   const debugThrottleByEvent = new Map<string, number>();
 
@@ -189,6 +195,9 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   });
 
   el.connect.onclick = () => {
+    const scopeId = el.graphSpaceId.value;
+    setPolicyLoading(scopeId);
+    void hydratePolicyForScope(scopeId);
     syncSession += 1;
     void connectAndSync(syncSession);
   };
@@ -265,6 +274,8 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     graphSpaceId: el.graphSpaceId.value,
     localCursorKey: cursorStorageKey(normalizePrincipal(el.principal.value), el.graphSpaceId.value)
   }));
+  setPolicyLoading(el.graphSpaceId.value);
+  void hydratePolicyForScope(el.graphSpaceId.value);
   void refreshProjects();
   syncSession += 1;
   void connectAndSync(syncSession);
@@ -281,6 +292,8 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
         const projectId = (button as HTMLButtonElement).dataset.projectId;
         if (!projectId) return;
         el.graphSpaceId.value = projectId;
+        setPolicyLoading(projectId);
+        void hydratePolicyForScope(projectId);
         syncSession += 1;
         void connectAndSync(syncSession);
       });
@@ -314,7 +327,47 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       body: JSON.stringify(body)
     });
     const payload = await response.json() as { retentionPolicy?: Record<string, unknown> };
-    el.projectReport.textContent = `effective policy projectId=${el.graphSpaceId.value} graphSpaceId=${el.graphSpaceId.value} => ${JSON.stringify(payload.retentionPolicy ?? {})}`;
+    const effective = toEffectiveRetentionPolicy(payload.retentionPolicy as Partial<RetentionPolicy> | undefined);
+    applyPolicyForm(effective);
+    el.projectReport.textContent = `effective policy projectId=${el.graphSpaceId.value} graphSpaceId=${el.graphSpaceId.value} => ${JSON.stringify(effective)}`;
+  }
+
+  async function fetchEffectivePolicy(scopeId: string): Promise<Partial<RetentionPolicy> | undefined> {
+    const response = await fetch(`${el.baseUrl.value}/v1/${encodeURIComponent(scopeId)}`, {
+      headers: headers(el.principal.value)
+    });
+    if (!response.ok) return undefined;
+    const payload = await response.json() as { retentionPolicy?: Partial<RetentionPolicy> };
+    return payload.retentionPolicy;
+  }
+
+  async function hydratePolicyForScope(scopeId: string): Promise<void> {
+    const hydrated = await policyHydration.hydrate(scopeId);
+    if (!hydrated) return;
+    if (el.graphSpaceId.value !== hydrated.scopeId) return;
+    applyPolicyForm(hydrated.policy);
+    el.projectReport.textContent = `effective policy projectId=${hydrated.scopeId} graphSpaceId=${hydrated.scopeId} => ${JSON.stringify(hydrated.policy)}`;
+  }
+
+  function setPolicyLoading(scopeId: string): void {
+    for (const field of [el.policyTtl, el.policyMaxEvents, el.policyEveryN, el.policyEverySeconds, el.policyMinSnapshots]) {
+      field.value = "";
+      field.disabled = true;
+    }
+    el.policySave.disabled = true;
+    el.projectReport.textContent = `loading effective policy projectId=${scopeId}...`;
+  }
+
+  function applyPolicyForm(policy: RetentionPolicy): void {
+    el.policyTtl.value = String(policy.ttlSeconds ?? "");
+    el.policyMaxEvents.value = String(policy.maxEvents ?? "");
+    el.policyEveryN.value = String(policy.snapshotEveryNEvents);
+    el.policyEverySeconds.value = String(policy.snapshotEverySeconds);
+    el.policyMinSnapshots.value = String(policy.minSnapshotsToKeep);
+    for (const field of [el.policyTtl, el.policyMaxEvents, el.policyEveryN, el.policyEverySeconds, el.policyMinSnapshots]) {
+      field.disabled = false;
+    }
+    el.policySave.disabled = false;
   }
 
   async function createSnapshot(): Promise<void> {
@@ -346,6 +399,8 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     el.projectReport.textContent = `forked => ${fork.newProjectId}`;
     await refreshProjects();
     el.graphSpaceId.value = fork.newProjectId;
+    setPolicyLoading(fork.newProjectId);
+    void hydratePolicyForScope(fork.newProjectId);
     syncSession += 1;
     void connectAndSync(syncSession);
   }

--- a/packages/mesh-explorer-ui/src/policyHydration.ts
+++ b/packages/mesh-explorer-ui/src/policyHydration.ts
@@ -1,0 +1,52 @@
+export type RetentionPolicy = {
+  ttlSeconds?: number;
+  maxEvents?: number;
+  snapshotEveryNEvents: number;
+  snapshotEverySeconds: number;
+  minSnapshotsToKeep: number;
+  mode: "delete" | "archive";
+};
+
+export const DEFAULT_RETENTION_POLICY: RetentionPolicy = {
+  ttlSeconds: 86400,
+  maxEvents: 20000,
+  snapshotEveryNEvents: 500,
+  snapshotEverySeconds: 300,
+  minSnapshotsToKeep: 3,
+  mode: "delete"
+};
+
+export function toEffectiveRetentionPolicy(raw?: Partial<RetentionPolicy> | null): RetentionPolicy {
+  if (!raw) return { ...DEFAULT_RETENTION_POLICY };
+  return {
+    ttlSeconds: typeof raw.ttlSeconds === "number" && raw.ttlSeconds > 0 ? Math.floor(raw.ttlSeconds) : DEFAULT_RETENTION_POLICY.ttlSeconds,
+    maxEvents: typeof raw.maxEvents === "number" && raw.maxEvents > 0 ? Math.floor(raw.maxEvents) : DEFAULT_RETENTION_POLICY.maxEvents,
+    snapshotEveryNEvents: typeof raw.snapshotEveryNEvents === "number" && raw.snapshotEveryNEvents > 0
+      ? Math.floor(raw.snapshotEveryNEvents)
+      : DEFAULT_RETENTION_POLICY.snapshotEveryNEvents,
+    snapshotEverySeconds: typeof raw.snapshotEverySeconds === "number" && raw.snapshotEverySeconds > 0
+      ? Math.floor(raw.snapshotEverySeconds)
+      : DEFAULT_RETENTION_POLICY.snapshotEverySeconds,
+    minSnapshotsToKeep: typeof raw.minSnapshotsToKeep === "number" && raw.minSnapshotsToKeep > 0
+      ? Math.floor(raw.minSnapshotsToKeep)
+      : DEFAULT_RETENTION_POLICY.minSnapshotsToKeep,
+    mode: raw.mode === "archive" ? "archive" : "delete"
+  };
+}
+
+type FetchPolicy = (scopeId: string) => Promise<Partial<RetentionPolicy> | null | undefined>;
+
+export function createPolicyHydrationController(fetchPolicy: FetchPolicy): {
+  hydrate: (scopeId: string) => Promise<{ scopeId: string; policy: RetentionPolicy } | null>;
+} {
+  let requestSeq = 0;
+  return {
+    async hydrate(scopeId: string) {
+      requestSeq += 1;
+      const requestId = requestSeq;
+      const raw = await fetchPolicy(scopeId);
+      if (requestId !== requestSeq) return null;
+      return { scopeId, policy: toEffectiveRetentionPolicy(raw) };
+    }
+  };
+}

--- a/packages/mesh-explorer-ui/test/policyHydration.test.ts
+++ b/packages/mesh-explorer-ui/test/policyHydration.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { createPolicyHydrationController, toEffectiveRetentionPolicy } from "../src/policyHydration.js";
+
+describe("policy hydration", () => {
+  it("uses defaults only as fallback when server policy is missing", () => {
+    const effective = toEffectiveRetentionPolicy(undefined);
+    expect(effective.ttlSeconds).toBe(86400);
+    expect(effective.maxEvents).toBe(20000);
+    expect(effective.snapshotEveryNEvents).toBe(500);
+    expect(effective.snapshotEverySeconds).toBe(300);
+    expect(effective.minSnapshotsToKeep).toBe(3);
+  });
+
+  it("hydrates latest selected scope and drops stale responses", async () => {
+    let resolveA: ((value: { ttlSeconds: number; snapshotEveryNEvents: number; snapshotEverySeconds: number; minSnapshotsToKeep: number }) => void) | undefined;
+    let resolveB: ((value: { ttlSeconds: number; snapshotEveryNEvents: number; snapshotEverySeconds: number; minSnapshotsToKeep: number }) => void) | undefined;
+    let aCallCount = 0;
+
+    const controller = createPolicyHydrationController(async (scopeId) => {
+      if (scopeId === "project-a") {
+        aCallCount += 1;
+        if (aCallCount === 1) {
+          return await new Promise((resolve) => {
+            resolveA = resolve;
+          });
+        }
+        return { ttlSeconds: 777, snapshotEveryNEvents: 7, snapshotEverySeconds: 70, minSnapshotsToKeep: 4 };
+      }
+      return await new Promise((resolve) => {
+        resolveB = resolve;
+      });
+    });
+
+    const pendingA = controller.hydrate("project-a");
+    const pendingB = controller.hydrate("project-b");
+
+    resolveB?.({ ttlSeconds: 111, snapshotEveryNEvents: 9, snapshotEverySeconds: 33, minSnapshotsToKeep: 2 });
+    const hydratedB = await pendingB;
+    expect(hydratedB?.scopeId).toBe("project-b");
+    expect(hydratedB?.policy.ttlSeconds).toBe(111);
+
+    resolveA?.({ ttlSeconds: 999, snapshotEveryNEvents: 5, snapshotEverySeconds: 10, minSnapshotsToKeep: 1 });
+    const hydratedA = await pendingA;
+    expect(hydratedA).toBeNull();
+
+    const hydratedAReload = await controller.hydrate("project-a");
+    expect(hydratedAReload?.scopeId).toBe("project-a");
+    expect(hydratedAReload?.policy.ttlSeconds).toBe(777);
+  });
+});


### PR DESCRIPTION
### Motivation
- The server policy form was rendering hardcoded defaults on app load and after refresh instead of hydrating from the server, and scope switches carried stale draft values between projects.
- The intent is to fetch the effective retention policy for the active project/graphSpace on bootstrap and on scope changes and to ensure the UI only shows defaults when the server has no policy.

### Description
- Added a new `policyHydration` module (`packages/mesh-explorer-ui/src/policyHydration.ts`) that provides `toEffectiveRetentionPolicy` (normalize/fallback defaults) and `createPolicyHydrationController` (suppresses stale responses when multiple hydrations race).
- Updated `mountMeshExplorerUi` (`packages/mesh-explorer-ui/src/index.ts`) to remove hardcoded default input values and introduce a loading state for policy fields via `setPolicyLoading` and `applyPolicyForm` so the form is disabled until hydration completes.
- Implemented `fetchEffectivePolicy` and `hydratePolicyForScope`, wired hydration to run on app bootstrap and when the user: connects, selects a project from the list, or forks a snapshot, ensuring the form always reflects the active scope's effective policy.
- Updated `savePolicy` to normalize the server-returned effective policy with `toEffectiveRetentionPolicy` and re-apply it to the form so the draft state resets after save.
- Added unit tests `packages/mesh-explorer-ui/test/policyHydration.test.ts` to verify default fallback behavior and that stale hydration responses are dropped so the latest selected scope wins.

### Testing
- Ran unit tests: `pnpm vitest run packages/mesh-explorer-ui/test/policyHydration.test.ts` and the new tests passed (2 tests passed).
- Built the UI: `pnpm --filter @mesh/mesh-explorer-ui build` completed successfully.
- Performed a manual UI verification by launching the web app and capturing a screenshot with Playwright to confirm the loading/hydration UX (artifact captured).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a2048915c8321b0d909b0d89421bb)