### PR TITLE
feat(projects): use UUID project ids with editable names and v1 invariant

### DIFF
--- a/apps/mesh-graph-server/src/index.ts
+++ b/apps/mesh-graph-server/src/index.ts
@@ -8,7 +8,8 @@ import { KernelMinimalImpl } from "@mesh/kernel-minimal";
 import { LocalSyncGateway } from "@mesh/sync-local/internal";
 import type { Command, CommandOutcome, Cursor, PrincipalContext } from "@mesh/shared";
 
-const GRAPH_SPACE_ID = "mesh-explorer-graph-v1";
+const GRAPH_SPACE_ID = "00000000-0000-4000-8000-000000000001";
+const UUID_V4ISH_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const PRINCIPAL_HEADER = "x-mesh-principal";
 const IDEMPOTENCY_HEADER = "x-idempotency-key";
 const DEBUG_AUTH_ENABLED = process.env.MESH_DEBUG_AUTH === "1";
@@ -55,8 +56,9 @@ interface RetentionPolicy {
 }
 
 type ProjectRecord = {
-  projectId: string;
-  name?: string;
+  id: string;
+  // v1 invariant: projectId and graphSpaceId are the same UUID.
+  name: string;
   createdAt: number;
   updatedAt: number;
   headCursor: Cursor;
@@ -127,9 +129,26 @@ export interface MeshGraphServerHandle {
   close: () => Promise<void>;
 }
 
+function graphSpaceIdFromProjectId(projectId: string): string {
+  // v1 constraint: 1 project == 1 graph space.
+  return projectId;
+}
+
+function assertV1ProjectGraphInvariant(projectId: string, graphSpaceId: string): void {
+  if (projectId !== graphSpaceId) {
+    throw new Error(`v1 invariant violated: projectId (${projectId}) must equal graphSpaceId (${graphSpaceId})`);
+  }
+}
+
+function isUuid(value: string): boolean {
+  return UUID_V4ISH_REGEX.test(value);
+}
+
 export async function startMeshGraphServer(options: MeshGraphServerOptions): Promise<MeshGraphServerHandle> {
   await fs.mkdir(options.storageDir, { recursive: true });
-  const graphSpaceId = options.graphSpaceId ?? GRAPH_SPACE_ID;
+  const preferredProjectId = options.graphSpaceId ?? GRAPH_SPACE_ID;
+  const graphSpaceId = isUuid(preferredProjectId) ? preferredProjectId : randomUUID();
+  if (!isUuid(preferredProjectId)) console.info(`[mesh-graph-server] migrated legacy configured graphSpaceId (${preferredProjectId}) to UUID project id (${graphSpaceId}).`);
   process.env.MESH_TX_VISIBILITY_POLICY = "acl";
 
   const projectStores = new Map<string, { store: FileBackedLocalEventStore; gateway: LocalSyncGatewayLike; kernel: KernelMinimalImpl }>();
@@ -142,20 +161,30 @@ export async function startMeshGraphServer(options: MeshGraphServerOptions): Pro
     const storePath = join(options.storageDir, `graph-eventstore-${projectId}.json`);
     const store = new FileBackedLocalEventStore(storePath);
     const kernel = new KernelMinimalImpl(store);
-    const gateway = new LocalSyncGateway(store, { graphSpaceId: projectId, executeCommand: (command) => kernel.execute(command) });
+    const graphSpaceId = graphSpaceIdFromProjectId(projectId);
+    assertV1ProjectGraphInvariant(projectId, graphSpaceId);
+    const gateway = new LocalSyncGateway(store, { graphSpaceId, executeCommand: (command) => kernel.execute(command) });
     const loaded = { store, gateway, kernel };
     projectStores.set(projectId, loaded);
     return loaded;
   }
 
   async function ensureProject(projectId: string, name?: string): Promise<ProjectRecord> {
+    if (!isUuid(projectId)) throw new Error(`projectId must be a UUID: ${projectId}`);
     const existing = catalog.projects[projectId];
-    if (existing) return existing;
+    if (existing) {
+      if (typeof name === "string" && name.trim() && name !== existing.name) {
+        existing.name = name.trim();
+        existing.updatedAt = Date.now();
+        await saveCatalog(catalogPath, catalog);
+      }
+      return existing;
+    }
     const now = Date.now();
     const policy = process.env.NODE_ENV === "production" ? PROD_RETENTION_PRESET : DEV_RETENTION_PRESET;
     const record: ProjectRecord = {
-      projectId,
-      name,
+      id: projectId,
+      name: typeof name === "string" && name.trim() ? name.trim() : "Untitled project",
       createdAt: now,
       updatedAt: now,
       headCursor: { metaSeq: 0, graphSeq: 0 },
@@ -190,7 +219,7 @@ export async function startMeshGraphServer(options: MeshGraphServerOptions): Pro
     const record: SnapshotRecord = {
       snapshotId: randomUUID(),
       projectId,
-      graphSpaceId: projectId,
+      graphSpaceId: graphSpaceIdFromProjectId(projectId),
       cursor,
       createdAt: Date.now(),
       label,
@@ -205,7 +234,7 @@ export async function startMeshGraphServer(options: MeshGraphServerOptions): Pro
       snapshotId: record.snapshotId,
       head: record.cursor.graphSeq,
       projectId,
-      graphSpaceId: projectId,
+      graphSpaceId: graphSpaceIdFromProjectId(projectId),
       reason: label === "auto" ? "auto" : "manual"
     });
     await saveCatalog(catalogPath, catalog);
@@ -226,7 +255,7 @@ export async function startMeshGraphServer(options: MeshGraphServerOptions): Pro
     const shouldSnapshot = head > 0 && head - lastSnapshotHead >= everyN;
     console.info("AUTO_SNAPSHOT_CHECK", {
       projectId,
-      graphSpaceId: projectId,
+      graphSpaceId: graphSpaceIdFromProjectId(projectId),
       head,
       lastSnapshotHead,
       everyN,
@@ -262,7 +291,7 @@ export async function startMeshGraphServer(options: MeshGraphServerOptions): Pro
     const context = await getProjectContext(projectId);
     const beforeHead = await context.store.getCursorHead(projectId);
     if (!dryRun) {
-      await context.store.compactUpToCursor({ graphSpaceId: projectId, cursorExclusive: cutSnapshot.cursor.graphSeq });
+      await context.store.compactUpToCursor({ graphSpaceId: graphSpaceIdFromProjectId(projectId), cursorExclusive: cutSnapshot.cursor.graphSeq });
       catalog.snapshots[projectId] = snapshots.filter((snapshot) => !toDelete.some((stale) => stale.snapshotId === snapshot.snapshotId));
       project.minReadableCursor = cutSnapshot.cursor;
       project.headCursor = await context.store.getCursorHead(projectId);
@@ -333,15 +362,34 @@ async function handleRequest(
   if (req.method === "GET" && requestUrl.pathname === "/") return void writePlainText(res, 200, buildRootHelpMessage(deps.graphSpaceId));
 
   if (req.method === "GET" && requestUrl.pathname === "/v1/projects") {
-    const entries = Object.values(deps.catalog.projects).map((project) => ({ ...project, snapshotsCount: deps.catalog.snapshots[project.projectId]?.length ?? 0 }));
+    const entries = Object.values(deps.catalog.projects).map((project) => ({ ...project, projectId: project.id, graphSpaceId: graphSpaceIdFromProjectId(project.id), snapshotsCount: deps.catalog.snapshots[project.id]?.length ?? 0 }));
     writeJson(res, 200, entries);
     return;
   }
 
   if (req.method === "POST" && requestUrl.pathname === "/v1/projects") {
-    const body = (await readJsonBody(req)) as { projectId?: string; name?: string };
-    const project = await deps.ensureProject(body.projectId && body.projectId.trim() ? body.projectId : randomUUID(), body.name);
-    writeJson(res, 201, { projectId: project.projectId });
+    const body = (await readJsonBody(req)) as { name?: string };
+    const projectId = randomUUID();
+    const project = await deps.ensureProject(projectId, body.name);
+    writeJson(res, 201, { id: project.id, projectId: project.id, name: project.name, graphSpaceId: graphSpaceIdFromProjectId(project.id) });
+    return;
+  }
+
+
+
+  const renameMatch = /^\/v1\/projects\/([^/]+)\/name$/.exec(requestUrl.pathname);
+  if (req.method === "PATCH" && renameMatch) {
+    const projectId = decodeURIComponent(renameMatch[1]!);
+    const project = deps.catalog.projects[projectId];
+    if (!project) return void writeJson(res, 404, { status: "error", reasonCode: "PROJECT.NOT_FOUND" });
+    const body = (await readJsonBody(req)) as { name?: unknown };
+    if (typeof body.name !== "string" || !body.name.trim()) {
+      return void writeJson(res, 400, { status: "rejected", category: "VALIDATION", reasonCode: "PROJECT.NAME_REQUIRED" });
+    }
+    project.name = body.name.trim();
+    project.updatedAt = Date.now();
+    await saveCatalog(deps.catalogPath, deps.catalog);
+    writeJson(res, 200, { id: project.id, projectId: project.id, name: project.name, graphSpaceId: graphSpaceIdFromProjectId(project.id) });
     return;
   }
 
@@ -354,7 +402,7 @@ async function handleRequest(
     await deps.ensureProject(projectId);
     await deps.refreshProjectHead(projectId);
     const project = deps.catalog.projects[projectId];
-    writeJson(res, 200, { ...project, snapshotsCount: deps.catalog.snapshots[projectId]?.length ?? 0 });
+    writeJson(res, 200, { ...project, projectId: project.id, graphSpaceId: graphSpaceIdFromProjectId(project.id), snapshotsCount: deps.catalog.snapshots[projectId]?.length ?? 0 });
     return;
   }
 
@@ -375,11 +423,17 @@ async function handleRequest(
     writeJson(res, 400, { status: "rejected", category: "VALIDATION", reasonCode: "GRAPH_SPACE_ID.REQUIRED" });
     return;
   }
+  if (!isUuid(projectId)) {
+    writeJson(res, 400, { status: "rejected", category: "VALIDATION", reasonCode: "PROJECT_ID.UUID_REQUIRED" });
+    return;
+  }
+  const graphSpaceId = graphSpaceIdFromProjectId(projectId);
+  assertV1ProjectGraphInvariant(projectId, graphSpaceId);
   await deps.ensureProject(projectId);
   const { gateway } = await deps.getProjectContext(projectId);
 
   if (req.method === "GET" && requestUrl.pathname === `/v1/${encodeURIComponent(projectId)}/graph:view`) {
-    writeJson(res, 200, await readGraphView(gateway, projectId, principal));
+    writeJson(res, 200, await readGraphView(gateway, graphSpaceId, principal));
     return;
   }
 
@@ -413,8 +467,8 @@ async function handleRequest(
     const snapshotId = decodeURIComponent(forkMatch[1]!);
     const snapshot = (deps.catalog.snapshots[projectId] ?? []).find((entry) => entry.snapshotId === snapshotId);
     if (!snapshot) return void writeJson(res, 404, { status: "error", reasonCode: "SNAPSHOT.NOT_FOUND" });
-    const body = (await readJsonBody(req)) as { newProjectId?: string; name?: string };
-    const newProjectId = body.newProjectId?.trim() || randomUUID();
+    const body = (await readJsonBody(req)) as { name?: string };
+    const newProjectId = randomUUID();
     await deps.ensureProject(newProjectId, body.name);
     const newContext = await deps.getProjectContext(newProjectId);
     for (const node of snapshot.payload.nodes) {
@@ -429,7 +483,7 @@ async function handleRequest(
     forked.minReadableCursor = boundedMinReadableCursor(snapshot.cursor, forked.headCursor);
     await saveCatalog(deps.catalogPath, deps.catalog);
     await deps.createSnapshot(newProjectId, `fork:${snapshot.snapshotId}`);
-    writeJson(res, 200, { newProjectId });
+    writeJson(res, 200, { newProjectId, id: newProjectId, graphSpaceId: graphSpaceIdFromProjectId(newProjectId) });
     return;
   }
 
@@ -449,7 +503,7 @@ async function handleRequest(
       writeJson(res, 410, { kind: "cursor_too_old", minReadableCursor: project.minReadableCursor, recommendedSnapshotId });
       return;
     }
-    const result = await gateway.syncPull(projectId, principal, from, {
+    const result = await gateway.syncPull(graphSpaceId, principal, from, {
       limitTx: Number.parseInt(requestUrl.searchParams.get("limitTx") ?? "64", 10) || 64,
       limitBytes: Number.parseInt(requestUrl.searchParams.get("limitBytes") ?? `${128 * 1024}`, 10) || 128 * 1024
     });
@@ -466,7 +520,7 @@ async function handleRequest(
       writeJson(res, 410, { kind: "cursor_too_old", minReadableCursor: project.minReadableCursor, recommendedSnapshotId });
       return;
     }
-    const result = await gateway.syncPoll(projectId, principal, cursor);
+    const result = await gateway.syncPoll(graphSpaceId, principal, cursor);
     writeJson(res, 200, result);
     return;
   }
@@ -480,7 +534,7 @@ async function handleRequest(
       writeJson(res, 410, { kind: "cursor_too_old", minReadableCursor: project.minReadableCursor, recommendedSnapshotId });
       return;
     }
-    await streamSubscribe(res, async (cursor) => gateway.syncPull(projectId, principal, cursor));
+    await streamSubscribe(res, async (cursor) => gateway.syncPull(graphSpaceId, principal, cursor));
     return;
   }
 
@@ -493,7 +547,7 @@ async function handleRequest(
       metadata: typeof body.metadata === "object" && body.metadata !== null ? body.metadata as Record<string, unknown> : undefined
     };
     const idempotencyKey = readIdempotencyKey(req, body.idempotencyKey);
-    const outcome = await submitGraphCommand(gateway, projectId, principal, idempotencyKey, { type: "graph.node.created", node });
+    const outcome = await submitGraphCommand(gateway, graphSpaceId, principal, idempotencyKey, { type: "graph.node.created", node });
     await deps.maybeCreateAutoSnapshot(projectId);
     writeJson(res, 200, { node, outcome });
     return;
@@ -510,7 +564,7 @@ async function handleRequest(
       label: typeof body.label === "string" ? body.label : undefined
     };
     const idempotencyKey = readIdempotencyKey(req, body.idempotencyKey);
-    const outcome = await submitGraphCommand(gateway, projectId, principal, idempotencyKey, { type: "graph.link.created", link });
+    const outcome = await submitGraphCommand(gateway, graphSpaceId, principal, idempotencyKey, { type: "graph.link.created", link });
     await deps.maybeCreateAutoSnapshot(projectId);
     writeJson(res, 200, { link, outcome });
     return;
@@ -520,7 +574,7 @@ async function handleRequest(
     const body = (await readJsonBody(req)) as { label?: unknown; idempotencyKey?: string };
     if (typeof body.label !== "string") return void writeJson(res, 400, { status: "rejected", category: "VALIDATION", reasonCode: "TRANSPORT.INVALID_REQUEST" });
     const nodeId = decodeURIComponent(requestUrl.pathname.slice(`/v1/${encodeURIComponent(projectId)}/graph:nodes/`.length));
-    const outcome = await submitGraphCommand(gateway, projectId, principal, readIdempotencyKey(req, body.idempotencyKey), { type: "graph.node.label.updated", nodeId, label: body.label });
+    const outcome = await submitGraphCommand(gateway, graphSpaceId, principal, readIdempotencyKey(req, body.idempotencyKey), { type: "graph.node.label.updated", nodeId, label: body.label });
     await deps.maybeCreateAutoSnapshot(projectId);
     writeJson(res, 200, { outcome, nodeId, label: body.label });
     return;
@@ -528,7 +582,7 @@ async function handleRequest(
 
   if (req.method === "DELETE" && new RegExp(`^/v1/${escapeRegExp(encodeURIComponent(projectId))}/graph:links/[^/]+$`).test(requestUrl.pathname)) {
     const linkId = decodeURIComponent(requestUrl.pathname.slice(`/v1/${encodeURIComponent(projectId)}/graph:links/`.length));
-    const outcome = await submitGraphCommand(gateway, projectId, principal, readIdempotencyKey(req), { type: "graph.link.deleted", linkId });
+    const outcome = await submitGraphCommand(gateway, graphSpaceId, principal, readIdempotencyKey(req), { type: "graph.link.deleted", linkId });
     await deps.maybeCreateAutoSnapshot(projectId);
     writeJson(res, 200, { outcome, linkId });
     return;
@@ -536,7 +590,7 @@ async function handleRequest(
 
   if (req.method === "DELETE" && new RegExp(`^/v1/${escapeRegExp(encodeURIComponent(projectId))}/graph:nodes/[^/]+$`).test(requestUrl.pathname)) {
     const nodeId = decodeURIComponent(requestUrl.pathname.slice(`/v1/${encodeURIComponent(projectId)}/graph:nodes/`.length));
-    const outcome = await submitGraphCommand(gateway, projectId, principal, readIdempotencyKey(req), { type: "graph.node.deleted", nodeId });
+    const outcome = await submitGraphCommand(gateway, graphSpaceId, principal, readIdempotencyKey(req), { type: "graph.node.deleted", nodeId });
     await deps.maybeCreateAutoSnapshot(projectId);
     writeJson(res, 200, { outcome, nodeId });
     return;
@@ -558,8 +612,47 @@ function normalizeRetentionPolicy(policy: RetentionPolicy): RetentionPolicy {
 
 async function loadCatalog(filePath: string): Promise<CatalogState> {
   try {
-    const raw = JSON.parse(await fs.readFile(filePath, "utf8")) as CatalogState;
-    return { projects: raw.projects ?? {}, snapshots: raw.snapshots ?? {} };
+    const raw = JSON.parse(await fs.readFile(filePath, "utf8")) as { projects?: Record<string, Partial<ProjectRecord> & { projectId?: string; id?: string; name?: string }>; snapshots?: Record<string, SnapshotRecord[]> };
+    const normalizedProjects: Record<string, ProjectRecord> = {};
+    const normalizedSnapshots: Record<string, SnapshotRecord[]> = {};
+    let migratedProjects = 0;
+
+    for (const [legacyKey, legacyProject] of Object.entries(raw.projects ?? {})) {
+      const legacyId = typeof legacyProject.projectId === "string"
+        ? legacyProject.projectId
+        : typeof legacyProject.id === "string"
+          ? legacyProject.id
+          : legacyKey;
+      const nextId = isUuid(legacyId) ? legacyId : randomUUID();
+      const now = Date.now();
+      const name = typeof legacyProject.name === "string" && legacyProject.name.trim()
+        ? legacyProject.name.trim()
+        : isUuid(legacyId)
+          ? `Project ${legacyId.slice(0, 8)}`
+          : legacyId;
+      normalizedProjects[nextId] = {
+        id: nextId,
+        name,
+        createdAt: typeof legacyProject.createdAt === "number" ? legacyProject.createdAt : now,
+        updatedAt: typeof legacyProject.updatedAt === "number" ? legacyProject.updatedAt : now,
+        headCursor: legacyProject.headCursor ?? { metaSeq: 0, graphSeq: 0 },
+        minReadableCursor: legacyProject.minReadableCursor ?? { metaSeq: 0, graphSeq: 0 },
+        retentionPolicy: normalizeRetentionPolicy((legacyProject.retentionPolicy as RetentionPolicy | undefined) ?? DEV_RETENTION_PRESET)
+      };
+      const legacySnapshots = [...(raw.snapshots?.[legacyKey] ?? []), ...(legacyId !== legacyKey ? (raw.snapshots?.[legacyId] ?? []) : [])];
+      normalizedSnapshots[nextId] = legacySnapshots.map((snapshot) => ({
+        ...snapshot,
+        projectId: nextId,
+        graphSpaceId: graphSpaceIdFromProjectId(nextId)
+      }));
+      if (legacyId !== nextId || legacyProject.projectId !== undefined || legacyProject.id !== nextId) migratedProjects += 1;
+    }
+
+    if (migratedProjects > 0) {
+      console.info(`[mesh-graph-server] migrated ${migratedProjects} legacy project record(s) to UUID project ids; old identifiers were retained as project names.`);
+    }
+
+    return { projects: normalizedProjects, snapshots: normalizedSnapshots };
   } catch {
     return { projects: {}, snapshots: {} };
   }

--- a/apps/mesh-graph-server/test/projects-snapshots-retention.test.ts
+++ b/apps/mesh-graph-server/test/projects-snapshots-retention.test.ts
@@ -12,6 +12,39 @@ describe("projects + snapshots + retention", () => {
     await Promise.all(startedServers.splice(0).map((server) => server.close()));
   });
 
+
+
+  it("creates projects with UUID ids, persists names, and supports rename", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "mesh-graph-server-project-create-"));
+    const server = await startMeshGraphServer({ storageDir, port: 0 });
+    startedServers.push(server);
+
+    const create = await fetch(`${server.url}/v1/projects`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ name: "J" })
+    });
+    expect(create.status).toBe(201);
+    const created = (await create.json()) as { id: string; name: string; graphSpaceId: string };
+    expect(created.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+    expect(created.name).toBe("J");
+    expect(created.graphSpaceId).toBe(created.id);
+
+    const rename = await fetch(`${server.url}/v1/projects/${created.id}/name`, {
+      method: "PATCH",
+      headers,
+      body: JSON.stringify({ name: "Renamed project" })
+    });
+    expect(rename.status).toBe(200);
+
+    const projects = await fetch(`${server.url}/v1/projects`, { headers });
+    const list = (await projects.json()) as Array<{ id: string; name: string; graphSpaceId: string }>;
+    const createdEntry = list.find((entry) => entry.id === created.id);
+    expect(createdEntry?.name).toBe("Renamed project");
+    expect(createdEntry?.graphSpaceId).toBe(createdEntry?.id);
+  });
+
+
   it("creates/lists/gets snapshots and supports fork", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "mesh-graph-server-projects-"));
     const server = await startMeshGraphServer({ storageDir, port: 0 });
@@ -38,12 +71,12 @@ describe("projects + snapshots + retention", () => {
     const fork = await fetch(`${server.url}/v1/${server.graphSpaceId}/snapshots/${createdBody.snapshotId}:fork`, {
       method: "POST",
       headers,
-      body: JSON.stringify({ newProjectId: "fork-p1" })
+      body: JSON.stringify({ name: "fork-p1" })
     });
     const forkBody = (await fork.json()) as { newProjectId: string };
-    expect(forkBody.newProjectId).toBe("fork-p1");
+    expect(forkBody.newProjectId).toMatch(/^[0-9a-f-]{36}$/i);
 
-    const forkSnapshot = await fetch(`${server.url}/v1/fork-p1/graph:snapshot`, { headers });
+    const forkSnapshot = await fetch(`${server.url}/v1/${forkBody.newProjectId}/graph:snapshot`, { headers });
     const forkSnapshotBody = (await forkSnapshot.json()) as { payload: { nodes: unknown[]; links: unknown[] } };
     expect(forkSnapshotBody.payload.nodes.length).toBe(2);
     expect(forkSnapshotBody.payload.links.length).toBe(1);
@@ -80,19 +113,20 @@ describe("projects + snapshots + retention", () => {
     const forkResponse = await fetch(`${server.url}/v1/${server.graphSpaceId}/snapshots/${latest!.snapshotId}:fork`, {
       method: "POST",
       headers,
-      body: JSON.stringify({ newProjectId: "fork-invariant" })
+      body: JSON.stringify({ name: "fork-invariant" })
     });
     expect(forkResponse.status).toBe(200);
+    const forkPayload = (await forkResponse.json()) as { newProjectId: string };
 
     const projects = await fetch(`${server.url}/v1/projects`, { headers });
     const forked = ((await projects.json()) as Array<{ projectId: string; headCursor: { graphSeq: number }; minReadableCursor: { graphSeq: number } }>)
-      .find((entry) => entry.projectId === "fork-invariant");
+      .find((entry) => entry.projectId === forkPayload.newProjectId);
 
     expect(forked).toBeDefined();
     expect(forked!.minReadableCursor.graphSeq).toBeGreaterThanOrEqual(0);
     expect(forked!.headCursor.graphSeq).toBeGreaterThanOrEqual(forked!.minReadableCursor.graphSeq);
 
-    const subscribe = await fetch(`${server.url}/v1/fork-invariant/sync:subscribe?from=${forked!.headCursor.graphSeq}`, { headers });
+    const subscribe = await fetch(`${server.url}/v1/${forkPayload.newProjectId}/sync:subscribe?from=${forked!.headCursor.graphSeq}`, { headers });
     expect(subscribe.status).toBe(200);
   });
 

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -70,13 +70,14 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       <aside style="padding:12px;border-right:1px solid #ddd;overflow:auto;">
         <h3>Mesh Explorer</h3>
         <label>baseUrl <input id="baseUrl" style="width:100%" value="http://127.0.0.1:8090"/></label><br/>
-        <label>graphSpaceId <input id="graphSpaceId" style="width:100%" value="mesh-explorer-graph-v1"/></label><br/>
+        <label>graphSpaceId <input id="graphSpaceId" style="width:100%" value="00000000-0000-4000-8000-000000000001"/></label><br/>
         <label>principal <input id="principal" style="width:100%" value="${escapeHtml(initialPrincipal)}"/></label><br/>
         <button id="connect">Connect</button>
         <div style="margin-top:8px;padding:8px;border:1px solid #ddd;border-radius:8px;">
           <div><strong>Server policy (per project)</strong></div>
           <button id="projectsRefresh">Refresh projects</button>
           <button id="projectCreate" style="margin-left:8px;">Create project</button>
+          <button id="projectRename" style="margin-left:8px;">Rename active</button>
           <div id="projectsList" style="margin-top:6px;font-size:12px;max-height:100px;overflow:auto;"></div>
           <label>ttlSeconds <input id="policyTtl" style="width:100%" type="number"/></label>
           <label>maxEvents <input id="policyMaxEvents" style="width:100%" type="number"/></label>
@@ -157,6 +158,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   const undoRedo = new UndoRedoManager();
   const policyHydration = createPolicyHydrationController(fetchEffectivePolicy);
   let layoutUiState: LayoutUiState = loadLayoutUiState();
+  let activeProjectName = "Untitled project";
   const debugThrottleByEvent = new Map<string, number>();
 
   setConnectionStatus("disconnected");
@@ -204,6 +206,9 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   };
   el.projectCreate.onclick = () => {
     void createProject();
+  };
+  el.projectRename.onclick = () => {
+    void renameActiveProject();
   };
   el.policySave.onclick = () => {
     void savePolicy();
@@ -269,7 +274,8 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
 
   installTestHook(store, () => ({
     projectId: el.graphSpaceId.value,
-    graphSpaceId: el.graphSpaceId.value,
+    projectName: activeProjectName,
+    graphSpaceId: graphSpaceIdFromProjectId(el.graphSpaceId.value),
     localCursorKey: cursorStorageKey(normalizePrincipal(el.principal.value), el.graphSpaceId.value)
   }));
   setPolicyLoading(el.graphSpaceId.value);
@@ -281,30 +287,54 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   async function refreshProjects(): Promise<void> {
     const response = await fetch(`${el.baseUrl.value}/v1/projects`);
     if (!response.ok) return;
-    const projects = (await response.json()) as Array<{ projectId: string; headCursor?: { graphSeq: number }; minReadableCursor?: { graphSeq: number } }>;
+    const projects = (await response.json()) as Array<{ id?: string; projectId?: string; name?: string; headCursor?: { graphSeq: number }; minReadableCursor?: { graphSeq: number } }>;
     el.projectsList.innerHTML = projects
-      .map((project) => `<button data-project-id="${escapeHtml(project.projectId)}" style="display:block;margin-top:4px;">${escapeHtml(project.projectId)} (head=${project.headCursor?.graphSeq ?? 0}, min=${project.minReadableCursor?.graphSeq ?? 0})</button>`)
+      .map((project) => {
+        const id = project.id ?? project.projectId ?? "";
+        const name = project.name ?? "Untitled project";
+        return `<button data-project-id="${escapeHtml(id)}" data-project-name="${escapeHtml(name)}" style="display:block;margin-top:4px;">${escapeHtml(name)} (head=${project.headCursor?.graphSeq ?? 0}, min=${project.minReadableCursor?.graphSeq ?? 0})</button>`;
+      })
       .join("");
     for (const button of Array.from(el.projectsList.querySelectorAll("button[data-project-id]"))) {
       button.addEventListener("click", () => {
         const projectId = (button as HTMLButtonElement).dataset.projectId;
+        const projectName = (button as HTMLButtonElement).dataset.projectName;
         if (!projectId) return;
+        if (projectName) activeProjectName = projectName;
         void activateScope(projectId);
       });
     }
   }
 
   async function createProject(): Promise<void> {
-    const requested = window.prompt("projectId (empty = uuid)", "") ?? "";
+    const requestedName = window.prompt("Project name (optional)", "") ?? "";
     const response = await fetch(`${el.baseUrl.value}/v1/projects`, {
       method: "POST",
       headers: headers(el.principal.value),
-      body: JSON.stringify({ projectId: requested || undefined })
+      body: JSON.stringify({ name: requestedName.trim() || undefined })
     });
-    const payload = (await response.json()) as { projectId: string };
-    el.projectReport.textContent = `created project ${payload.projectId}`;
+    const payload = (await response.json()) as { id?: string; projectId?: string; name?: string };
+    const projectId = payload.id ?? payload.projectId ?? "";
+    if (!projectId) return;
+    activeProjectName = payload.name ?? (requestedName.trim() || "Untitled project");
+    el.projectReport.textContent = `created project ${activeProjectName}`;
     await refreshProjects();
-    await activateScope(payload.projectId);
+    await activateScope(projectId);
+  }
+
+  async function renameActiveProject(): Promise<void> {
+    const requestedName = window.prompt("New project name", activeProjectName) ?? "";
+    if (!requestedName.trim()) return;
+    const response = await fetch(`${el.baseUrl.value}/v1/projects/${encodeURIComponent(el.graphSpaceId.value)}/name`, {
+      method: "PATCH",
+      headers: headers(el.principal.value),
+      body: JSON.stringify({ name: requestedName.trim() })
+    });
+    if (!response.ok) return;
+    const payload = (await response.json()) as { name?: string };
+    activeProjectName = payload.name ?? requestedName.trim();
+    el.projectReport.textContent = `renamed project to ${activeProjectName}`;
+    await refreshProjects();
   }
 
   async function savePolicy(): Promise<void> {
@@ -324,7 +354,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     const payload = await response.json() as { retentionPolicy?: Record<string, unknown> };
     const effective = toEffectiveRetentionPolicy(payload.retentionPolicy as Partial<RetentionPolicy> | undefined);
     applyPolicyForm(effective);
-    el.projectReport.textContent = `effective policy projectId=${el.graphSpaceId.value} graphSpaceId=${el.graphSpaceId.value} => ${JSON.stringify(effective)}`;
+    el.projectReport.textContent = `effective policy projectId=${el.graphSpaceId.value} graphSpaceId=${graphSpaceIdFromProjectId(el.graphSpaceId.value)} => ${JSON.stringify(effective)}`;
   }
 
   async function fetchEffectivePolicy(scopeId: string): Promise<Partial<RetentionPolicy> | undefined> {
@@ -332,7 +362,8 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       headers: headers(el.principal.value)
     });
     if (!response.ok) return undefined;
-    const payload = await response.json() as { retentionPolicy?: Partial<RetentionPolicy> };
+    const payload = await response.json() as { name?: string; retentionPolicy?: Partial<RetentionPolicy> };
+    if (payload.name) activeProjectName = payload.name;
     return payload.retentionPolicy;
   }
 
@@ -341,7 +372,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     if (!hydrated) return;
     if (el.graphSpaceId.value !== hydrated.scopeId) return;
     applyPolicyForm(hydrated.policy);
-    el.projectReport.textContent = `effective policy projectId=${hydrated.scopeId} graphSpaceId=${hydrated.scopeId} => ${JSON.stringify(hydrated.policy)}`;
+    el.projectReport.textContent = `effective policy projectId=${hydrated.scopeId} graphSpaceId=${graphSpaceIdFromProjectId(hydrated.scopeId)} => ${JSON.stringify(hydrated.policy)}`;
   }
 
   function setPolicyLoading(scopeId: string): void {
@@ -1188,6 +1219,7 @@ type UiElements = {
   layoutPanelHost: HTMLDivElement;
   projectsRefresh: HTMLButtonElement;
   projectCreate: HTMLButtonElement;
+  projectRename: HTMLButtonElement;
   projectsList: HTMLDivElement;
   policyTtl: HTMLInputElement;
   policyMaxEvents: HTMLInputElement;
@@ -1226,6 +1258,7 @@ function byId(container: HTMLElement): UiElements {
     layoutPanelHost: container.querySelector("#layoutPanelHost") as HTMLDivElement,
     projectsRefresh: container.querySelector("#projectsRefresh") as HTMLButtonElement,
     projectCreate: container.querySelector("#projectCreate") as HTMLButtonElement,
+    projectRename: container.querySelector("#projectRename") as HTMLButtonElement,
     projectsList: container.querySelector("#projectsList") as HTMLDivElement,
     policyTtl: container.querySelector("#policyTtl") as HTMLInputElement,
     policyMaxEvents: container.querySelector("#policyMaxEvents") as HTMLInputElement,
@@ -1370,6 +1403,11 @@ function normalizePrincipal(principal: string): string {
   return trimmed || DEFAULT_PRINCIPAL;
 }
 
+function graphSpaceIdFromProjectId(projectId: string): string {
+  // v1 invariant: graphSpaceId === projectId.
+  return projectId;
+}
+
 function escapeHtml(value: string): string {
   return value
     .replaceAll("&", "&amp;")
@@ -1456,12 +1494,12 @@ function reportDevInfo(el: Pick<UiElements, "devBanner">, message: string): void
 
 type MeshDebugApi = {
   selectNodes: (ids: string[]) => void;
-  dump: () => { projectId: string; graphSpaceId: string; head: number; minReadableCursor: number; cursor: Cursor; nodesCount: number; linksCount: number; localCursorKey: string };
+  dump: () => { projectId: string; projectName: string; graphSpaceId: string; head: number; minReadableCursor: number; cursor: Cursor; nodesCount: number; linksCount: number; localCursorKey: string };
   logs?: Array<{ message: string; detail?: unknown }>;
   log?: (message: string, detail?: unknown) => void;
 };
 
-function installTestHook(store: GraphStore, readContext: () => { projectId: string; graphSpaceId: string; localCursorKey: string }): void {
+function installTestHook(store: GraphStore, readContext: () => { projectId: string; projectName: string; graphSpaceId: string; localCursorKey: string }): void {
   const mode = (import.meta as ImportMeta & { env?: { MODE?: string } }).env?.MODE;
   if (mode !== "test" && !isDebugEnabled()) return;
   const meshDebug: MeshDebugApi = {
@@ -1475,6 +1513,7 @@ function installTestHook(store: GraphStore, readContext: () => { projectId: stri
       const context = readContext();
       return {
         projectId: context.projectId,
+        projectName: context.projectName,
         graphSpaceId: context.graphSpaceId,
         head: state.cursor.graphSeq,
         minReadableCursor: 0,


### PR DESCRIPTION
### Motivation

- Replace fragile human-entered project identifiers with immutable UUIDs while keeping a human-editable project `name` for display. 
- Maintain the v1 simplification that 1 project == 1 graphSpace and make that invariant explicit in code. 
- Preserve existing developer/local data by migrating legacy project identifiers instead of silently breaking them.

### Description

- Data model: project records now use `{ id: string, name: string, createdAt, updatedAt, ... }` and `id` must be a UUID; `graphSpaceId` is derived from `id` via `graphSpaceIdFromProjectId` and the v1 invariant is asserted where appropriate. 
- Migration: `loadCatalog` normalizes legacy projects by generating UUIDs for non-UUID keys, preserving old identifiers as the human-readable `name`, remapping snapshots, and emitting a one-time migration info log. 
- API changes: `POST /v1/projects` accepts optional `{ name? }`, server generates a UUID `id` and returns `{ id, projectId: id, name, graphSpaceId }`; `GET /v1/projects` lists projects with `id/name/...`; `PATCH /v1/projects/:id/name` updates a project name only. Forking always creates a UUID project id and accepts a `name` (no client-specified id). 
- Server-side safety: added `UUID_V4ISH_REGEX` and `isUuid` validation, and an assertion helper to enforce `projectId === graphSpaceId` for v1. 
- UI: project list now shows `project.name` (not the id), create flow prompts for an optional name and auto-switches to the created project, added a “Rename active” button that calls the new rename endpoint and refreshes the list, and debug payload augmented to include `projectName`. 
- Tests: integration test updated/added to cover creating projects (UUID id + name), renaming and list reflection, and fork/list flows using the new UUID semantics.

### Testing

- Built server and UI: ran `pnpm --filter @mesh/graph-server build` and `pnpm --filter @mesh/mesh-explorer-ui build`, both completed successfully. 
- Ran server integration tests: `pnpm exec vitest run -c apps/mesh-graph-server/test/vitest.config.ts apps/mesh-graph-server/test/projects-snapshots-retention.test.ts`, which passed (all tests in that file succeeded after fixes). 
- Performed a webapp dev build and captured a UI screenshot to validate the updated project controls (create/rename) via a headless browser run; the screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a2c377b108321804a1bc7e8af93ef)