### PR TITLE
Add one-time observability for legacy project ID migration

### DIFF
--- a/apps/mesh-graph-server/src/index.ts
+++ b/apps/mesh-graph-server/src/index.ts
@@ -82,6 +82,27 @@ type SnapshotRecord = {
 type CatalogState = {
   projects: Record<string, ProjectRecord>;
   snapshots: Record<string, SnapshotRecord[]>;
+  metadata?: {
+    legacyProjectMigration?: LegacyProjectMigrationSummary;
+  };
+};
+
+type LegacyProjectMigrationMapping = {
+  oldId: string;
+  newId: string;
+  derivedName: string;
+};
+
+type LegacyProjectMigrationSummary = {
+  pendingNotice: boolean;
+  migratedCount: number;
+  mappings: LegacyProjectMigrationMapping[];
+  appliedAt: number;
+};
+
+export type LegacyProjectMigrationResult = {
+  migratedCount: number;
+  mappings: LegacyProjectMigrationMapping[];
 };
 
 type LocalSyncGatewayLike = {
@@ -153,7 +174,20 @@ export async function startMeshGraphServer(options: MeshGraphServerOptions): Pro
 
   const projectStores = new Map<string, { store: FileBackedLocalEventStore; gateway: LocalSyncGatewayLike; kernel: KernelMinimalImpl }>();
   const catalogPath = join(options.storageDir, "mesh-projects.json");
-  const catalog = await loadCatalog(catalogPath);
+  const { catalog, writeApplied } = await loadCatalog(catalogPath);
+  let shouldPersistCatalog = writeApplied;
+  const migration = catalog.metadata?.legacyProjectMigration;
+  if (migration?.pendingNotice) {
+    console.info("[mesh-graph-server] migrated legacy projects", {
+      migratedCount: migration.migratedCount,
+      mappings: migration.mappings
+    });
+    migration.pendingNotice = false;
+    shouldPersistCatalog = true;
+  }
+  if (shouldPersistCatalog) {
+    await saveCatalog(catalogPath, catalog);
+  }
 
   async function getProjectContext(projectId: string): Promise<{ store: FileBackedLocalEventStore; gateway: LocalSyncGatewayLike; kernel: KernelMinimalImpl }> {
     const cached = projectStores.get(projectId);
@@ -362,6 +396,12 @@ async function handleRequest(
   if (req.method === "GET" && requestUrl.pathname === "/") return void writePlainText(res, 200, buildRootHelpMessage(deps.graphSpaceId));
 
   if (req.method === "GET" && requestUrl.pathname === "/v1/projects") {
+    const migration = deps.catalog.metadata?.legacyProjectMigration;
+    if (migration && migration.migratedCount > 0) {
+      res.setHeader("x-mesh-legacy-migration-count", String(migration.migratedCount));
+      res.setHeader("x-mesh-legacy-migration-applied-at", String(migration.appliedAt));
+      res.setHeader("x-mesh-legacy-migration-mappings", JSON.stringify(migration.mappings));
+    }
     const entries = Object.values(deps.catalog.projects).map((project) => ({ ...project, projectId: project.id, graphSpaceId: graphSpaceIdFromProjectId(project.id), snapshotsCount: deps.catalog.snapshots[project.id]?.length ?? 0 }));
     writeJson(res, 200, entries);
     return;
@@ -610,51 +650,85 @@ function normalizeRetentionPolicy(policy: RetentionPolicy): RetentionPolicy {
   };
 }
 
-async function loadCatalog(filePath: string): Promise<CatalogState> {
+export function migrateLegacyCatalog(raw: {
+  projects?: Record<string, Partial<ProjectRecord> & { projectId?: string; id?: string; name?: string }>;
+  snapshots?: Record<string, SnapshotRecord[]>;
+  metadata?: CatalogState["metadata"];
+}): { catalog: CatalogState; migration: LegacyProjectMigrationResult; migrationApplied: boolean } {
+  const normalizedProjects: Record<string, ProjectRecord> = {};
+  const normalizedSnapshots: Record<string, SnapshotRecord[]> = {};
+  const mappings: LegacyProjectMigrationMapping[] = [];
+
+  for (const [legacyKey, legacyProject] of Object.entries(raw.projects ?? {})) {
+    const legacyId = typeof legacyProject.projectId === "string"
+      ? legacyProject.projectId
+      : typeof legacyProject.id === "string"
+        ? legacyProject.id
+        : legacyKey;
+    const nextId = isUuid(legacyId) ? legacyId : randomUUID();
+    const now = Date.now();
+    const name = typeof legacyProject.name === "string" && legacyProject.name.trim()
+      ? legacyProject.name.trim()
+      : isUuid(legacyId)
+        ? `Project ${legacyId.slice(0, 8)}`
+        : legacyId;
+    normalizedProjects[nextId] = {
+      id: nextId,
+      name,
+      createdAt: typeof legacyProject.createdAt === "number" ? legacyProject.createdAt : now,
+      updatedAt: typeof legacyProject.updatedAt === "number" ? legacyProject.updatedAt : now,
+      headCursor: legacyProject.headCursor ?? { metaSeq: 0, graphSeq: 0 },
+      minReadableCursor: legacyProject.minReadableCursor ?? { metaSeq: 0, graphSeq: 0 },
+      retentionPolicy: normalizeRetentionPolicy((legacyProject.retentionPolicy as RetentionPolicy | undefined) ?? DEV_RETENTION_PRESET)
+    };
+    const legacySnapshots = [...(raw.snapshots?.[legacyKey] ?? []), ...(legacyId !== legacyKey ? (raw.snapshots?.[legacyId] ?? []) : [])];
+    normalizedSnapshots[nextId] = legacySnapshots.map((snapshot) => ({
+      ...snapshot,
+      projectId: nextId,
+      graphSpaceId: graphSpaceIdFromProjectId(nextId)
+    }));
+    if (legacyId !== nextId || legacyProject.projectId !== undefined || legacyProject.id !== nextId) {
+      mappings.push({ oldId: legacyId, newId: nextId, derivedName: name });
+    }
+  }
+
+  const migration: LegacyProjectMigrationResult = {
+    migratedCount: mappings.length,
+    mappings
+  };
+  const migrationApplied = migration.migratedCount > 0;
+
+  return {
+    catalog: {
+      projects: normalizedProjects,
+      snapshots: normalizedSnapshots,
+      metadata: migrationApplied
+        ? {
+          legacyProjectMigration: {
+            pendingNotice: true,
+            migratedCount: migration.migratedCount,
+            mappings: migration.mappings,
+            appliedAt: Date.now()
+          }
+        }
+        : raw.metadata
+    },
+    migration,
+    migrationApplied
+  };
+}
+
+async function loadCatalog(filePath: string): Promise<{ catalog: CatalogState; writeApplied: boolean }> {
   try {
-    const raw = JSON.parse(await fs.readFile(filePath, "utf8")) as { projects?: Record<string, Partial<ProjectRecord> & { projectId?: string; id?: string; name?: string }>; snapshots?: Record<string, SnapshotRecord[]> };
-    const normalizedProjects: Record<string, ProjectRecord> = {};
-    const normalizedSnapshots: Record<string, SnapshotRecord[]> = {};
-    let migratedProjects = 0;
-
-    for (const [legacyKey, legacyProject] of Object.entries(raw.projects ?? {})) {
-      const legacyId = typeof legacyProject.projectId === "string"
-        ? legacyProject.projectId
-        : typeof legacyProject.id === "string"
-          ? legacyProject.id
-          : legacyKey;
-      const nextId = isUuid(legacyId) ? legacyId : randomUUID();
-      const now = Date.now();
-      const name = typeof legacyProject.name === "string" && legacyProject.name.trim()
-        ? legacyProject.name.trim()
-        : isUuid(legacyId)
-          ? `Project ${legacyId.slice(0, 8)}`
-          : legacyId;
-      normalizedProjects[nextId] = {
-        id: nextId,
-        name,
-        createdAt: typeof legacyProject.createdAt === "number" ? legacyProject.createdAt : now,
-        updatedAt: typeof legacyProject.updatedAt === "number" ? legacyProject.updatedAt : now,
-        headCursor: legacyProject.headCursor ?? { metaSeq: 0, graphSeq: 0 },
-        minReadableCursor: legacyProject.minReadableCursor ?? { metaSeq: 0, graphSeq: 0 },
-        retentionPolicy: normalizeRetentionPolicy((legacyProject.retentionPolicy as RetentionPolicy | undefined) ?? DEV_RETENTION_PRESET)
-      };
-      const legacySnapshots = [...(raw.snapshots?.[legacyKey] ?? []), ...(legacyId !== legacyKey ? (raw.snapshots?.[legacyId] ?? []) : [])];
-      normalizedSnapshots[nextId] = legacySnapshots.map((snapshot) => ({
-        ...snapshot,
-        projectId: nextId,
-        graphSpaceId: graphSpaceIdFromProjectId(nextId)
-      }));
-      if (legacyId !== nextId || legacyProject.projectId !== undefined || legacyProject.id !== nextId) migratedProjects += 1;
-    }
-
-    if (migratedProjects > 0) {
-      console.info(`[mesh-graph-server] migrated ${migratedProjects} legacy project record(s) to UUID project ids; old identifiers were retained as project names.`);
-    }
-
-    return { projects: normalizedProjects, snapshots: normalizedSnapshots };
+    const raw = JSON.parse(await fs.readFile(filePath, "utf8")) as {
+      projects?: Record<string, Partial<ProjectRecord> & { projectId?: string; id?: string; name?: string }>;
+      snapshots?: Record<string, SnapshotRecord[]>;
+      metadata?: CatalogState["metadata"];
+    };
+    const { catalog, migrationApplied } = migrateLegacyCatalog(raw);
+    return { catalog, writeApplied: migrationApplied };
   } catch {
-    return { projects: {}, snapshots: {} };
+    return { catalog: { projects: {}, snapshots: {} }, writeApplied: false };
   }
 }
 

--- a/apps/mesh-graph-server/test/projects-snapshots-retention.test.ts
+++ b/apps/mesh-graph-server/test/projects-snapshots-retention.test.ts
@@ -1,8 +1,8 @@
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-import { startMeshGraphServer, type MeshGraphServerHandle } from "../src/index";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { migrateLegacyCatalog, startMeshGraphServer, type MeshGraphServerHandle } from "../src/index";
 
 describe("projects + snapshots + retention", () => {
   const startedServers: MeshGraphServerHandle[] = [];
@@ -80,6 +80,68 @@ describe("projects + snapshots + retention", () => {
     const forkSnapshotBody = (await forkSnapshot.json()) as { payload: { nodes: unknown[]; links: unknown[] } };
     expect(forkSnapshotBody.payload.nodes.length).toBe(2);
     expect(forkSnapshotBody.payload.links.length).toBe(1);
+  });
+
+  it("reports legacy migration mappings and logs migration only once across restarts", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "mesh-graph-server-legacy-migration-"));
+    const catalogPath = join(storageDir, "mesh-projects.json");
+    await writeFile(catalogPath, JSON.stringify({
+      projects: {
+        J: {
+          id: "J",
+          headCursor: { metaSeq: 0, graphSeq: 0 },
+          minReadableCursor: { metaSeq: 0, graphSeq: 0 },
+          retentionPolicy: { snapshotEveryNEvents: 10, snapshotEverySeconds: 10, minSnapshotsToKeep: 1, mode: "delete" }
+        }
+      },
+      snapshots: {}
+    }), "utf8");
+
+    const migrationProbe = migrateLegacyCatalog({
+      projects: {
+        J: {
+          id: "J",
+          headCursor: { metaSeq: 0, graphSeq: 0 },
+          minReadableCursor: { metaSeq: 0, graphSeq: 0 },
+          retentionPolicy: { snapshotEveryNEvents: 10, snapshotEverySeconds: 10, minSnapshotsToKeep: 1, mode: "delete" }
+        }
+      },
+      snapshots: {}
+    });
+    expect(migrationProbe.migration).toMatchObject({
+      migratedCount: 1,
+      mappings: [
+        { oldId: "J", derivedName: "J" }
+      ]
+    });
+    expect(migrationProbe.migration.mappings[0]?.newId).toMatch(/^[0-9a-f-]{36}$/i);
+
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const server = await startMeshGraphServer({ storageDir, port: 0 });
+    startedServers.push(server);
+
+    expect(infoSpy).toHaveBeenCalledWith("[mesh-graph-server] migrated legacy projects", expect.objectContaining({
+      migratedCount: 1,
+      mappings: [expect.objectContaining({ oldId: "J", derivedName: "J" })]
+    }));
+
+    const projects = await fetch(`${server.url}/v1/projects`, { headers });
+    expect(projects.headers.get("x-mesh-legacy-migration-count")).toBe("1");
+    const firstPayload = (await projects.json()) as Array<{ id: string; name: string }>;
+    expect(firstPayload.some((entry) => entry.name === "J")).toBe(true);
+
+    await server.close();
+    startedServers.pop();
+
+    const afterFirstBootCalls = infoSpy.mock.calls.length;
+    const restarted = await startMeshGraphServer({ storageDir, port: 0 });
+    startedServers.push(restarted);
+    expect(infoSpy.mock.calls.length).toBe(afterFirstBootCalls);
+
+    const restartedProjects = await fetch(`${restarted.url}/v1/projects`, { headers });
+    expect(restartedProjects.headers.get("x-mesh-legacy-migration-count")).toBe("1");
+
+    infoSpy.mockRestore();
   });
 
 

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -287,6 +287,18 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   async function refreshProjects(): Promise<void> {
     const response = await fetch(`${el.baseUrl.value}/v1/projects`);
     if (!response.ok) return;
+    const legacyMigrationCount = Number(response.headers.get("x-mesh-legacy-migration-count") ?? "0");
+    const legacyMigrationMappings = response.headers.get("x-mesh-legacy-migration-mappings");
+    if (isDevRuntime() && Number.isFinite(legacyMigrationCount) && legacyMigrationCount > 0) {
+      reportDevInfo(el, `Migrated legacy projects: ${legacyMigrationCount}`);
+      if (legacyMigrationMappings) {
+        try {
+          console.info("[mesh-explorer-ui] legacy migration details", JSON.parse(legacyMigrationMappings));
+        } catch {
+          console.info("[mesh-explorer-ui] legacy migration details", legacyMigrationMappings);
+        }
+      }
+    }
     const projects = (await response.json()) as Array<{ id?: string; projectId?: string; name?: string; headCursor?: { graphSeq: number }; minReadableCursor?: { graphSeq: number } }>;
     el.projectsList.innerHTML = projects
       .map((project) => {
@@ -1194,6 +1206,12 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     activeAbort?.abort();
     setConnectionStatus("disconnected");
   });
+}
+
+function isDevRuntime(): boolean {
+  if (typeof window === "undefined") return false;
+  const host = window.location.hostname;
+  return host === "localhost" || host === "127.0.0.1" || host.endsWith(".local");
 }
 
 type UiElements = {


### PR DESCRIPTION
### Motivation
- Make legacy project ID → UUID migrations observable so operators/developers know when legacy IDs were upgraded and to avoid silent conversions.
- Prevent repeated noisy logs on every boot by emitting a structured one-time notice when a migration actually writes changes.

### Description
- Introduced migration plumbing and metadata into the catalog: added `migrateLegacyCatalog()` (exported) and catalog `metadata.legacyProjectMigration` that stores `migratedCount`, `mappings` (oldId/newId/derivedName), `appliedAt`, and a `pendingNotice` flag. (edited `apps/mesh-graph-server/src/index.ts`)
- On startup, the server now emits a single INFO log when `pendingNotice` is present and then marks it as consumed and persists the catalog to avoid repeated logs on subsequent boots. (edited `apps/mesh-graph-server/src/index.ts`)
- The `GET /v1/projects` handler sets headers `x-mesh-legacy-migration-count`, `x-mesh-legacy-migration-applied-at`, and `x-mesh-legacy-migration-mappings` when migration data exists so clients can detect the event. (edited `apps/mesh-graph-server/src/index.ts`)
- UI: the explorer reads these headers in `refreshProjects()` and, when running in a dev runtime, shows a small non-blocking dev banner via `reportDevInfo()` with the message `Migrated legacy projects: N` and logs mapping details to console for debugging. (edited `packages/mesh-explorer-ui/src/index.ts`)
- Tests: added an integration test that creates a legacy catalog with a legacy id (`J`), exercises `migrateLegacyCatalog()` for expected shape, starts the server and asserts the one-time log was emitted once and that the migration headers are exposed; then restarts the server and asserts the migration INFO is not re-logged. (edited `apps/mesh-graph-server/test/projects-snapshots-retention.test.ts`)

### Testing
- Ran the target test file with `vitest`: `pnpm -s vitest --run apps/mesh-graph-server/test/projects-snapshots-retention.test.ts` and it passed (6 tests passed).
- Type-checks succeeded for server and UI with `tsc`: `pnpm -s tsc -p apps/mesh-graph-server/tsconfig.json` and `pnpm -s tsc -p packages/mesh-explorer-ui/tsconfig.json`.
- The new test uses a `vi.spyOn(console, 'info')` probe to verify the migration log is emitted exactly once on first boot and not re-emitted on restart; assertions in the test succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b544e7b6c8321947fb90e00f58c6d)