### PR TITLE
Prefer persisted local cursor during sync bootstrap

### DIFF
--- a/apps/mesh-graph-server/src/index.ts
+++ b/apps/mesh-graph-server/src/index.ts
@@ -442,7 +442,13 @@ async function handleRequest(
     await deps.ensureProject(projectId);
     await deps.refreshProjectHead(projectId);
     const project = deps.catalog.projects[projectId];
-    writeJson(res, 200, { ...project, projectId: project.id, graphSpaceId: graphSpaceIdFromProjectId(project.id), snapshotsCount: deps.catalog.snapshots[projectId]?.length ?? 0 });
+    writeJson(res, 200, {
+      ...project,
+      serverCursor: project.headCursor,
+      projectId: project.id,
+      graphSpaceId: graphSpaceIdFromProjectId(project.id),
+      snapshotsCount: deps.catalog.snapshots[projectId]?.length ?? 0
+    });
     return;
   }
 

--- a/apps/mesh-graph-server/test/projects-snapshots-retention.test.ts
+++ b/apps/mesh-graph-server/test/projects-snapshots-retention.test.ts
@@ -42,6 +42,11 @@ describe("projects + snapshots + retention", () => {
     const createdEntry = list.find((entry) => entry.id === created.id);
     expect(createdEntry?.name).toBe("Renamed project");
     expect(createdEntry?.graphSpaceId).toBe(createdEntry?.id);
+
+    const projectRead = await fetch(`${server.url}/v1/${created.id}`, { headers });
+    expect(projectRead.status).toBe(200);
+    const projectPayload = (await projectRead.json()) as { headCursor?: { graphSeq: number }; serverCursor?: { graphSeq: number } };
+    expect(projectPayload.serverCursor?.graphSeq).toBe(projectPayload.headCursor?.graphSeq);
   });
 
 

--- a/packages/mesh-explorer-ui/src/bootstrapCursor.ts
+++ b/packages/mesh-explorer-ui/src/bootstrapCursor.ts
@@ -25,3 +25,26 @@ export function shouldPersistBootstrapCursor(fromCursor: Cursor, finalCursor: Cu
   if (compareCursor(finalCursor, currentCursor) < 0) return false;
   return true;
 }
+
+export function chooseInitialSyncCursor(input: {
+  persistedCursor: Cursor | null;
+  serverCursor: Cursor | null;
+  minReadableCursor: Cursor | null;
+  snapshotCursor: Cursor | null;
+}): Cursor {
+  const persisted = sanitizeCursor(input.persistedCursor);
+  if (persisted) return persisted;
+
+  const candidates = [input.serverCursor, input.minReadableCursor, input.snapshotCursor]
+    .map(sanitizeCursor)
+    .filter((cursor): cursor is Cursor => cursor !== null);
+  if (candidates.length === 0) return ZERO_CURSOR;
+  return candidates.reduce((max, cursor) => (compareCursor(cursor, max) > 0 ? cursor : max), candidates[0]!);
+}
+
+function sanitizeCursor(cursor: Cursor | null): Cursor | null {
+  if (!cursor) return null;
+  if (!Number.isFinite(cursor.metaSeq) || !Number.isFinite(cursor.graphSeq)) return null;
+  if (compareCursor(cursor, ZERO_CURSOR) < 0) return null;
+  return cursor;
+}

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -8,7 +8,7 @@ import {
   type GraphStore
 } from "./graphStore.js";
 import { compareCursor, persistCursorSafely, rotateAbortController } from "./syncGuards.js";
-import { nextMonotonicCursor, shouldPersistBootstrapCursor } from "./bootstrapCursor.js";
+import { chooseInitialSyncCursor, nextMonotonicCursor, shouldPersistBootstrapCursor } from "./bootstrapCursor.js";
 import { cursorStorageKey } from "./cursorStorage.js";
 import { buildSyncPollUrl } from "./syncPollRequest.js";
 import {
@@ -61,6 +61,15 @@ type CursorTooOldPayload = {
 type SnapshotPayloadResponse = {
   payload?: { nodes?: GraphNode[]; links?: GraphLink[] };
   cursor?: Cursor;
+};
+
+type ProjectRootPayload = {
+  cursor?: Cursor;
+  serverCursor?: Cursor;
+  headCursor?: Cursor;
+  minReadableCursor?: Cursor;
+  name?: string;
+  retentionPolicy?: Partial<RetentionPolicy>;
 };
 
 export function mountMeshExplorerUi(container: HTMLElement): void {
@@ -374,7 +383,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       headers: headers(el.principal.value)
     });
     if (!response.ok) return undefined;
-    const payload = await response.json() as { name?: string; retentionPolicy?: Partial<RetentionPolicy> };
+    const payload = await response.json() as ProjectRootPayload;
     if (payload.name) activeProjectName = payload.name;
     return payload.retentionPolicy;
   }
@@ -475,10 +484,34 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     setConnectionStatus("connecting");
     const normalizedPrincipal = normalizePrincipal(el.principal.value);
     const storageKey = cursorStorageKey(normalizedPrincipal, el.graphSpaceId.value);
-    const snapshotCursor = await bootstrapFromSnapshot(normalizedPrincipal);
-    const replayResult = await pollReplayFromCursor(snapshotCursor, sessionId, activeAbort.signal);
+    const persistedCursor = readCursor(storageKey);
+    const serverBootstrap = await fetchServerBootstrapCursor(normalizedPrincipal);
+    const snapshotCursor = persistedCursor ? null : await bootstrapFromSnapshot(normalizedPrincipal);
+    const initialCursor = chooseInitialSyncCursor({
+      persistedCursor,
+      serverCursor: serverBootstrap.serverCursor,
+      minReadableCursor: serverBootstrap.minReadableCursor,
+      snapshotCursor
+    });
+    store.setCursor(initialCursor);
+    emitUiDebugLog("sync.bootstrap.cursor_choice", {
+      graphSpaceId: el.graphSpaceId.value,
+      localCursorKey: storageKey,
+      persistedCursor,
+      serverCursor: serverBootstrap.serverCursor,
+      chosenCursor: initialCursor
+    });
+    console.info("[mesh-ui] sync bootstrap cursor choice", {
+      graphSpaceId: el.graphSpaceId.value,
+      localCursorKey: storageKey,
+      persistedCursor,
+      serverCursor: serverBootstrap.serverCursor,
+      chosenCursor: initialCursor
+    });
+
+    const replayResult = await pollReplayFromCursor(initialCursor, sessionId, activeAbort.signal);
     if (sessionId !== syncSession) return;
-    persistBootstrapCursor(storageKey, snapshotCursor, replayResult.cursor);
+    persistBootstrapCursor(storageKey, initialCursor, replayResult.cursor);
     setConnectionStatus("connected (poll-only)");
     void subscribeLoop(sessionId, activeAbort.signal);
 
@@ -503,6 +536,21 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       });
       if (!response.ok) return { metaSeq: 0, graphSeq: 0 };
       return applySnapshot((await response.json()) as SnapshotPayloadResponse);
+    }
+
+    async function fetchServerBootstrapCursor(principalValue: string): Promise<{ serverCursor: Cursor | null; minReadableCursor: Cursor | null }> {
+      const response = await meshFetch(`${el.baseUrl.value}/v1/${encodeURIComponent(el.graphSpaceId.value)}`, { headers: headers(principalValue) }, {
+        principal: principalValue,
+        transport: "fetch",
+        debugAuth,
+        onNetworkResult: (status) => markNetworkConnectivity(status, "project-root-bootstrap")
+      });
+      if (!response.ok) return { serverCursor: null, minReadableCursor: null };
+      const payload = (await response.json()) as ProjectRootPayload;
+      return {
+        serverCursor: payload.serverCursor ?? payload.headCursor ?? payload.cursor ?? null,
+        minReadableCursor: payload.minReadableCursor ?? null
+      };
     }
 
     async function recoverFromCursorTooOld(payload: CursorTooOldPayload, signal: AbortSignal): Promise<Cursor | null> {

--- a/packages/mesh-explorer-ui/test/bootstrapCursor.test.ts
+++ b/packages/mesh-explorer-ui/test/bootstrapCursor.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
 
 import { cursorStorageKey } from "../src/cursorStorage.js";
-import { isStoreEmpty, nextMonotonicCursor, resolveBootstrapFromCursor, shouldPersistBootstrapCursor, ZERO_CURSOR } from "../src/bootstrapCursor.js";
+import {
+  chooseInitialSyncCursor,
+  isStoreEmpty,
+  nextMonotonicCursor,
+  resolveBootstrapFromCursor,
+  shouldPersistBootstrapCursor,
+  ZERO_CURSOR
+} from "../src/bootstrapCursor.js";
 
 describe("mesh explorer bootstrap cursor", () => {
   it("uses {0,0} when no local cursor exists (fresh browser)", () => {
@@ -38,5 +45,23 @@ describe("mesh explorer bootstrap cursor", () => {
     expect(shouldPersistBootstrapCursor({ metaSeq: 0, graphSeq: 0 }, { metaSeq: 0, graphSeq: 5 }, { metaSeq: 0, graphSeq: 5 })).toBe(true);
     expect(shouldPersistBootstrapCursor({ metaSeq: 0, graphSeq: 5 }, { metaSeq: 0, graphSeq: 5 }, { metaSeq: 0, graphSeq: 5 })).toBe(false);
     expect(shouldPersistBootstrapCursor({ metaSeq: 0, graphSeq: 0 }, { metaSeq: 0, graphSeq: 5 }, { metaSeq: 0, graphSeq: 6 })).toBe(false);
+  });
+
+  it("prefers persisted cursor over stale server cursor for bootstrap", () => {
+    expect(chooseInitialSyncCursor({
+      persistedCursor: { metaSeq: 0, graphSeq: 100 },
+      serverCursor: { metaSeq: 0, graphSeq: 76 },
+      minReadableCursor: { metaSeq: 0, graphSeq: 100 },
+      snapshotCursor: { metaSeq: 0, graphSeq: 100 }
+    })).toEqual({ metaSeq: 0, graphSeq: 100 });
+  });
+
+  it("uses server cursor only when persisted cursor is missing", () => {
+    expect(chooseInitialSyncCursor({
+      persistedCursor: null,
+      serverCursor: { metaSeq: 0, graphSeq: 76 },
+      minReadableCursor: null,
+      snapshotCursor: null
+    })).toEqual({ metaSeq: 0, graphSeq: 76 });
   });
 });


### PR DESCRIPTION
### Motivation
- Fix a bug where the client would subscribe from a stale cursor returned by `GET /v1/:projectId` even when a newer persisted local cursor existed, causing repeated `410 cursor_too_old` recovery loops.
- Ensure bootstrap precedence uses the persisted local cursor for (principal, graphSpaceId) when present, and only falls back to server/snapshot/minReadable when missing.

### Description
- Add `chooseInitialSyncCursor` with sanitization and explicit precedence (persisted local cursor → server/head/minReadable/snapshot → `{0,0}`).
- Wire the chooser into `connectAndSync` so the UI sets `store.cursor` from the chosen cursor before `sync:poll`/`sync:subscribe`, and add diagnostic logging via `emitUiDebugLog` and `console.info` including `persistedCursor`, `serverCursor`, `chosenCursor`, `graphSpaceId`, and `localCursorKey`.
- Make `GET /v1/:projectId` return `serverCursor` (alias of `headCursor`) to clarify root endpoint semantics and support the client reading `serverCursor/head/cursor` variants safely.
- Add unit tests asserting cursor precedence (persisted=100 vs server=76 chooses persisted) and a server test verifying `serverCursor` matches `headCursor` on root reads; changes touch `bootstrapCursor.ts`, `index.ts` (UI), server root handler, and related tests.

### Testing
- Ran `pnpm vitest run packages/mesh-explorer-ui/test/bootstrapCursor.test.ts` and it passed (10 tests OK). 
- Ran targeted server test `pnpm vitest run apps/mesh-graph-server/test/projects-snapshots-retention.test.ts -t "creates projects with UUID ids, persists names, and supports rename"` and it passed (server root payload assertion OK).
- Performed a focused build `pnpm -r --filter @mesh/mesh-explorer-ui... --filter @mesh/graph-server... build` which completed successfully.
- A combined full suite run initially hit an existing long-running test timeout in `keeps fork cursors consistent and allows subscribe from head` in this CI environment, so validation used the focused tests above which demonstrate the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c52c7052c8321aaae8caeaafc951e)