### PR TITLE
Fix bootstrap cursor precedence for empty projection

### DIFF
--- a/packages/mesh-explorer-ui/src/bootstrapCursor.ts
+++ b/packages/mesh-explorer-ui/src/bootstrapCursor.ts
@@ -31,12 +31,22 @@ export function chooseInitialSyncCursor(input: {
   serverCursor: Cursor | null;
   minReadableCursor: Cursor | null;
   snapshotCursor: Cursor | null;
+  projectionEmpty: boolean;
 }): Cursor {
   const persisted = sanitizeCursor(input.persistedCursor);
+  const snapshot = sanitizeCursor(input.snapshotCursor);
+  const minReadable = sanitizeCursor(input.minReadableCursor);
+  const server = sanitizeCursor(input.serverCursor);
+
+  if (input.projectionEmpty) {
+    if (snapshot) return snapshot;
+    if (minReadable) return minReadable;
+    return ZERO_CURSOR;
+  }
+
   if (persisted) return persisted;
 
-  const candidates = [input.serverCursor, input.minReadableCursor, input.snapshotCursor]
-    .map(sanitizeCursor)
+  const candidates = [server, minReadable, snapshot]
     .filter((cursor): cursor is Cursor => cursor !== null);
   if (candidates.length === 0) return ZERO_CURSOR;
   return candidates.reduce((max, cursor) => (compareCursor(cursor, max) > 0 ? cursor : max), candidates[0]!);

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -482,16 +482,18 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     canvasRenderer?.clearTransientUiState();
     resetAutoFitState();
     setConnectionStatus("connecting");
+    const projectionEmpty = store.getState().nodesById.size === 0 && store.getState().linksById.size === 0;
     const normalizedPrincipal = normalizePrincipal(el.principal.value);
     const storageKey = cursorStorageKey(normalizedPrincipal, el.graphSpaceId.value);
     const persistedCursor = readCursor(storageKey);
     const serverBootstrap = await fetchServerBootstrapCursor(normalizedPrincipal);
-    const snapshotCursor = persistedCursor ? null : await bootstrapFromSnapshot(normalizedPrincipal);
+    const snapshotCursor = await bootstrapFromSnapshot(normalizedPrincipal);
     const initialCursor = chooseInitialSyncCursor({
       persistedCursor,
       serverCursor: serverBootstrap.serverCursor,
       minReadableCursor: serverBootstrap.minReadableCursor,
-      snapshotCursor
+      snapshotCursor,
+      projectionEmpty
     });
     store.setCursor(initialCursor);
     emitUiDebugLog("sync.bootstrap.cursor_choice", {
@@ -499,6 +501,8 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       localCursorKey: storageKey,
       persistedCursor,
       serverCursor: serverBootstrap.serverCursor,
+      snapshotCursor,
+      projectionEmpty,
       chosenCursor: initialCursor
     });
     console.info("[mesh-ui] sync bootstrap cursor choice", {
@@ -506,22 +510,55 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       localCursorKey: storageKey,
       persistedCursor,
       serverCursor: serverBootstrap.serverCursor,
+      snapshotCursor,
+      projectionEmpty,
       chosenCursor: initialCursor
     });
 
     const replayResult = await pollReplayFromCursor(initialCursor, sessionId, activeAbort.signal);
     if (sessionId !== syncSession) return;
+    emitBootstrapDiagnostics("sync.bootstrap.poll_result", {
+      cursorBefore: initialCursor,
+      cursorAfter: replayResult.cursor,
+      pollMetaEventsRead: replayResult.metaEventsRead,
+      pollGraphEventsRead: replayResult.graphEventsRead,
+      pollGraphEventTypesHead: replayResult.graphEventTypesHead,
+      appliedGraphEventsCount: replayResult.graphEventsApplied,
+      resultingNodesCount: store.getState().nodesById.size,
+      resultingLinksCount: store.getState().linksById.size
+    });
     persistBootstrapCursor(storageKey, initialCursor, replayResult.cursor);
     setConnectionStatus("connected (poll-only)");
     void subscribeLoop(sessionId, activeAbort.signal);
 
 
+    function emitBootstrapDiagnostics(event: string, payload: Record<string, unknown>): void {
+      if (!isDevRuntime()) return;
+      console.info("[mesh-ui] sync bootstrap diagnostics", {
+        event,
+        graphSpaceId: el.graphSpaceId.value,
+        localCursorKey: storageKey,
+        ...payload
+      });
+    }
+
+    function applyGraphEventsWithDiagnostics(source: "poll" | "sse", events: GraphEvent[]): void {
+      if (events.length === 0) return;
+      store.applyGraphEvents(events);
+      emitBootstrapDiagnostics("sync.graph.apply", {
+        source,
+        appliedGraphEventsCount: events.length,
+        resultingNodesCount: store.getState().nodesById.size,
+        resultingLinksCount: store.getState().linksById.size
+      });
+    }
+
     function applySnapshot(snapshot: SnapshotPayloadResponse): Cursor {
       const nodes = snapshot.payload?.nodes ?? [];
       const links = snapshot.payload?.links ?? [];
       store.resetProjection();
-      store.applyGraphEvents(nodes.map((node) => ({ type: "graph.node.created", node } as GraphEvent)));
-      store.applyGraphEvents(links.map((link) => ({ type: "graph.link.created", link } as GraphEvent)));
+      applyGraphEventsWithDiagnostics("poll", nodes.map((node) => ({ type: "graph.node.created", node } as GraphEvent)));
+      applyGraphEventsWithDiagnostics("poll", links.map((link) => ({ type: "graph.link.created", link } as GraphEvent)));
       const cursor = snapshot.cursor ?? { metaSeq: 0, graphSeq: 0 };
       store.setCursor(cursor);
       return cursor;
@@ -636,14 +673,14 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
                   const next = { ...store.getState().cursor, graphSeq: cursorFromBundles };
                   const advanced = applyCursorIfAdvanced(storageKey, next, "sse");
                   if (advanced) {
-                    store.applyGraphEvents(extractGraphEventsFromTxBundles(txBundles));
+                    applyGraphEventsWithDiagnostics("sse", extractGraphEventsFromTxBundles(txBundles));
                     setLastSyncNow();
                   }
                   continue;
                 }
                 const events = extractGraphEventsFromTxBundles(txBundles);
                 if (events.length > 0) {
-                  store.applyGraphEvents(events);
+                  applyGraphEventsWithDiagnostics("sse", events);
                   setLastSyncNow();
                 }
               }
@@ -670,9 +707,12 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       }
     }
 
-    async function pollReplayFromCursor(initialCursor: Cursor, activeSessionId: number, signal: AbortSignal): Promise<{ cursor: Cursor; graphEventsApplied: number }> {
+    async function pollReplayFromCursor(initialCursor: Cursor, activeSessionId: number, signal: AbortSignal): Promise<{ cursor: Cursor; graphEventsApplied: number; graphEventsRead: number; metaEventsRead: number; graphEventTypesHead: string[] }> {
       let cursor = initialCursor;
       let graphEventsApplied = 0;
+      let graphEventsRead = 0;
+      let metaEventsRead = 0;
+      const graphEventTypesHead: string[] = [];
       try {
         while (activeSessionId === syncSession) {
           const response = await meshFetch(
@@ -683,32 +723,46 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
           if (!response.ok) {
             if (response.status === 410) {
               const nextCursor = await bootstrapFromSnapshot(normalizedPrincipal);
-              return { cursor: nextCursor, graphEventsApplied };
+              return { cursor: nextCursor, graphEventsApplied, graphEventsRead, metaEventsRead, graphEventTypesHead };
             }
             markNetworkConnectivity(response.status === 0 ? "offline" : "degraded", "poll-non-ok");
             reportDevError(el, `sync poll non-ok: ${response.status}`);
-            return { cursor, graphEventsApplied };
+            return { cursor, graphEventsApplied, graphEventsRead, metaEventsRead, graphEventTypesHead };
           }
           const payload = (await response.json()) as SyncPollPayload;
           markNetworkConnectivity("online", "poll-success");
           const graphEvents = (payload.graph ?? []).map((entry) => asGraphEvent(entry.payload)).filter((event): event is GraphEvent => event !== null);
+          graphEventsRead += payload.graph?.length ?? 0;
+          metaEventsRead += payload.meta?.length ?? 0;
+          for (const event of graphEvents) {
+            if (graphEventTypesHead.length >= 5) break;
+            graphEventTypesHead.push(event.type);
+          }
           const nextCursor = payload.cursorAfter ?? cursor;
           const nextMonotonic = nextMonotonicCursor(cursor, nextCursor);
           const cursorUnchanged = cursorEq(nextMonotonic, cursor);
+          emitBootstrapDiagnostics("sync.bootstrap.poll_batch", {
+            cursorBefore: cursor,
+            cursorAfter: nextMonotonic,
+            metaCount: payload.meta?.length ?? 0,
+            graphCount: payload.graph?.length ?? 0,
+            graphEventTypesHead: graphEvents.slice(0, 5).map((event) => event.type),
+            cursorUnchanged
+          });
           if (!cursorUnchanged && graphEvents.length > 0) {
             graphEventsApplied += graphEvents.length;
-            store.applyGraphEvents(graphEvents);
+            applyGraphEventsWithDiagnostics("poll", graphEvents);
             setLastSyncNow();
           }
           cursor = nextMonotonic;
           if ((payload.meta?.length ?? 0) === 0 && (payload.graph?.length ?? 0) === 0 || cursorUnchanged) break;
         }
-        return { cursor, graphEventsApplied };
+        return { cursor, graphEventsApplied, graphEventsRead, metaEventsRead, graphEventTypesHead };
       } catch (error) {
-        if (signal.aborted) return { cursor, graphEventsApplied };
+        if (signal.aborted) return { cursor, graphEventsApplied, graphEventsRead, metaEventsRead, graphEventTypesHead };
         markNetworkConnectivity("offline", "poll-error");
         reportDevError(el, `sync poll failed: ${String(error)}`, error);
-        return { cursor, graphEventsApplied };
+        return { cursor, graphEventsApplied, graphEventsRead, metaEventsRead, graphEventTypesHead };
       }
     }
   }

--- a/packages/mesh-explorer-ui/test/bootstrapCursor.test.ts
+++ b/packages/mesh-explorer-ui/test/bootstrapCursor.test.ts
@@ -52,7 +52,8 @@ describe("mesh explorer bootstrap cursor", () => {
       persistedCursor: { metaSeq: 0, graphSeq: 100 },
       serverCursor: { metaSeq: 0, graphSeq: 76 },
       minReadableCursor: { metaSeq: 0, graphSeq: 100 },
-      snapshotCursor: { metaSeq: 0, graphSeq: 100 }
+      snapshotCursor: { metaSeq: 0, graphSeq: 100 },
+      projectionEmpty: false
     })).toEqual({ metaSeq: 0, graphSeq: 100 });
   });
 
@@ -61,7 +62,29 @@ describe("mesh explorer bootstrap cursor", () => {
       persistedCursor: null,
       serverCursor: { metaSeq: 0, graphSeq: 76 },
       minReadableCursor: null,
-      snapshotCursor: null
+      snapshotCursor: null,
+      projectionEmpty: false
     })).toEqual({ metaSeq: 0, graphSeq: 76 });
   });
+
+  it("prefers snapshot cursor when projection is empty", () => {
+    expect(chooseInitialSyncCursor({
+      persistedCursor: { metaSeq: 0, graphSeq: 18 },
+      serverCursor: { metaSeq: 0, graphSeq: 18 },
+      minReadableCursor: { metaSeq: 0, graphSeq: 0 },
+      snapshotCursor: { metaSeq: 0, graphSeq: 10 },
+      projectionEmpty: true
+    })).toEqual({ metaSeq: 0, graphSeq: 10 });
+  });
+
+  it("falls back to minReadable when projection is empty and snapshot is missing", () => {
+    expect(chooseInitialSyncCursor({
+      persistedCursor: { metaSeq: 0, graphSeq: 18 },
+      serverCursor: { metaSeq: 0, graphSeq: 18 },
+      minReadableCursor: { metaSeq: 0, graphSeq: 7 },
+      snapshotCursor: null,
+      projectionEmpty: true
+    })).toEqual({ metaSeq: 0, graphSeq: 7 });
+  });
+
 });


### PR DESCRIPTION
### Motivation
- Prevent bootstrapping with an advanced persisted cursor when the in-memory projection is empty, which could cold-start the UI with an empty GraphState despite a non-zero persisted cursor.
- Make the cursor-choice decision observable through existing DEV-only diagnostics so it's easier to debug bootstrap failures.

### Description
- Updated `chooseInitialSyncCursor` signature to accept `projectionEmpty` and, when true, prefer `snapshotCursor`, then `minReadableCursor`, then `ZERO_CURSOR`; otherwise preserve existing persisted/server selection logic (`packages/mesh-explorer-ui/src/bootstrapCursor.ts`).
- Changed the UI bootstrap flow in `connectAndSync` to compute `projectionEmpty`, always attempt snapshot bootstrap prior to cursor selection, pass `projectionEmpty` into `chooseInitialSyncCursor`, and surface `snapshotCursor`/`projectionEmpty` in bootstrap debug logs (`packages/mesh-explorer-ui/src/index.ts`).
- Added lightweight DEV-only instrumentation and helpers (`emitBootstrapDiagnostics`, `applyGraphEventsWithDiagnostics`) and instrumented poll/SSE/snapshot application points to emit structured diagnostics about read/applied event counts and resulting projection size without changing runtime behavior (`packages/mesh-explorer-ui/src/index.ts`).
- Added two regression tests to cover the new empty-projection behavior (snapshot preference and `minReadable` fallback) and updated existing tests to include the new `projectionEmpty` parameter (`packages/mesh-explorer-ui/test/bootstrapCursor.test.ts`).

### Testing
- Ran unit tests with `pnpm vitest run packages/mesh-explorer-ui/test/bootstrapCursor.test.ts packages/mesh-explorer-ui/test/syncPollRequest.test.ts` and all tests passed (14/14).
- Built the package with `pnpm -C packages/mesh-explorer-ui build` and TypeScript compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cddca38e0832182d54b5dff9d8821)