### PR TITLE
Add dev/test-only endpoint + UI to advance `minReadableCursor` for deterministic 410 bootstrap testing

### DIFF
--- a/apps/mesh-graph-server/src/index.ts
+++ b/apps/mesh-graph-server/src/index.ts
@@ -12,6 +12,7 @@ const GRAPH_SPACE_ID = "00000000-0000-4000-8000-000000000001";
 const UUID_V4ISH_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const PRINCIPAL_HEADER = "x-mesh-principal";
 const IDEMPOTENCY_HEADER = "x-idempotency-key";
+const DEBUG_TOKEN_HEADER = "x-mesh-debug-token";
 const DEBUG_AUTH_ENABLED = process.env.MESH_DEBUG_AUTH === "1";
 const RETENTION_JOB_ENABLED = process.env.MESH_RETENTION_JOB_ENABLED !== "0";
 const RETENTION_JOB_INTERVAL_MS = Number(process.env.MESH_RETENTION_JOB_INTERVAL_MS ?? (process.env.NODE_ENV === "production" ? 60 * 60_000 : 5 * 60_000));
@@ -133,6 +134,13 @@ type LocalSyncGatewayLike = {
       graphLimitBytes?: number;
     }
   ): Promise<{ meta: unknown[]; graph: unknown[]; cursorAfter: Cursor }>;
+};
+
+type AdvanceMinReadableRequest = {
+  projectId?: unknown;
+  graphSpaceId?: unknown;
+  newMinReadableCursor?: unknown;
+  dryRun?: unknown;
 };
 
 export interface MeshGraphServerOptions {
@@ -412,6 +420,61 @@ async function handleRequest(
     const projectId = randomUUID();
     const project = await deps.ensureProject(projectId, body.name);
     writeJson(res, 201, { id: project.id, projectId: project.id, name: project.name, graphSpaceId: graphSpaceIdFromProjectId(project.id) });
+    return;
+  }
+
+  if (req.method === "POST" && requestUrl.pathname === "/debug/advance-min-readable-cursor") {
+    if (!debugEndpointsEnabled()) {
+      writeJson(res, 403, { status: "rejected", category: "PERMISSION", reasonCode: "DEBUG_ENDPOINTS.DISABLED" });
+      return;
+    }
+    if (!hasValidDebugToken(req)) {
+      writeJson(res, 403, { status: "rejected", category: "PERMISSION", reasonCode: "DEBUG_ENDPOINTS.INVALID_TOKEN" });
+      return;
+    }
+    const body = (await readJsonBody(req)) as AdvanceMinReadableRequest;
+    const projectId = typeof body.projectId === "string" ? body.projectId : "";
+    const graphSpaceId = typeof body.graphSpaceId === "string" ? body.graphSpaceId : "";
+    if (!projectId || !graphSpaceId || !isUuid(projectId) || !isUuid(graphSpaceId)) {
+      writeJson(res, 400, { status: "rejected", category: "VALIDATION", reasonCode: "PROJECT_SCOPE.INVALID" });
+      return;
+    }
+    if (graphSpaceIdFromProjectId(projectId) !== graphSpaceId) {
+      writeJson(res, 400, { status: "rejected", category: "VALIDATION", reasonCode: "PROJECT_SCOPE.MISMATCH" });
+      return;
+    }
+    const project = deps.catalog.projects[projectId];
+    if (!project) {
+      writeJson(res, 404, { status: "error", category: "NOT_FOUND", reasonCode: "PROJECT.NOT_FOUND", projectId, graphSpaceId });
+      return;
+    }
+    const nextCursor = parseCursorFromBody(body.newMinReadableCursor);
+    if (!nextCursor) {
+      writeJson(res, 400, { status: "rejected", category: "VALIDATION", reasonCode: "CURSOR.INVALID", projectId, graphSpaceId });
+      return;
+    }
+    const dryRun = body.dryRun !== false;
+    await deps.refreshProjectHead(projectId);
+    const previous = project.minReadableCursor;
+    const advanced = compareCursor(nextCursor, previous) > 0;
+    if (!dryRun && advanced) {
+      project.minReadableCursor = boundedMinReadableCursor(nextCursor, project.headCursor);
+      project.updatedAt = Date.now();
+      await saveCatalog(deps.catalogPath, deps.catalog);
+    }
+    const latestSnapshot = deps.catalog.snapshots[projectId]?.[0] ?? null;
+    writeJson(res, 200, {
+      projectId,
+      graphSpaceId,
+      dryRun,
+      previousMinReadableCursor: previous,
+      proposedMinReadableCursor: nextCursor,
+      appliedMinReadableCursor: !dryRun && advanced ? project.minReadableCursor : previous,
+      advanced,
+      headCursor: project.headCursor,
+      latestSnapshotCursor: latestSnapshot?.cursor ?? null,
+      cutSnapshotId: latestSnapshot?.snapshotId ?? null
+    });
     return;
   }
 
@@ -887,7 +950,38 @@ function parsePrincipal(req: IncomingMessage): PrincipalContext | null {
 function applyCorsHeaders(res: ServerResponse): void {
   res.setHeader("access-control-allow-origin", "*");
   res.setHeader("access-control-allow-methods", "GET,POST,PATCH,DELETE,OPTIONS");
-  res.setHeader("access-control-allow-headers", "content-type,x-mesh-principal,x-idempotency-key");
+  res.setHeader("access-control-allow-headers", "content-type,x-mesh-principal,x-idempotency-key,x-mesh-debug-token");
+}
+
+function debugEndpointsEnabled(): boolean {
+  if (process.env.NODE_ENV === "production") return false;
+  return process.env.ENABLE_DEBUG_ENDPOINTS !== "0";
+}
+
+function hasValidDebugToken(req: IncomingMessage): boolean {
+  const raw = req.headers[DEBUG_TOKEN_HEADER];
+  const token = (Array.isArray(raw) ? raw[0] : raw)?.trim();
+  const expected = (process.env.MESH_DEBUG_ENDPOINT_TOKEN ?? "mesh-dev-debug-token").trim();
+  return Boolean(token) && token === expected;
+}
+
+function parseCursorFromBody(input: unknown): Cursor | null {
+  if (!input || typeof input !== "object") return null;
+  const candidate = input as { metaSeq?: unknown; graphSeq?: unknown };
+  const metaSeq = toNonNegativeInteger(candidate.metaSeq);
+  const graphSeq = toNonNegativeInteger(candidate.graphSeq);
+  if (metaSeq == null || graphSeq == null) return null;
+  return { metaSeq, graphSeq };
+}
+
+function compareCursor(left: Cursor, right: Cursor): number {
+  if (left.metaSeq !== right.metaSeq) return left.metaSeq - right.metaSeq;
+  return left.graphSeq - right.graphSeq;
+}
+
+function toNonNegativeInteger(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) return null;
+  return value;
 }
 
 function maskForOtherPrincipal(principal: string): Record<string, "mask"> {

--- a/apps/mesh-graph-server/test/projects-snapshots-retention.test.ts
+++ b/apps/mesh-graph-server/test/projects-snapshots-retention.test.ts
@@ -221,6 +221,117 @@ describe("projects + snapshots + retention", () => {
     expect(heads.some((head) => head >= 150)).toBe(true);
   });
 
+  it("gates debug cursor endpoint in production mode", async () => {
+    const prevNodeEnv = process.env.NODE_ENV;
+    const prevDebugEnabled = process.env.ENABLE_DEBUG_ENDPOINTS;
+    const prevDebugToken = process.env.MESH_DEBUG_ENDPOINT_TOKEN;
+    process.env.NODE_ENV = "production";
+    process.env.ENABLE_DEBUG_ENDPOINTS = "1";
+    process.env.MESH_DEBUG_ENDPOINT_TOKEN = "debug-token";
+
+    const storageDir = await mkdtemp(join(tmpdir(), "mesh-graph-server-debug-gate-"));
+    const server = await startMeshGraphServer({ storageDir, port: 0 });
+    startedServers.push(server);
+
+    const response = await fetch(`${server.url}/debug/advance-min-readable-cursor`, {
+      method: "POST",
+      headers: { ...headers, "x-mesh-debug-token": "debug-token" },
+      body: JSON.stringify({
+        projectId: server.graphSpaceId,
+        graphSpaceId: server.graphSpaceId,
+        newMinReadableCursor: { metaSeq: 0, graphSeq: 1 },
+        dryRun: true
+      })
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ reasonCode: "DEBUG_ENDPOINTS.DISABLED" });
+
+    process.env.NODE_ENV = prevNodeEnv;
+    process.env.ENABLE_DEBUG_ENDPOINTS = prevDebugEnabled;
+    process.env.MESH_DEBUG_ENDPOINT_TOKEN = prevDebugToken;
+  });
+
+  it("supports dry-run, monotonic minReadable advance, and scope validation", async () => {
+    const prevNodeEnv = process.env.NODE_ENV;
+    const prevDebugEnabled = process.env.ENABLE_DEBUG_ENDPOINTS;
+    const prevDebugToken = process.env.MESH_DEBUG_ENDPOINT_TOKEN;
+    process.env.NODE_ENV = "test";
+    process.env.ENABLE_DEBUG_ENDPOINTS = "1";
+    process.env.MESH_DEBUG_ENDPOINT_TOKEN = "debug-token";
+
+    const storageDir = await mkdtemp(join(tmpdir(), "mesh-graph-server-debug-min-readable-"));
+    const server = await startMeshGraphServer({ storageDir, port: 0 });
+    startedServers.push(server);
+
+    await fetch(`${server.url}/v1/${server.graphSpaceId}/graph:nodes`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ id: "D-1", label: "D-1" })
+    });
+
+    const dryRun = await fetch(`${server.url}/debug/advance-min-readable-cursor`, {
+      method: "POST",
+      headers: { ...headers, "x-mesh-debug-token": "debug-token" },
+      body: JSON.stringify({
+        projectId: server.graphSpaceId,
+        graphSpaceId: server.graphSpaceId,
+        newMinReadableCursor: { metaSeq: 0, graphSeq: 1 },
+        dryRun: true
+      })
+    });
+    expect(dryRun.status).toBe(200);
+    const dryRunBody = (await dryRun.json()) as { advanced: boolean; previousMinReadableCursor: { graphSeq: number }; appliedMinReadableCursor: { graphSeq: number } };
+    expect(dryRunBody.advanced).toBe(true);
+    expect(dryRunBody.previousMinReadableCursor.graphSeq).toBe(0);
+    expect(dryRunBody.appliedMinReadableCursor.graphSeq).toBe(0);
+
+    const apply = await fetch(`${server.url}/debug/advance-min-readable-cursor`, {
+      method: "POST",
+      headers: { ...headers, "x-mesh-debug-token": "debug-token" },
+      body: JSON.stringify({
+        projectId: server.graphSpaceId,
+        graphSpaceId: server.graphSpaceId,
+        newMinReadableCursor: { metaSeq: 0, graphSeq: 1 },
+        dryRun: false
+      })
+    });
+    expect(apply.status).toBe(200);
+    await expect(apply.json()).resolves.toMatchObject({ advanced: true, appliedMinReadableCursor: { graphSeq: 1 } });
+
+    const nonMonotonic = await fetch(`${server.url}/debug/advance-min-readable-cursor`, {
+      method: "POST",
+      headers: { ...headers, "x-mesh-debug-token": "debug-token" },
+      body: JSON.stringify({
+        projectId: server.graphSpaceId,
+        graphSpaceId: server.graphSpaceId,
+        newMinReadableCursor: { metaSeq: 0, graphSeq: 1 },
+        dryRun: false
+      })
+    });
+    await expect(nonMonotonic.json()).resolves.toMatchObject({ advanced: false, appliedMinReadableCursor: { graphSeq: 1 } });
+
+    const stalePoll = await fetch(`${server.url}/v1/${server.graphSpaceId}/sync:poll?cursor=${encodeURIComponent(JSON.stringify({ metaSeq: 0, graphSeq: 0 }))}`, { headers });
+    expect(stalePoll.status).toBe(410);
+    await expect(stalePoll.json()).resolves.toMatchObject({ kind: "cursor_too_old", minReadableCursor: { graphSeq: 1 } });
+
+    const missingScope = await fetch(`${server.url}/debug/advance-min-readable-cursor`, {
+      method: "POST",
+      headers: { ...headers, "x-mesh-debug-token": "debug-token" },
+      body: JSON.stringify({
+        projectId: "00000000-0000-4000-8000-000000000099",
+        graphSpaceId: "00000000-0000-4000-8000-000000000099",
+        newMinReadableCursor: { metaSeq: 0, graphSeq: 1 },
+        dryRun: true
+      })
+    });
+    expect(missingScope.status).toBe(404);
+
+    process.env.NODE_ENV = prevNodeEnv;
+    process.env.ENABLE_DEBUG_ENDPOINTS = prevDebugEnabled;
+    process.env.MESH_DEBUG_ENDPOINT_TOKEN = prevDebugToken;
+  });
+
   it("purges history and returns cursor_too_old", async () => {
     const storageDir = await mkdtemp(join(tmpdir(), "mesh-graph-server-retention-"));
     const server = await startMeshGraphServer({ storageDir, port: 0 });

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -98,6 +98,14 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
           <button id="snapshotList" style="margin-left:8px;">List snapshots</button>
           <button id="snapshotFork" style="margin-left:8px;">Fork latest</button>
           <button id="purgeNow" style="margin-left:8px;">Purge dry-run</button>
+          <div id="debugMinReadablePanel" style="display:none;margin-top:8px;padding:8px;border:1px dashed #9ca3af;border-radius:6px;">
+            <div><strong>Debug minReadable cursor (dev/test only)</strong></div>
+            <div id="debugScopeInfo" style="margin-top:4px;font-size:12px;color:#374151;"></div>
+            <label>metaSeq <input id="debugMinReadableMetaSeq" style="width:100%" type="number" min="0" value="0"/></label>
+            <label>graphSeq <input id="debugMinReadableGraphSeq" style="width:100%" type="number" min="0" value="0"/></label>
+            <button id="debugMinReadableDryRun">Set minReadable (dry run)</button>
+            <button id="debugMinReadableApply" style="margin-left:8px;">Apply</button>
+          </div>
           <div id="projectReport" style="margin-top:6px;font-size:12px;color:#374151;"></div>
           <div style="margin-top:6px;font-size:12px;color:#6b7280;"><strong>App preferences (local only)</strong>: layout and debug options in the panel below.</div>
         </div>
@@ -131,6 +139,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   const el = byId(container);
   const debugAuth = isDebugAuthEnabled();
   const debugEnabled = isDebugEnabled();
+  el.debugMinReadablePanel.style.display = isDevRuntime() ? "block" : "none";
   const verboseSyncErrors = isSyncDebugEnabled();
   const store = createGraphStore();
   let syncSession = 0;
@@ -181,6 +190,8 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     el.principal.value = normalized;
     persistPrincipal(normalized);
   };
+
+  void refreshMinReadableDebugState();
 
   const unsubscribe = store.subscribe((snapshot: GraphState) => {
     const data: GraphData = {
@@ -233,6 +244,12 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   };
   el.purgeNow.onclick = () => {
     void purgeHistoryDryRun();
+  };
+  el.debugMinReadableDryRun.onclick = () => {
+    void advanceMinReadableCursor(true);
+  };
+  el.debugMinReadableApply.onclick = () => {
+    void advanceMinReadableCursor(false);
   };
 
   el.addNode.onclick = () => {
@@ -452,6 +469,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     await activateProjectScope(projectId, {
       setActiveProject(scopeId) {
         el.graphSpaceId.value = scopeId;
+        void refreshMinReadableDebugState();
       },
       updateRouteSelection(scopeId) {
         syncProjectIdRoute(scopeId);
@@ -474,6 +492,48 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       body: JSON.stringify({ dryRun: true })
     });
     el.projectReport.textContent = `purge report: ${await response.text()}`;
+  }
+
+  async function refreshMinReadableDebugState(): Promise<void> {
+    if (!isDevRuntime()) return;
+    try {
+      const response = await fetch(`${el.baseUrl.value}/v1/${encodeURIComponent(el.graphSpaceId.value)}`, {
+        headers: headers(el.principal.value)
+      });
+      if (!response.ok) return;
+      const payload = (await response.json()) as { minReadableCursor?: Cursor; projectId?: string; graphSpaceId?: string };
+      const minReadable = payload.minReadableCursor ?? { metaSeq: 0, graphSeq: 0 };
+      el.debugScopeInfo.textContent = `scope projectId=${payload.projectId ?? el.graphSpaceId.value}, graphSpaceId=${payload.graphSpaceId ?? el.graphSpaceId.value}, current minReadable=(${minReadable.metaSeq}, ${minReadable.graphSeq})`;
+      el.debugMinReadableMetaSeq.value = String(minReadable.metaSeq);
+      el.debugMinReadableGraphSeq.value = String(minReadable.graphSeq);
+    } catch (error) {
+      console.error("[mesh-ui] refreshMinReadableDebugState failed", error);
+    }
+  }
+
+  async function advanceMinReadableCursor(dryRun: boolean): Promise<void> {
+    try {
+      const metaSeq = Number.parseInt(el.debugMinReadableMetaSeq.value, 10);
+      const graphSeq = Number.parseInt(el.debugMinReadableGraphSeq.value, 10);
+      const response = await fetch(`${el.baseUrl.value}/debug/advance-min-readable-cursor`, {
+        method: "POST",
+        headers: headers(el.principal.value, undefined, true),
+        body: JSON.stringify({
+          projectId: el.graphSpaceId.value,
+          graphSpaceId: el.graphSpaceId.value,
+          newMinReadableCursor: { metaSeq, graphSeq },
+          dryRun
+        })
+      });
+      const bodyText = await response.text();
+      el.projectReport.textContent = `advance minReadable (${dryRun ? "dry-run" : "apply"}): ${bodyText}`;
+      if (!response.ok) {
+        console.error("[mesh-ui] advanceMinReadableCursor failed", { status: response.status, bodyText });
+      }
+      await refreshMinReadableDebugState();
+    } catch (error) {
+      console.error("[mesh-ui] advanceMinReadableCursor error", error);
+    }
   }
 
   async function connectAndSync(sessionId: number): Promise<void> {
@@ -1351,6 +1411,12 @@ type UiElements = {
   snapshotList: HTMLButtonElement;
   snapshotFork: HTMLButtonElement;
   purgeNow: HTMLButtonElement;
+  debugMinReadablePanel: HTMLDivElement;
+  debugScopeInfo: HTMLDivElement;
+  debugMinReadableMetaSeq: HTMLInputElement;
+  debugMinReadableGraphSeq: HTMLInputElement;
+  debugMinReadableDryRun: HTMLButtonElement;
+  debugMinReadableApply: HTMLButtonElement;
   projectReport: HTMLDivElement;
 };
 
@@ -1390,17 +1456,34 @@ function byId(container: HTMLElement): UiElements {
     snapshotList: container.querySelector("#snapshotList") as HTMLButtonElement,
     snapshotFork: container.querySelector("#snapshotFork") as HTMLButtonElement,
     purgeNow: container.querySelector("#purgeNow") as HTMLButtonElement,
+    debugMinReadablePanel: container.querySelector("#debugMinReadablePanel") as HTMLDivElement,
+    debugScopeInfo: container.querySelector("#debugScopeInfo") as HTMLDivElement,
+    debugMinReadableMetaSeq: container.querySelector("#debugMinReadableMetaSeq") as HTMLInputElement,
+    debugMinReadableGraphSeq: container.querySelector("#debugMinReadableGraphSeq") as HTMLInputElement,
+    debugMinReadableDryRun: container.querySelector("#debugMinReadableDryRun") as HTMLButtonElement,
+    debugMinReadableApply: container.querySelector("#debugMinReadableApply") as HTMLButtonElement,
     projectReport: container.querySelector("#projectReport") as HTMLDivElement
   };
 }
 
-function headers(principal: string, idempotencyKey?: string): HeadersInit {
+function headers(principal: string, idempotencyKey?: string, includeDebugToken = false): HeadersInit {
   const next: Record<string, string> = {
     "content-type": "application/json",
     "x-mesh-principal": normalizePrincipal(principal)
   };
   if (idempotencyKey) next["x-idempotency-key"] = idempotencyKey;
+  if (includeDebugToken) {
+    next["x-mesh-debug-token"] = readDebugEndpointToken();
+  }
   return next;
+}
+
+function readDebugEndpointToken(): string {
+  try {
+    return localStorage.getItem("meshDebugEndpointToken") || "mesh-dev-debug-token";
+  } catch {
+    return "mesh-dev-debug-token";
+  }
 }
 
 type MeshFetchMeta = {


### PR DESCRIPTION
### Motivation
- Provide a safe, dev/test-only mechanism to deterministically reproduce the `cursor_too_old` (HTTP 410) bootstrap path without deleting event files so clients can be exercised to recover via snapshot-first bootstrap.
- Keep changes gated so no accidental use in production by requiring `NODE_ENV !== 'production'` (or `ENABLE_DEBUG_ENDPOINTS`) and an explicit debug token header.

### Description
- Added a new admin/debug route `POST /debug/advance-min-readable-cursor` that validates scope ids and cursor shape, supports `dryRun: true` to preview changes, and when applied persists the new `minReadableCursor` only if it is strictly greater (monotonic) and bounded by `headCursor`; response includes `projectId`, `graphSpaceId`, `previousMinReadableCursor`, `appliedMinReadableCursor`, `advanced`, `headCursor`, `latestSnapshotCursor`, and `cutSnapshotId` (see `apps/mesh-graph-server/src/index.ts`).
- Debug endpoints are gated by `debugEndpointsEnabled()` (disabled in production) and require `x-mesh-debug-token` matching `MESH_DEBUG_ENDPOINT_TOKEN` (default `mesh-dev-debug-token`); CORS was extended to allow the debug header and helpers for parsing/validating cursors/comparing cursors were added.
- UI: added a dev-only panel in the Mesh Explorer admin panel to show current scope and `minReadableCursor`, inputs for `metaSeq`/`graphSeq`, and buttons `Set minReadable (dry run)` and `Apply` which call the new endpoint and render the JSON response to `projectReport`; the UI includes sending the debug token from localStorage (`meshDebugEndpointToken`) and is only visible in dev-like runtimes (`isDevRuntime`) (see `packages/mesh-explorer-ui/src/index.ts`).
- Tests: added tests exercising production gating, dry-run behavior, monotonic enforcement, scope validation, and that advancing `minReadableCursor` triggers `cursor_too_old` in `sync:poll` (see `apps/mesh-graph-server/test/projects-snapshots-retention.test.ts`).

### Testing
- Build: `pnpm -r build` completed successfully.
- Unit / integration tests: targeted runs used `vitest` and the relevant test cases passed: the new debug endpoint tests were run with `pnpm vitest run apps/mesh-graph-server/test/projects-snapshots-retention.test.ts -t "gates debug cursor endpoint in production mode|supports dry-run, monotonic minReadable advance, and scope validation|purges history and returns cursor_too_old"` and passed; `packages/mesh-explorer-ui/test/bootstrapCursor.test.ts` passed as well; a full run of the longer graph-server suite encountered an unrelated timeout in an existing long-running test when run together, so targeted tests were used to verify this change.
- Manual test plan (dev/test only, reproducible in <10 minutes):
  1. Start local graph server and UI in dev mode and connect to a project.
  2. Create several events and at least one snapshot using the UI (`Create snapshot`).
  3. Open the new "Debug minReadable cursor" panel, confirm the displayed `minReadableCursor`, enter a `graphSeq` > snapshot cursor (e.g., `snapshotCursor + 1`), and click `Set minReadable (dry run)` to confirm `advanced: true` but no mutation.
  4. Click `Apply` to persist the advance and confirm response shows `appliedMinReadableCursor` updated and subsequent `dry-run`/`apply` calls report `advanced: false` for the same value.
  5. Force a stale client cursor by setting the UI localStorage cursor key to an older value (e.g., `graphSeq: 0`) and reload; observe a real HTTP `410` response for `sync:poll`/`sync:subscribe` in Network tab with `kind: "cursor_too_old"` and `minReadableCursor` in payload, and verify the client bootstraps from the snapshot cursor (not jumping to head) and recovers to steady state.
  6. Failure signals to watch for are repeated `410` loops, bootstrap jumping to head on empty projection, missing `cursor_too_old` payload, or inconsistent node/link counts after recovery.

If you want, I can split the manual test plan into a dedicated README file in the repo or add an example `curl` snippet for exercising the new endpoint.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699da9a56cbc8321a20903a8b680d842)