### PR TITLE
fix(ui): floor sync bootstrap cursor to minReadable to stop 410 loops

### DIFF
--- a/docs/recovery-endpoints-sync-v1.md
+++ b/docs/recovery-endpoints-sync-v1.md
@@ -21,6 +21,7 @@
   - `sync:poll` / `events:read`: event-sequence cursors (`metaSeq`, `graphSeq`).
   - `sync:subscribe` / `sync:pull`: principal-visible transaction cursor (`from`, `cursorVisible`).
 - Always keep a durable local event cursor (`metaSeq`, `graphSeq`) for recovery and call `sync:poll` on reconnect, uncertainty, duplicate ambiguity, or cursor mismatch.
+- Client bootstrap rule: initial `chosenCursor` must be bounded by `minReadableCursor` when provided by `GET /v1/:graphSpaceId`; never start poll/subscribe below that floor, even when reusing a snapshot cursor.
 
 ## Gap / mismatch handling
 

--- a/packages/mesh-explorer-ui/src/bootstrapCursor.ts
+++ b/packages/mesh-explorer-ui/src/bootstrapCursor.ts
@@ -33,23 +33,54 @@ export function chooseInitialSyncCursor(input: {
   snapshotCursor: Cursor | null;
   projectionEmpty: boolean;
 }): Cursor {
+  return chooseInitialSyncCursorWithDiagnostics(input).chosenCursor;
+}
+
+export function chooseInitialSyncCursorWithDiagnostics(input: {
+  persistedCursor: Cursor | null;
+  serverCursor: Cursor | null;
+  minReadableCursor: Cursor | null;
+  snapshotCursor: Cursor | null;
+  projectionEmpty: boolean;
+}): {
+  chosenCursor: Cursor;
+  floorCursor: Cursor;
+  candidateDiagnostics: Array<{ source: "persistedCursor" | "snapshotCursor"; cursor: Cursor | null; accepted: boolean; reason: string }>;
+} {
   const persisted = sanitizeCursor(input.persistedCursor);
   const snapshot = sanitizeCursor(input.snapshotCursor);
   const minReadable = sanitizeCursor(input.minReadableCursor);
-  const server = sanitizeCursor(input.serverCursor);
+  const floor = minReadable ?? ZERO_CURSOR;
 
-  if (input.projectionEmpty) {
-    if (snapshot) return snapshot;
-    if (minReadable) return minReadable;
-    return ZERO_CURSOR;
+  const candidateDiagnostics: Array<{ source: "persistedCursor" | "snapshotCursor"; cursor: Cursor | null; accepted: boolean; reason: string }> = [
+    { source: "persistedCursor", cursor: persisted, accepted: false, reason: "missing_or_invalid" },
+    { source: "snapshotCursor", cursor: snapshot, accepted: false, reason: "missing_or_invalid" }
+  ];
+
+  const validCandidates = candidateDiagnostics.flatMap((candidate) => {
+    if (!candidate.cursor) return [];
+    if (compareCursor(candidate.cursor, floor) < 0) {
+      candidate.reason = "below_min_readable_floor";
+      return [];
+    }
+    candidate.accepted = true;
+    candidate.reason = "admissible";
+    return [candidate.cursor];
+  });
+
+  if (validCandidates.length > 0) {
+    return {
+      chosenCursor: validCandidates.reduce((max, cursor) => (compareCursor(cursor, max) > 0 ? cursor : max), validCandidates[0]!),
+      floorCursor: floor,
+      candidateDiagnostics
+    };
   }
 
-  if (persisted) return persisted;
-
-  const candidates = [server, minReadable, snapshot]
-    .filter((cursor): cursor is Cursor => cursor !== null);
-  if (candidates.length === 0) return ZERO_CURSOR;
-  return candidates.reduce((max, cursor) => (compareCursor(cursor, max) > 0 ? cursor : max), candidates[0]!);
+  return {
+    chosenCursor: floor,
+    floorCursor: floor,
+    candidateDiagnostics
+  };
 }
 
 function sanitizeCursor(cursor: Cursor | null): Cursor | null {

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -8,7 +8,7 @@ import {
   type GraphStore
 } from "./graphStore.js";
 import { compareCursor, persistCursorSafely, rotateAbortController } from "./syncGuards.js";
-import { chooseInitialSyncCursor, nextMonotonicCursor, shouldPersistBootstrapCursor } from "./bootstrapCursor.js";
+import { chooseInitialSyncCursorWithDiagnostics, nextMonotonicCursor, shouldPersistBootstrapCursor } from "./bootstrapCursor.js";
 import { cursorStorageKey } from "./cursorStorage.js";
 import { buildSyncPollUrl } from "./syncPollRequest.js";
 import {
@@ -585,21 +585,25 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     const persistedCursor = readCursor(storageKey);
     const serverBootstrap = await fetchServerBootstrapCursor(normalizedPrincipal);
     const snapshotCursor = await bootstrapFromSnapshot(normalizedPrincipal);
-    const initialCursor = chooseInitialSyncCursor({
+    const cursorChoice = chooseInitialSyncCursorWithDiagnostics({
       persistedCursor,
       serverCursor: serverBootstrap.serverCursor,
       minReadableCursor: serverBootstrap.minReadableCursor,
       snapshotCursor,
       projectionEmpty
     });
+    const initialCursor = cursorChoice.chosenCursor;
     store.setCursor(initialCursor);
     emitUiDebugLog("sync.bootstrap.cursor_choice", {
       graphSpaceId: el.graphSpaceId.value,
       localCursorKey: storageKey,
       persistedCursor,
       serverCursor: serverBootstrap.serverCursor,
+      minReadableCursor: serverBootstrap.minReadableCursor,
+      floorCursor: cursorChoice.floorCursor,
       snapshotCursor,
       projectionEmpty,
+      candidateDiagnostics: cursorChoice.candidateDiagnostics,
       chosenCursor: initialCursor
     });
     console.info("[mesh-ui] sync bootstrap cursor choice", {
@@ -607,8 +611,11 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       localCursorKey: storageKey,
       persistedCursor,
       serverCursor: serverBootstrap.serverCursor,
+      minReadableCursor: serverBootstrap.minReadableCursor,
+      floorCursor: cursorChoice.floorCursor,
       snapshotCursor,
       projectionEmpty,
+      candidateDiagnostics: cursorChoice.candidateDiagnostics,
       chosenCursor: initialCursor
     });
 

--- a/packages/mesh-explorer-ui/test/bootstrapCursor.test.ts
+++ b/packages/mesh-explorer-ui/test/bootstrapCursor.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { cursorStorageKey } from "../src/cursorStorage.js";
 import {
   chooseInitialSyncCursor,
+  chooseInitialSyncCursorWithDiagnostics,
   isStoreEmpty,
   nextMonotonicCursor,
   resolveBootstrapFromCursor,
@@ -57,34 +58,71 @@ describe("mesh explorer bootstrap cursor", () => {
     })).toEqual({ metaSeq: 0, graphSeq: 100 });
   });
 
-  it("uses server cursor only when persisted cursor is missing", () => {
+  it("falls back to floor when persisted/snapshot are missing", () => {
     expect(chooseInitialSyncCursor({
       persistedCursor: null,
       serverCursor: { metaSeq: 0, graphSeq: 76 },
-      minReadableCursor: null,
+      minReadableCursor: { metaSeq: 0, graphSeq: 12 },
       snapshotCursor: null,
       projectionEmpty: false
-    })).toEqual({ metaSeq: 0, graphSeq: 76 });
+    })).toEqual({ metaSeq: 0, graphSeq: 12 });
   });
 
-  it("prefers snapshot cursor when projection is empty", () => {
+  it("bootstrap respects minReadable floor even when projectionEmpty=true and snapshotCursor < minReadable", () => {
     expect(chooseInitialSyncCursor({
-      persistedCursor: { metaSeq: 0, graphSeq: 18 },
+      persistedCursor: { metaSeq: 0, graphSeq: 6 },
       serverCursor: { metaSeq: 0, graphSeq: 18 },
-      minReadableCursor: { metaSeq: 0, graphSeq: 0 },
-      snapshotCursor: { metaSeq: 0, graphSeq: 10 },
+      minReadableCursor: { metaSeq: 0, graphSeq: 6 },
+      snapshotCursor: { metaSeq: 0, graphSeq: 5 },
       projectionEmpty: true
-    })).toEqual({ metaSeq: 0, graphSeq: 10 });
+    })).toEqual({ metaSeq: 0, graphSeq: 6 });
   });
 
-  it("falls back to minReadable when projection is empty and snapshot is missing", () => {
+  it("falls back to minReadable when projection is empty and all candidates are below floor", () => {
     expect(chooseInitialSyncCursor({
-      persistedCursor: { metaSeq: 0, graphSeq: 18 },
+      persistedCursor: { metaSeq: 0, graphSeq: 5 },
       serverCursor: { metaSeq: 0, graphSeq: 18 },
-      minReadableCursor: { metaSeq: 0, graphSeq: 7 },
-      snapshotCursor: null,
+      minReadableCursor: { metaSeq: 0, graphSeq: 6 },
+      snapshotCursor: { metaSeq: 0, graphSeq: 4 },
       projectionEmpty: true
-    })).toEqual({ metaSeq: 0, graphSeq: 7 });
+    })).toEqual({ metaSeq: 0, graphSeq: 6 });
+  });
+
+  it("no repeated 410 loop after recovery when persistedCursor is updated to minReadable", () => {
+    const firstLoad = chooseInitialSyncCursor({
+      persistedCursor: null,
+      serverCursor: null,
+      minReadableCursor: { metaSeq: 0, graphSeq: 6 },
+      snapshotCursor: { metaSeq: 0, graphSeq: 5 },
+      projectionEmpty: true
+    });
+    expect(firstLoad.graphSeq).toBeGreaterThanOrEqual(6);
+
+    const refreshLoad = chooseInitialSyncCursor({
+      persistedCursor: { metaSeq: 0, graphSeq: 6 },
+      serverCursor: null,
+      minReadableCursor: null,
+      snapshotCursor: { metaSeq: 0, graphSeq: 5 },
+      projectionEmpty: true
+    });
+    expect(refreshLoad.graphSeq).toBeGreaterThanOrEqual(6);
+  });
+
+  it("emits diagnostics including rejected candidates under minReadable floor", () => {
+    const result = chooseInitialSyncCursorWithDiagnostics({
+      persistedCursor: { metaSeq: 0, graphSeq: 5 },
+      serverCursor: { metaSeq: 0, graphSeq: 9 },
+      minReadableCursor: { metaSeq: 0, graphSeq: 6 },
+      snapshotCursor: { metaSeq: 0, graphSeq: 4 },
+      projectionEmpty: true
+    });
+
+    expect(result.floorCursor).toEqual({ metaSeq: 0, graphSeq: 6 });
+    expect(result.chosenCursor).toEqual({ metaSeq: 0, graphSeq: 6 });
+    expect(result.candidateDiagnostics).toEqual([
+      { source: "persistedCursor", cursor: { metaSeq: 0, graphSeq: 5 }, accepted: false, reason: "below_min_readable_floor" },
+      { source: "snapshotCursor", cursor: { metaSeq: 0, graphSeq: 4 }, accepted: false, reason: "below_min_readable_floor" }
+    ]);
   });
 
 });


### PR DESCRIPTION
### Motivation

- Prevent a recurring 410 `cursor_too_old` loop where the client chose a snapshot cursor below the server-enforced `minReadableCursor` (notably when `projectionEmpty=true`).
- Enforce the invariant that the bootstrap `chosenCursor` MUST be >= `minReadableCursor` while preserving snapshot-when-admissible semantics and avoiding a jump-to-head shortcut.

### Description

- Implemented a diagnostics-aware chooser `chooseInitialSyncCursorWithDiagnostics` that: evaluates only `persistedCursor` and `snapshotCursor` as candidates, applies a hard `floor = minReadableCursor ?? {0,0}`, filters out candidates below the floor, returns the max admissible candidate or the floor if none, and records per-candidate diagnostics (accepted/rejected + reason).
- Wired diagnostics into bootstrap flow and logging so `sync bootstrap cursor choice` now includes `minReadableCursor`, `floorCursor`, `candidateDiagnostics`, and the `chosenCursor` to make rejections explicit.
- Updated bootstrap behavior: server/head cursor is not used as a first-class candidate; the floor guarantees chosenCursor >= minReadableCursor when provided.
- Added unit tests covering floor enforcement, convergence after recovery (no repeated 410 loop), and diagnostics output, and documented the client bootstrap rule in recovery docs.

Manual test checklist (quick):
- Start server + webapp in dev and open a project; create ~5 events and a snapshot (snapshot=5), add one event (head=6); set/apply `minReadableCursor=6`; refresh.
- Expect no repeated 410 loop; network requests must not start poll/subscribe from graphSeq=5; `sync bootstrap cursor choice` log shows `minReadableCursor=6`, `floorCursor=6`, and `chosenCursor>=6` with candidate diagnostics.
- Variants: clear localStorage -> refresh (chosenCursor==6), force localStorage cursor=0 -> at most one 410 then converge on refresh.

### Testing

- Ran unit tests: `pnpm vitest packages/mesh-explorer-ui/test/bootstrapCursor.test.ts` — 14 tests passed (OK).
- Tests added/updated: covers "bootstrap respects minReadable floor even when projectionEmpty=true and snapshotCursor < minReadable", "no repeated 410 loop after recovery when persistedCursor is updated to minReadable", and diagnostics expectations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a04c60f0108321b215cd736ad9d000)