### PR TITLE
Fix bootstrap replay when projectionEmpty=true to apply snapshot + deltas from floor

### DIFF
--- a/packages/mesh-explorer-ui/src/bootstrapCursor.ts
+++ b/packages/mesh-explorer-ui/src/bootstrapCursor.ts
@@ -83,6 +83,33 @@ export function chooseInitialSyncCursorWithDiagnostics(input: {
   };
 }
 
+export function resolveBootstrapReplayPlan(input: {
+  projectionEmpty: boolean;
+  floorCursor: Cursor;
+  snapshotCursor: Cursor | null;
+  targetCursor: Cursor;
+}): { bootstrapStartCursor: Cursor; bootstrapTargetCursor: Cursor; pollFromCursor: Cursor } {
+  const snapshot = sanitizeCursor(input.snapshotCursor);
+  const floor = sanitizeCursor(input.floorCursor) ?? ZERO_CURSOR;
+  const target = sanitizeCursor(input.targetCursor) ?? floor;
+
+  if (!input.projectionEmpty) {
+    return {
+      bootstrapStartCursor: target,
+      bootstrapTargetCursor: target,
+      pollFromCursor: target
+    };
+  }
+
+  const bootstrapStartCursor = snapshot ?? floor;
+  const pollFromCursor = snapshot && compareCursor(snapshot, floor) > 0 ? snapshot : floor;
+  return {
+    bootstrapStartCursor,
+    bootstrapTargetCursor: target,
+    pollFromCursor
+  };
+}
+
 function sanitizeCursor(cursor: Cursor | null): Cursor | null {
   if (!cursor) return null;
   if (!Number.isFinite(cursor.metaSeq) || !Number.isFinite(cursor.graphSeq)) return null;

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -8,7 +8,7 @@ import {
   type GraphStore
 } from "./graphStore.js";
 import { compareCursor, persistCursorSafely, rotateAbortController } from "./syncGuards.js";
-import { chooseInitialSyncCursorWithDiagnostics, nextMonotonicCursor, shouldPersistBootstrapCursor } from "./bootstrapCursor.js";
+import { chooseInitialSyncCursorWithDiagnostics, nextMonotonicCursor, resolveBootstrapReplayPlan, shouldPersistBootstrapCursor } from "./bootstrapCursor.js";
 import { cursorStorageKey } from "./cursorStorage.js";
 import { buildSyncPollUrl } from "./syncPollRequest.js";
 import {
@@ -584,7 +584,8 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     const storageKey = cursorStorageKey(normalizedPrincipal, el.graphSpaceId.value);
     const persistedCursor = readCursor(storageKey);
     const serverBootstrap = await fetchServerBootstrapCursor(normalizedPrincipal);
-    const snapshotCursor = await bootstrapFromSnapshot(normalizedPrincipal);
+    const snapshotBootstrap = await bootstrapFromSnapshot(normalizedPrincipal);
+    const snapshotCursor = snapshotBootstrap.cursor;
     const cursorChoice = chooseInitialSyncCursorWithDiagnostics({
       persistedCursor,
       serverCursor: serverBootstrap.serverCursor,
@@ -592,8 +593,13 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       snapshotCursor,
       projectionEmpty
     });
-    const initialCursor = cursorChoice.chosenCursor;
-    store.setCursor(initialCursor);
+    const bootstrapPlan = resolveBootstrapReplayPlan({
+      projectionEmpty,
+      floorCursor: cursorChoice.floorCursor,
+      snapshotCursor,
+      targetCursor: cursorChoice.chosenCursor
+    });
+    store.setCursor(bootstrapPlan.bootstrapStartCursor);
     emitUiDebugLog("sync.bootstrap.cursor_choice", {
       graphSpaceId: el.graphSpaceId.value,
       localCursorKey: storageKey,
@@ -603,8 +609,11 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       floorCursor: cursorChoice.floorCursor,
       snapshotCursor,
       projectionEmpty,
+      bootstrapStartCursor: bootstrapPlan.bootstrapStartCursor,
+      bootstrapTargetCursor: bootstrapPlan.bootstrapTargetCursor,
+      pollFromCursor: bootstrapPlan.pollFromCursor,
       candidateDiagnostics: cursorChoice.candidateDiagnostics,
-      chosenCursor: initialCursor
+      chosenCursor: bootstrapPlan.bootstrapTargetCursor
     });
     console.info("[mesh-ui] sync bootstrap cursor choice", {
       graphSpaceId: el.graphSpaceId.value,
@@ -615,23 +624,27 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       floorCursor: cursorChoice.floorCursor,
       snapshotCursor,
       projectionEmpty,
+      bootstrapStartCursor: bootstrapPlan.bootstrapStartCursor,
+      bootstrapTargetCursor: bootstrapPlan.bootstrapTargetCursor,
+      pollFromCursor: bootstrapPlan.pollFromCursor,
       candidateDiagnostics: cursorChoice.candidateDiagnostics,
-      chosenCursor: initialCursor
+      chosenCursor: bootstrapPlan.bootstrapTargetCursor
     });
 
-    const replayResult = await pollReplayFromCursor(initialCursor, sessionId, activeAbort.signal);
+    const replayResult = await pollReplayFromCursor(bootstrapPlan.pollFromCursor, sessionId, activeAbort.signal);
     if (sessionId !== syncSession) return;
     emitBootstrapDiagnostics("sync.bootstrap.poll_result", {
-      cursorBefore: initialCursor,
+      cursorBefore: bootstrapPlan.pollFromCursor,
       cursorAfter: replayResult.cursor,
       pollMetaEventsRead: replayResult.metaEventsRead,
       pollGraphEventsRead: replayResult.graphEventsRead,
       pollGraphEventTypesHead: replayResult.graphEventTypesHead,
       appliedGraphEventsCount: replayResult.graphEventsApplied,
+      reachedCursor: replayResult.cursor,
       resultingNodesCount: store.getState().nodesById.size,
       resultingLinksCount: store.getState().linksById.size
     });
-    persistBootstrapCursor(storageKey, initialCursor, replayResult.cursor);
+    persistBootstrapCursor(storageKey, bootstrapPlan.pollFromCursor, replayResult.cursor);
     setConnectionStatus("connected (poll-only)");
     void subscribeLoop(sessionId, activeAbort.signal);
 
@@ -646,7 +659,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       });
     }
 
-    function applyGraphEventsWithDiagnostics(source: "poll" | "sse", events: GraphEvent[]): void {
+    function applyGraphEventsWithDiagnostics(source: "snapshot" | "poll" | "sse", events: GraphEvent[]): void {
       if (events.length === 0) return;
       store.applyGraphEvents(events);
       emitBootstrapDiagnostics("sync.graph.apply", {
@@ -661,22 +674,22 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       const nodes = snapshot.payload?.nodes ?? [];
       const links = snapshot.payload?.links ?? [];
       store.resetProjection();
-      applyGraphEventsWithDiagnostics("poll", nodes.map((node) => ({ type: "graph.node.created", node } as GraphEvent)));
-      applyGraphEventsWithDiagnostics("poll", links.map((link) => ({ type: "graph.link.created", link } as GraphEvent)));
+      applyGraphEventsWithDiagnostics("snapshot", nodes.map((node) => ({ type: "graph.node.created", node } as GraphEvent)));
+      applyGraphEventsWithDiagnostics("snapshot", links.map((link) => ({ type: "graph.link.created", link } as GraphEvent)));
       const cursor = snapshot.cursor ?? { metaSeq: 0, graphSeq: 0 };
       store.setCursor(cursor);
       return cursor;
     }
 
-    async function bootstrapFromSnapshot(principalValue: string): Promise<Cursor> {
+    async function bootstrapFromSnapshot(principalValue: string): Promise<{ cursor: Cursor | null }> {
       const response = await meshFetch(`${el.baseUrl.value}/v1/${encodeURIComponent(el.graphSpaceId.value)}/graph:snapshot`, { headers: headers(principalValue) }, {
         principal: principalValue,
         transport: "fetch",
         debugAuth,
         onNetworkResult: (status) => markNetworkConnectivity(status, "snapshot-bootstrap")
       });
-      if (!response.ok) return { metaSeq: 0, graphSeq: 0 };
-      return applySnapshot((await response.json()) as SnapshotPayloadResponse);
+      if (!response.ok) return { cursor: null };
+      return { cursor: applySnapshot((await response.json()) as SnapshotPayloadResponse) };
     }
 
     async function fetchServerBootstrapCursor(principalValue: string): Promise<{ serverCursor: Cursor | null; minReadableCursor: Cursor | null }> {
@@ -826,7 +839,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
           );
           if (!response.ok) {
             if (response.status === 410) {
-              const nextCursor = await bootstrapFromSnapshot(normalizedPrincipal);
+              const nextCursor = (await bootstrapFromSnapshot(normalizedPrincipal)).cursor ?? cursor;
               return { cursor: nextCursor, graphEventsApplied, graphEventsRead, metaEventsRead, graphEventTypesHead };
             }
             markNetworkConnectivity(response.status === 0 ? "offline" : "degraded", "poll-non-ok");

--- a/packages/mesh-explorer-ui/test/bootstrapCursor.test.ts
+++ b/packages/mesh-explorer-ui/test/bootstrapCursor.test.ts
@@ -6,6 +6,7 @@ import {
   chooseInitialSyncCursorWithDiagnostics,
   isStoreEmpty,
   nextMonotonicCursor,
+  resolveBootstrapReplayPlan,
   resolveBootstrapFromCursor,
   shouldPersistBootstrapCursor,
   ZERO_CURSOR
@@ -123,6 +124,49 @@ describe("mesh explorer bootstrap cursor", () => {
       { source: "persistedCursor", cursor: { metaSeq: 0, graphSeq: 5 }, accepted: false, reason: "below_min_readable_floor" },
       { source: "snapshotCursor", cursor: { metaSeq: 0, graphSeq: 4 }, accepted: false, reason: "below_min_readable_floor" }
     ]);
+  });
+
+  it("projectionEmpty replay plan uses snapshot baseline but polls from floor when snapshot is below floor", () => {
+    const targetCursor = chooseInitialSyncCursor({
+      persistedCursor: { metaSeq: 0, graphSeq: 8 },
+      serverCursor: { metaSeq: 0, graphSeq: 8 },
+      minReadableCursor: { metaSeq: 0, graphSeq: 6 },
+      snapshotCursor: { metaSeq: 0, graphSeq: 5 },
+      projectionEmpty: true
+    });
+
+    expect(targetCursor).toEqual({ metaSeq: 0, graphSeq: 8 });
+    expect(resolveBootstrapReplayPlan({
+      projectionEmpty: true,
+      floorCursor: { metaSeq: 0, graphSeq: 6 },
+      snapshotCursor: { metaSeq: 0, graphSeq: 5 },
+      targetCursor
+    })).toEqual({
+      bootstrapStartCursor: { metaSeq: 0, graphSeq: 5 },
+      bootstrapTargetCursor: { metaSeq: 0, graphSeq: 8 },
+      pollFromCursor: { metaSeq: 0, graphSeq: 6 }
+    });
+  });
+
+  it("projectionEmpty replay plan without snapshot starts and polls from floor", () => {
+    const targetCursor = chooseInitialSyncCursor({
+      persistedCursor: { metaSeq: 0, graphSeq: 8 },
+      serverCursor: { metaSeq: 0, graphSeq: 8 },
+      minReadableCursor: { metaSeq: 0, graphSeq: 6 },
+      snapshotCursor: null,
+      projectionEmpty: true
+    });
+
+    expect(resolveBootstrapReplayPlan({
+      projectionEmpty: true,
+      floorCursor: { metaSeq: 0, graphSeq: 6 },
+      snapshotCursor: null,
+      targetCursor
+    })).toEqual({
+      bootstrapStartCursor: { metaSeq: 0, graphSeq: 6 },
+      bootstrapTargetCursor: { metaSeq: 0, graphSeq: 8 },
+      pollFromCursor: { metaSeq: 0, graphSeq: 6 }
+    });
   });
 
 });


### PR DESCRIPTION
### Motivation
- Repair bootstrap when `projectionEmpty=true` so the UI is deterministically rebuilt as snapshot + replayed deltas even if the chosen/target cursor is already at head and a poll from head returns empty.
- Prevent the observed symptom where a snapshot at 5 + deltas up to 8 are never applied because the client polled from the target/head (8) which returned no events.
- Enforce invariant that catch‑up polling never requests data from a cursor below `minReadableCursor` and that snapshot vs poll sources are correctly logged for diagnostics.

### Description
- Added `resolveBootstrapReplayPlan` to compute explicit `bootstrapStartCursor`, `bootstrapTargetCursor` and `pollFromCursor` based on `projectionEmpty`, `snapshotCursor` and `floorCursor` so replay behavior is deterministic. (file: `packages/mesh-explorer-ui/src/bootstrapCursor.ts`)
- Updated `connectAndSync` to: apply the snapshot baseline first, use the replay plan to set the store cursor to `bootstrapStartCursor`, poll from `pollFromCursor` (instead of polling from the chosen/head), and persist the bootstrap outcome accordingly. (file: `packages/mesh-explorer-ui/src/index.ts`)
- Tagged snapshot materialization with `source: "snapshot"` in apply diagnostics and extended the apply diagnostics type to include `snapshot` so logs accurately reflect whether events came from snapshot/poll/sse. (file: `packages/mesh-explorer-ui/src/index.ts`)
- Made `bootstrapFromSnapshot` return a nullable cursor to safely handle missing snapshots and adapted the 410 recovery path in `pollReplayFromCursor` to use the returned nullable cursor with a safe fallback to the current cursor. (file: `packages/mesh-explorer-ui/src/index.ts`)
- Added unit tests that validate the replay plan when `projectionEmpty=true`: one covers `snapshotCursor < floor && target=head` (snapshot applied, poll starts from floor), and one covers no-snapshot case (start/poll from floor). (file: `packages/mesh-explorer-ui/test/bootstrapCursor.test.ts`)

### Testing
- Ran unit tests: `pnpm vitest run packages/mesh-explorer-ui/test/bootstrapCursor.test.ts` and all tests passed (16 tests passed).
- Built the UI package: `pnpm --filter @mesh/mesh-explorer-ui build` and the TypeScript build completed successfully.
- The new tests validate the two key scenarios: (1) `projectionEmpty + snapshotCursor < floor + target=head` produces `bootstrapStartCursor=snapshot`, `pollFromCursor=floor` and (2) `projectionEmpty + no snapshot` starts and polls from `floor`, and the existing regression test for no repeated 410 loops remains passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0be79be188321addb6075126a0297)