### PR TITLE
Fix cursor_too_old off-by-one for sync:poll and sync:subscribe

### DIFF
--- a/apps/mesh-graph-server/PROJECT_SNAPSHOT_RETENTION.md
+++ b/apps/mesh-graph-server/PROJECT_SNAPSHOT_RETENTION.md
@@ -29,7 +29,11 @@ The graph server now treats each project as an isolated graph space with its own
 - `GET /v1/:projectId/sync:poll`
 - `GET /v1/:projectId/sync:subscribe`
 
-`sync:poll` and `sync:subscribe` return `cursor_too_old` (HTTP 410) when requesting below `minReadableCursor`.
+`sync:poll` cursor semantics are `lastApplied`, so events are returned for `(cursor, cursorAfter]`.
+`minReadableCursor` is interpreted as the minimal readable **start** seq (inclusive).
+
+- `sync:poll` rejects with `cursor_too_old` (HTTP 410) when `cursor + 1 < minReadableCursor`.
+- `sync:subscribe?from=...` uses the same exclusive semantics (`start = from + 1`) and rejects when `from + 1 < minReadableCursor`.
 
 ## Retention job
 

--- a/apps/mesh-graph-server/src/index.ts
+++ b/apps/mesh-graph-server/src/index.ts
@@ -448,6 +448,8 @@ async function handleRequest(
       writeJson(res, 404, { status: "error", category: "NOT_FOUND", reasonCode: "PROJECT.NOT_FOUND", projectId, graphSpaceId });
       return;
     }
+    // minReadableCursor is the minimal readable *start* sequence (inclusive).
+    // For sync:poll/sync:subscribe, callers provide the last applied cursor and read from +1.
     const nextCursor = parseCursorFromBody(body.newMinReadableCursor);
     if (!nextCursor) {
       writeJson(res, 400, { status: "rejected", category: "VALIDATION", reasonCode: "CURSOR.INVALID", projectId, graphSpaceId });
@@ -636,7 +638,7 @@ async function handleRequest(
   if (req.method === "GET" && pollMatch) {
     const cursor = parseCursor(requestUrl.searchParams.get("cursor"));
     const project = deps.catalog.projects[projectId]!;
-    if (isCursorTooOld(cursor, project.minReadableCursor)) {
+    if (isPollCursorTooOld(cursor, project.minReadableCursor)) {
       const recommendedSnapshotId = deps.catalog.snapshots[projectId]?.[0]?.snapshotId;
       writeJson(res, 410, { kind: "cursor_too_old", minReadableCursor: project.minReadableCursor, recommendedSnapshotId });
       return;
@@ -650,12 +652,12 @@ async function handleRequest(
   if (req.method === "GET" && subscribeMatch) {
     const from = Number.parseInt(requestUrl.searchParams.get("from") ?? "0", 10) || 0;
     const project = deps.catalog.projects[projectId]!;
-    if (from < project.minReadableCursor.graphSeq) {
+    if (isSubscribeFromTooOld(from, project.minReadableCursor.graphSeq)) {
       const recommendedSnapshotId = deps.catalog.snapshots[projectId]?.[0]?.snapshotId;
       writeJson(res, 410, { kind: "cursor_too_old", minReadableCursor: project.minReadableCursor, recommendedSnapshotId });
       return;
     }
-    await streamSubscribe(res, async (cursor) => gateway.syncPull(graphSpaceId, principal, cursor));
+    await streamSubscribe(res, async (cursor) => gateway.syncPull(graphSpaceId, principal, cursor), from);
     return;
   }
 
@@ -832,8 +834,14 @@ function parseCursor(raw: string | null): Cursor {
   }
 }
 
-function isCursorTooOld(requested: Cursor, minReadable: Cursor): boolean {
-  return requested.metaSeq < minReadable.metaSeq || requested.graphSeq < minReadable.graphSeq;
+function isPollCursorTooOld(lastAppliedCursor: Cursor, minReadableStartCursor: Cursor): boolean {
+  // sync:poll uses "cursor" as the last applied event position and reads from cursor+1,
+  // so staleness is determined against the effective start sequence, not the cursor itself.
+  return lastAppliedCursor.metaSeq + 1 < minReadableStartCursor.metaSeq || lastAppliedCursor.graphSeq + 1 < minReadableStartCursor.graphSeq;
+}
+
+function isSubscribeFromTooOld(fromLastAppliedGraphSeq: number, minReadableGraphStartSeq: number): boolean {
+  return fromLastAppliedGraphSeq + 1 < minReadableGraphStartSeq;
 }
 
 function boundedMinReadableCursor(minReadable: Cursor, head: Cursor): Cursor {
@@ -845,12 +853,13 @@ function boundedMinReadableCursor(minReadable: Cursor, head: Cursor): Cursor {
 
 async function streamSubscribe(
   res: ServerResponse,
-  syncPull: (fromCursorVisible: number) => Promise<{ txBundlesVisible: Array<{ principalCursor: number; txBundle: { graphEvents: unknown[] } }>; cursorAfterVisible: number }>
+  syncPull: (fromCursorVisible: number) => Promise<{ txBundlesVisible: Array<{ principalCursor: number; txBundle: { graphEvents: unknown[] } }>; cursorAfterVisible: number }>,
+  initialCursorVisible: number
 ): Promise<void> {
   res.statusCode = 200;
   res.setHeader("content-type", "text/event-stream");
   res.setHeader("cache-control", "no-cache");
-  let cursor = 0;
+  let cursor = initialCursorVisible;
   const timer = setInterval(async () => {
     const pulled = await syncPull(cursor);
     if (pulled.txBundlesVisible.length > 0) {

--- a/apps/mesh-graph-server/test/projects-snapshots-retention.test.ts
+++ b/apps/mesh-graph-server/test/projects-snapshots-retention.test.ts
@@ -326,8 +326,10 @@ describe("projects + snapshots + retention", () => {
     await expect(beyondHead.json()).resolves.toMatchObject({ reasonCode: "CURSOR.BEYOND_HEAD" });
 
     const stalePoll = await fetch(`${server.url}/v1/${server.graphSpaceId}/sync:poll?cursor=${encodeURIComponent(JSON.stringify({ metaSeq: 0, graphSeq: 0 }))}`, { headers });
-    expect(stalePoll.status).toBe(410);
-    await expect(stalePoll.json()).resolves.toMatchObject({ kind: "cursor_too_old", minReadableCursor: { graphSeq: 1 } });
+    expect(stalePoll.status).toBe(200);
+    const stalePollBody = (await stalePoll.json()) as { graph: Array<{ seq: number }>; cursorAfter: { graphSeq: number } };
+    expect(stalePollBody.graph[0]?.seq).toBe(1);
+    expect(stalePollBody.cursorAfter.graphSeq).toBeGreaterThanOrEqual(1);
 
     const missingScope = await fetch(`${server.url}/debug/advance-min-readable-cursor`, {
       method: "POST",
@@ -370,4 +372,78 @@ describe("projects + snapshots + retention", () => {
     expect(oldPoll.status).toBe(410);
     await expect(oldPoll.json()).resolves.toMatchObject({ kind: "cursor_too_old" });
   });
+
+  it("enforces minReadable as startSeq for poll and subscribe without off-by-one", async () => {
+    const prevNodeEnv = process.env.NODE_ENV;
+    const prevDebugEnabled = process.env.ENABLE_DEBUG_ENDPOINTS;
+    const prevDebugToken = process.env.MESH_DEBUG_ENDPOINT_TOKEN;
+    process.env.NODE_ENV = "development";
+    process.env.ENABLE_DEBUG_ENDPOINTS = "1";
+    process.env.MESH_DEBUG_ENDPOINT_TOKEN = "debug-token";
+
+    const storageDir = await mkdtemp(join(tmpdir(), "mesh-graph-server-min-readable-off-by-one-"));
+    const server = await startMeshGraphServer({ storageDir, port: 0 });
+    startedServers.push(server);
+
+    for (let idx = 1; idx <= 8; idx += 1) {
+      const createNode = await fetch(`${server.url}/v1/${server.graphSpaceId}/graph:nodes`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ id: `MR-${idx}`, label: `MR-${idx}` })
+      });
+      expect(createNode.status).toBe(200);
+    }
+
+    const snapshot = await fetch(`${server.url}/v1/${server.graphSpaceId}/snapshots:create`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ label: "pre-min-readable" })
+    });
+    const snapshotBody = (await snapshot.json()) as { snapshotId: string };
+    expect(snapshotBody.snapshotId).toBeTruthy();
+
+    const applyMinReadable = await fetch(`${server.url}/debug/advance-min-readable-cursor`, {
+      method: "POST",
+      headers: { ...headers, "x-mesh-debug-token": "debug-token" },
+      body: JSON.stringify({
+        projectId: server.graphSpaceId,
+        graphSpaceId: server.graphSpaceId,
+        newMinReadableCursor: { metaSeq: 0, graphSeq: 6 },
+        dryRun: false
+      })
+    });
+    expect(applyMinReadable.status).toBe(200);
+
+    const allowedPoll = await fetch(`${server.url}/v1/${server.graphSpaceId}/sync:poll?cursor=${encodeURIComponent(JSON.stringify({ metaSeq: 0, graphSeq: 5 }))}`, { headers });
+    expect(allowedPoll.status).toBe(200);
+    const allowedPollBody = (await allowedPoll.json()) as { graph: Array<{ seq: number }>; cursorAfter: { graphSeq: number } };
+    expect(allowedPollBody.graph.length).toBeGreaterThan(0);
+    expect(allowedPollBody.graph[0]?.seq).toBe(6);
+    expect(allowedPollBody.cursorAfter.graphSeq).toBeGreaterThanOrEqual(6);
+
+    const stalePoll = await fetch(`${server.url}/v1/${server.graphSpaceId}/sync:poll?cursor=${encodeURIComponent(JSON.stringify({ metaSeq: 0, graphSeq: 4 }))}`, { headers });
+    expect(stalePoll.status).toBe(410);
+    await expect(stalePoll.json()).resolves.toMatchObject({
+      kind: "cursor_too_old",
+      minReadableCursor: { graphSeq: 6 },
+      recommendedSnapshotId: snapshotBody.snapshotId
+    });
+
+    const allowedSubscribe = await fetch(`${server.url}/v1/${server.graphSpaceId}/sync:subscribe?from=5`, { headers });
+    expect(allowedSubscribe.status).toBe(200);
+    await allowedSubscribe.body?.cancel();
+
+    const staleSubscribe = await fetch(`${server.url}/v1/${server.graphSpaceId}/sync:subscribe?from=4`, { headers });
+    expect(staleSubscribe.status).toBe(410);
+    await expect(staleSubscribe.json()).resolves.toMatchObject({
+      kind: "cursor_too_old",
+      minReadableCursor: { graphSeq: 6 },
+      recommendedSnapshotId: snapshotBody.snapshotId
+    });
+
+    process.env.NODE_ENV = prevNodeEnv;
+    process.env.ENABLE_DEBUG_ENDPOINTS = prevDebugEnabled;
+    process.env.MESH_DEBUG_ENDPOINT_TOKEN = prevDebugToken;
+  });
+
 });


### PR DESCRIPTION
### Motivation
- Clients could never read the event at `minReadableCursor` because the server compared the provided `cursor` directly to `minReadableCursor` instead of comparing the effective start (`cursor + 1`).
- This off-by-one causes `sync:poll` and `sync:subscribe` to return `410 cursor_too_old` for requests that should be allowed, producing visible data loss on clients.
- The intended contract is that the provided `cursor`/`from` is the last-applied position and the server reads from `cursor + 1` (start inclusive), so validation must operate on that start sequence.

### Description
- Replace the old strict check with `isPollCursorTooOld` that compares `cursor + 1` against `minReadableCursor` and a parallel `isSubscribeFromTooOld` for subscribe `from` checks, and use them in the `sync:poll` and `sync:subscribe` handlers.
- Start SSE subscribe streaming from the requested `from` (as the last-applied position) by adding an `initialCursorVisible` parameter to `streamSubscribe` so the stream begins at `from` and reads from `from + 1`.
- Update retention doc and add inline server comments to document that `cursor` = lastApplied, events are returned for `(cursor, cursorAfter]`, and `minReadableCursor` is a minimal readable start seq (inclusive).
- Add and adjust automated tests in `apps/mesh-graph-server/test/projects-snapshots-retention.test.ts` to lock the contract (allow `poll` at `minReadable-1`, reject below that, mirror subscribe semantics, and preserve `410` payload shape including `recommendedSnapshotId`).

### Testing
- Built the affected server package with `pnpm -r --filter @mesh/graph-server... build` which completed successfully.
- Ran the focused test for retention behavior with `pnpm vitest run apps/mesh-graph-server/test/projects-snapshots-retention.test.ts -t "supports dry-run, monotonic minReadable advance, and scope validation"` and it passed.
- Ran the new off-by-one contract test with `pnpm vitest run apps/mesh-graph-server/test/projects-snapshots-retention.test.ts -t "enforces minReadable as startSeq for poll and subscribe without off-by-one"` and it passed.
- The automated tests verify the network behaviour: `GET /sync:poll?cursor={"graphSeq":5}` returns `200` with first graph event `seq=6`, and `GET /sync:poll?cursor={"graphSeq":4}` returns `410 cursor_too_old` with `minReadableCursor` and `recommendedSnapshotId` in the payload.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e2789b3c832194ceb0349a09e637)