### PR TITLE
Add explicit snapshot-build telemetry and retention safety tests

### DIFF
--- a/apps/mesh-graph-server/src/index.ts
+++ b/apps/mesh-graph-server/src/index.ts
@@ -253,10 +253,10 @@ export async function startMeshGraphServer(options: MeshGraphServerOptions): Pro
     const project = await ensureProject(projectId);
     const context = await getProjectContext(projectId);
     const principal = { principalId: "system" };
-    const view = await readGraphView(context.gateway, projectId, principal);
+    const snapshotBuild = await readGraphView(context.gateway, projectId, principal);
     const cursor = await context.store.getCursorHead(projectId);
     project.headCursor = cursor;
-    const payload: SnapshotPayload = { nodes: view.nodes, links: view.links, version: 1 };
+    const payload: SnapshotPayload = { nodes: snapshotBuild.view.nodes, links: snapshotBuild.view.links, version: 1 };
     const serialized = JSON.stringify(payload);
     const record: SnapshotRecord = {
       snapshotId: randomUUID(),
@@ -278,6 +278,19 @@ export async function startMeshGraphServer(options: MeshGraphServerOptions): Pro
       projectId,
       graphSpaceId: graphSpaceIdFromProjectId(projectId),
       reason: label === "auto" ? "auto" : "manual"
+    });
+    console.info("SNAPSHOT_BUILD", {
+      snapshotId: record.snapshotId,
+      projectId,
+      graphSpaceId: graphSpaceIdFromProjectId(projectId),
+      reason: label === "auto" ? "auto" : "manual",
+      buildStrategy: "replay",
+      baseCursor: snapshotBuild.baseCursor,
+      replayedEventsCount: snapshotBuild.replayedEventsCount,
+      snapshotCursor: cursor,
+      sizeBytes: record.sizeBytes,
+      nodeCount: record.nodeCount,
+      linkCount: record.linkCount
     });
     await saveCatalog(catalogPath, catalog);
     return record;
@@ -556,7 +569,7 @@ async function handleRequest(
   const { gateway } = await deps.getProjectContext(projectId);
 
   if (req.method === "GET" && requestUrl.pathname === `/v1/${encodeURIComponent(projectId)}/graph:view`) {
-    writeJson(res, 200, await readGraphView(gateway, graphSpaceId, principal));
+    writeJson(res, 200, (await readGraphView(gateway, graphSpaceId, principal)).view);
     return;
   }
 
@@ -920,19 +933,32 @@ async function submitGraphCommand(
   return gateway.submit(graphSpaceId, principal, command, idempotencyKey).final;
 }
 
-async function readGraphView(gateway: LocalSyncGatewayLike, graphSpaceId: string, principal: PrincipalContext): Promise<GraphView> {
+async function readGraphView(
+  gateway: LocalSyncGatewayLike,
+  graphSpaceId: string,
+  principal: PrincipalContext
+): Promise<{ view: GraphView; replayedEventsCount: number; baseCursor: Cursor }> {
   const nodes = new Map<string, GraphNode>();
   const links = new Map<string, GraphLink>();
+  const baseCursor: Cursor = { metaSeq: 0, graphSeq: 0 };
+  let replayedEventsCount = 0;
   let cursor = 0;
   while (true) {
     const pulled = await gateway.syncPull(graphSpaceId, principal, cursor, { limitTx: 64, limitBytes: 128 * 1024 });
     for (const bundle of pulled.txBundlesVisible) {
-      for (const rawEvent of bundle.txBundle.graphEvents) applyGraphEvent(nodes, links, rawEvent as GraphEvent);
+      for (const rawEvent of bundle.txBundle.graphEvents) {
+        applyGraphEvent(nodes, links, rawEvent as GraphEvent);
+        replayedEventsCount += 1;
+      }
     }
     if (pulled.cursorAfterVisible === cursor) break;
     cursor = pulled.cursorAfterVisible;
   }
-  return { nodes: Array.from(nodes.values()), links: Array.from(links.values()).filter((link) => nodes.has(link.source) && nodes.has(link.target)) };
+  return {
+    view: { nodes: Array.from(nodes.values()), links: Array.from(links.values()).filter((link) => nodes.has(link.source) && nodes.has(link.target)) },
+    replayedEventsCount,
+    baseCursor
+  };
 }
 
 function applyGraphEvent(nodes: Map<string, GraphNode>, links: Map<string, GraphLink>, event: GraphEvent): void {

--- a/apps/mesh-graph-server/test/projects-snapshots-retention.test.ts
+++ b/apps/mesh-graph-server/test/projects-snapshots-retention.test.ts
@@ -446,4 +446,66 @@ describe("projects + snapshots + retention", () => {
     process.env.MESH_DEBUG_ENDPOINT_TOKEN = prevDebugToken;
   });
 
+
+  it("logs replay snapshot build telemetry when creating snapshots", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "mesh-graph-server-snapshot-telemetry-"));
+    const server = await startMeshGraphServer({ storageDir, port: 0 });
+    startedServers.push(server);
+
+    await fetch(`${server.url}/v1/${server.graphSpaceId}/graph:nodes`, { method: "POST", headers, body: JSON.stringify({ id: "S-1", label: "S-1" }) });
+    await fetch(`${server.url}/v1/${server.graphSpaceId}/snapshots:create`, { method: "POST", headers, body: JSON.stringify({ label: "baseline" }) });
+    await fetch(`${server.url}/v1/${server.graphSpaceId}/graph:nodes`, { method: "POST", headers, body: JSON.stringify({ id: "S-2", label: "S-2" }) });
+
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const created = await fetch(`${server.url}/v1/${server.graphSpaceId}/snapshots:create`, { method: "POST", headers, body: JSON.stringify({ label: "manual" }) });
+    expect(created.status).toBe(200);
+
+    expect(infoSpy).toHaveBeenCalledWith("SNAPSHOT_BUILD", expect.objectContaining({
+      buildStrategy: "replay",
+      baseCursor: { metaSeq: 0, graphSeq: 0 },
+      replayedEventsCount: expect.any(Number)
+    }));
+
+    const telemetryCall = infoSpy.mock.calls.find((call) => call[0] === "SNAPSHOT_BUILD");
+    const telemetryPayload = telemetryCall?.[1] as { replayedEventsCount?: number; snapshotCursor?: { graphSeq: number } } | undefined;
+    expect(telemetryPayload?.replayedEventsCount).toBeGreaterThan(0);
+    expect(telemetryPayload?.snapshotCursor?.graphSeq).toBeGreaterThan(0);
+
+    infoSpy.mockRestore();
+  });
+
+  it("does not advance minReadable or compact history on snapshot commit", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "mesh-graph-server-snapshot-commit-order-"));
+    const server = await startMeshGraphServer({ storageDir, port: 0 });
+    startedServers.push(server);
+
+    for (let idx = 0; idx < 3; idx += 1) {
+      await fetch(`${server.url}/v1/${server.graphSpaceId}/graph:nodes`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ id: `C-${idx}`, label: `C-${idx}` })
+      });
+    }
+
+    const before = await fetch(`${server.url}/v1/${server.graphSpaceId}`, { headers });
+    const beforeBody = (await before.json()) as { minReadableCursor: { graphSeq: number } };
+    expect(beforeBody.minReadableCursor.graphSeq).toBe(0);
+
+    const snapshot = await fetch(`${server.url}/v1/${server.graphSpaceId}/snapshots:create`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ label: "commit-check" })
+    });
+    expect(snapshot.status).toBe(200);
+
+    const after = await fetch(`${server.url}/v1/${server.graphSpaceId}`, { headers });
+    const afterBody = (await after.json()) as { minReadableCursor: { graphSeq: number } };
+    expect(afterBody.minReadableCursor.graphSeq).toBe(0);
+
+    const pollFromZero = await fetch(`${server.url}/v1/${server.graphSpaceId}/sync:poll?cursor=${encodeURIComponent(JSON.stringify({ metaSeq: 0, graphSeq: 0 }))}`, { headers });
+    expect(pollFromZero.status).toBe(200);
+    const pollBody = (await pollFromZero.json()) as { graph: Array<{ seq: number }> };
+    expect(pollBody.graph.length).toBeGreaterThan(0);
+  });
+
 });


### PR DESCRIPTION
### Motivation
- Make snapshot construction observable and provable by emitting telemetry that shows whether snapshots are built by replay or by serializing an in-memory projection. 
- Ensure retention/GC semantics do not delete events or advance `minReadableCursor` before a snapshot commit is durable. 
- Provide automated tests that assert snapshot build strategy and commit ordering to serve as machine-checkable evidence.

### Description
- Instrumented snapshot creation in `apps/mesh-graph-server/src/index.ts` to call a refactored `readGraphView(...)` and emit a `SNAPSHOT_BUILD` log containing `buildStrategy`, `baseCursor`, `replayedEventsCount`, `snapshotCursor`, `sizeBytes`, `nodeCount`, and `linkCount`.
- Refactored `readGraphView` to return `{ view: GraphView; replayedEventsCount: number; baseCursor: Cursor }` so the server can report replay metrics; updated `graph:view` handler to return `.view`.
- Snapshot creation remains: `POST /v1/:projectId/snapshots:create` → handler calls `createSnapshot(projectId, label)` which builds payload from the reconstructed view and serializes `{ nodes, links, version: 1 }` (replay strategy from base cursor 0). File pointers: `apps/mesh-graph-server/src/index.ts` (createSnapshot, readGraphView, SNAPSHOT_BUILD log) and UI caller in `packages/mesh-explorer-ui/src/index.ts` (button → `POST /v1/:projectId/snapshots:create`).
- Added integration tests in `apps/mesh-graph-server/test/projects-snapshots-retention.test.ts` that assert telemetry is emitted for replay builds and that creating a snapshot does not advance `minReadableCursor` / cause GC to make cursor 0 unreadable.

### Testing
- Ran full TypeScript build with `pnpm -r build`, which completed successfully.
- Ran targeted unit/integration tests with Vitest: `pnpm vitest run apps/mesh-graph-server/test/projects-snapshots-retention.test.ts -t "logs replay snapshot build telemetry when creating snapshots|does not advance minReadable or compact history on snapshot commit"`, and these targeted tests passed (telemetry observed and commit-ordering assertions passed).
- A broader Vitest run of the file exercised more cases and showed one existing test hook timeout unrelated to these changes (a long-running test hook); the failure is not caused by the snapshot telemetry additions and the focused tests above demonstrate the new behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a35c8ed6cc8321b523bf16504c0750)