### PR TITLE
Harden cursor bootstrap resume and file-backed atomic staging

### DIFF
--- a/packages/eventstore-local/src/FileBackedLocalEventStore.ts
+++ b/packages/eventstore-local/src/FileBackedLocalEventStore.ts
@@ -141,13 +141,27 @@ export class FileBackedLocalEventStore implements LocalEventStore {
     this.hitHook(hooks, "AFTER_IDEMPOTENCY_UPSERT");
     this.hitHook(hooks, "BEFORE_IDB_COMMIT");
 
-    space.meta.push(...meta);
-    space.graph.push(...graph);
-    space.txIndex.push(txIndexEntry);
-    this.txIndexBySpace.delete(graphSpaceId);
-    space.idempotency[idempotencySlot] = { payloadHash: idempotencyCtx.payloadHash, receipt };
+    const stagedSpace: SpaceState = {
+      meta: [...space.meta, ...meta],
+      graph: [...space.graph, ...graph],
+      txIndex: [...space.txIndex, txIndexEntry],
+      idempotency: {
+        ...space.idempotency,
+        [idempotencySlot]: { payloadHash: idempotencyCtx.payloadHash, receipt }
+      }
+    };
 
-    await this.persistState();
+    if (!this.state) {
+      throw new Error("Store state not loaded");
+    }
+    this.state.spaces[graphSpaceId] = stagedSpace;
+    try {
+      await this.persistState();
+    } catch (error) {
+      this.state.spaces[graphSpaceId] = space;
+      throw error;
+    }
+    this.txIndexBySpace.delete(graphSpaceId);
     return receipt;
     });
   }

--- a/packages/eventstore-local/test/fileBackedAtomicCommit.test.ts
+++ b/packages/eventstore-local/test/fileBackedAtomicCommit.test.ts
@@ -1,0 +1,54 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { FileBackedLocalEventStore } from "../src/index.js";
+
+describe("file-backed tx atomicity", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (dir) await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps appendTx commit-or-nothing when persistState fails after staging", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "mesh-eventstore-atomic-"));
+    tempDirs.push(dir);
+    const filePath = path.join(dir, "store.json");
+
+    const store = new FileBackedLocalEventStore(filePath);
+    const graphSpaceId = "space-atomic";
+
+    const originalPersist = (store as unknown as { persistState: () => Promise<void> }).persistState.bind(store);
+    let failOnce = true;
+    (store as unknown as { persistState: () => Promise<void> }).persistState = async () => {
+      if (failOnce) {
+        failOnce = false;
+        throw new Error("simulated persist failure");
+      }
+      await originalPersist();
+    };
+
+    await expect(
+      store.appendTx(
+        graphSpaceId,
+        { txId: "tx-atomic-1", metaEvents: [{ m: 1 }], graphEvents: [{ g: 1 }] },
+        { actorId: "alice", idempotencyKey: "idem-atomic-1", payloadHash: "hash-atomic-1" }
+      )
+    ).rejects.toThrow("simulated persist failure");
+
+    expect(await store.readTxIndex(graphSpaceId)).toEqual([]);
+    expect(await store.readRange(graphSpaceId, "meta", 0, 10, "TX_CLOSED")).toEqual([]);
+    expect(await store.readRange(graphSpaceId, "graph", 0, 10, "TX_CLOSED")).toEqual([]);
+
+    const retry = await store.appendTx(
+      graphSpaceId,
+      { txId: "tx-atomic-1", metaEvents: [{ m: 1 }], graphEvents: [{ g: 1 }] },
+      { actorId: "alice", idempotencyKey: "idem-atomic-1", payloadHash: "hash-atomic-1" }
+    );
+    expect(retry).toMatchObject({ status: "committed", txId: "tx-atomic-1", txIndex: 1 });
+  });
+});

--- a/packages/mesh-explorer-ui/src/bootstrapCursor.ts
+++ b/packages/mesh-explorer-ui/src/bootstrapCursor.ts
@@ -3,17 +3,18 @@ import { compareCursor } from "./syncGuards.js";
 
 export const ZERO_CURSOR: Cursor = { metaSeq: 0, graphSeq: 0 };
 
-type StoreSnapshot = { nodesCount: number; linksCount: number };
+type StoreSnapshot = { cursor?: Cursor | null };
 
 export function resolveBootstrapFromCursor(saved: Cursor | null, snapshot: StoreSnapshot): Cursor {
-  if (isStoreEmpty(snapshot)) return ZERO_CURSOR;
-  if (!saved) return ZERO_CURSOR;
-  if (compareCursor(saved, ZERO_CURSOR) < 0) return ZERO_CURSOR;
-  return saved;
+  const normalizedSaved = normalizeCursor(saved);
+  const normalizedSnapshot = normalizeCursor(snapshot.cursor ?? null);
+  return compareCursor(normalizedSaved, normalizedSnapshot) >= 0 ? normalizedSaved : normalizedSnapshot;
 }
 
-export function isStoreEmpty(snapshot: StoreSnapshot): boolean {
-  return snapshot.nodesCount === 0 && snapshot.linksCount === 0;
+function normalizeCursor(candidate: Cursor | null): Cursor {
+  if (!candidate) return ZERO_CURSOR;
+  if (compareCursor(candidate, ZERO_CURSOR) < 0) return ZERO_CURSOR;
+  return candidate;
 }
 
 export function nextMonotonicCursor(current: Cursor, candidate: Cursor): Cursor {

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -8,7 +8,7 @@ import {
   type GraphStore
 } from "./graphStore.js";
 import { compareCursor, persistCursorSafely, rotateAbortController } from "./syncGuards.js";
-import { nextMonotonicCursor, shouldPersistBootstrapCursor } from "./bootstrapCursor.js";
+import { nextMonotonicCursor, resolveBootstrapFromCursor, shouldPersistBootstrapCursor } from "./bootstrapCursor.js";
 import { cursorStorageKey } from "./cursorStorage.js";
 import { buildSyncPollUrl } from "./syncPollRequest.js";
 import {
@@ -356,8 +356,10 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     setConnectionStatus("connecting");
     const normalizedPrincipal = normalizePrincipal(el.principal.value);
     const storageKey = cursorStorageKey(normalizedPrincipal, el.graphSpaceId.value);
+    const savedCursor = readCursor(storageKey);
     const snapshotCursor = await bootstrapFromSnapshot(normalizedPrincipal);
-    const replayResult = await pollReplayFromCursor(snapshotCursor, sessionId, activeAbort.signal);
+    const bootstrapCursor = resolveBootstrapFromCursor(savedCursor, { cursor: snapshotCursor });
+    const replayResult = await pollReplayFromCursor(bootstrapCursor, sessionId, activeAbort.signal);
     if (sessionId !== syncSession) return;
     persistBootstrapCursor(storageKey, snapshotCursor, replayResult.cursor);
     setConnectionStatus("connected (poll-only)");

--- a/packages/mesh-explorer-ui/test/bootstrapCursor.test.ts
+++ b/packages/mesh-explorer-ui/test/bootstrapCursor.test.ts
@@ -1,28 +1,23 @@
 import { describe, expect, it } from "vitest";
 
 import { cursorStorageKey } from "../src/cursorStorage.js";
-import { isStoreEmpty, nextMonotonicCursor, resolveBootstrapFromCursor, shouldPersistBootstrapCursor, ZERO_CURSOR } from "../src/bootstrapCursor.js";
+import { nextMonotonicCursor, resolveBootstrapFromCursor, shouldPersistBootstrapCursor, ZERO_CURSOR } from "../src/bootstrapCursor.js";
 
 describe("mesh explorer bootstrap cursor", () => {
-  it("uses {0,0} when no local cursor exists (fresh browser)", () => {
-    expect(resolveBootstrapFromCursor(null, { nodesCount: 1, linksCount: 0 })).toEqual({ metaSeq: 0, graphSeq: 0 });
+  it("uses {0,0} when neither snapshot nor local cursor exists", () => {
+    expect(resolveBootstrapFromCursor(null, { cursor: null })).toEqual({ metaSeq: 0, graphSeq: 0 });
   });
 
-  it("keeps replaying history from {0,0} across refresh when local cursor is still absent", () => {
-    expect(resolveBootstrapFromCursor(null, { nodesCount: 0, linksCount: 0 })).toEqual(ZERO_CURSOR);
+  it("uses persisted cursor when snapshot cursor is behind", () => {
+    expect(resolveBootstrapFromCursor({ metaSeq: 2, graphSeq: 8 }, { cursor: { metaSeq: 1, graphSeq: 6 } })).toEqual({ metaSeq: 2, graphSeq: 8 });
   });
 
-  it("uses {0,0} when store is empty even when persisted cursor exists", () => {
-    expect(resolveBootstrapFromCursor({ metaSeq: 2, graphSeq: 8 }, { nodesCount: 0, linksCount: 0 })).toEqual(ZERO_CURSOR);
+  it("uses snapshot cursor when persisted cursor is absent", () => {
+    expect(resolveBootstrapFromCursor(null, { cursor: { metaSeq: 2, graphSeq: 8 } })).toEqual({ metaSeq: 2, graphSeq: 8 });
   });
 
-  it("uses persisted cursor when store is not empty", () => {
-    expect(resolveBootstrapFromCursor({ metaSeq: 2, graphSeq: 8 }, { nodesCount: 1, linksCount: 0 })).toEqual({ metaSeq: 2, graphSeq: 8 });
-  });
-
-  it("detects when store snapshot is empty", () => {
-    expect(isStoreEmpty({ nodesCount: 0, linksCount: 0 })).toBe(true);
-    expect(isStoreEmpty({ nodesCount: 1, linksCount: 0 })).toBe(false);
+  it("uses max(savedCursor, snapshotCursor) to guarantee durable resume monotonicity", () => {
+    expect(resolveBootstrapFromCursor({ metaSeq: 3, graphSeq: 10 }, { cursor: { metaSeq: 4, graphSeq: 9 } })).toEqual({ metaSeq: 4, graphSeq: 9 });
   });
 
   it("writes exact storage key format mesh.cursor.<principal>.<graphSpaceId>", () => {
@@ -38,5 +33,9 @@ describe("mesh explorer bootstrap cursor", () => {
     expect(shouldPersistBootstrapCursor({ metaSeq: 0, graphSeq: 0 }, { metaSeq: 0, graphSeq: 5 }, { metaSeq: 0, graphSeq: 5 })).toBe(true);
     expect(shouldPersistBootstrapCursor({ metaSeq: 0, graphSeq: 5 }, { metaSeq: 0, graphSeq: 5 }, { metaSeq: 0, graphSeq: 5 })).toBe(false);
     expect(shouldPersistBootstrapCursor({ metaSeq: 0, graphSeq: 0 }, { metaSeq: 0, graphSeq: 5 }, { metaSeq: 0, graphSeq: 6 })).toBe(false);
+  });
+
+  it("normalizes negative cursors to zero cursor", () => {
+    expect(resolveBootstrapFromCursor({ metaSeq: -1, graphSeq: -5 }, { cursor: ZERO_CURSOR })).toEqual(ZERO_CURSOR);
   });
 });

--- a/packages/mesh-explorer-ui/test/syncPollRequest.test.ts
+++ b/packages/mesh-explorer-ui/test/syncPollRequest.test.ts
@@ -4,17 +4,17 @@ import { resolveBootstrapFromCursor } from "../src/bootstrapCursor.js";
 import { buildSyncPollUrl } from "../src/syncPollRequest.js";
 
 describe("sync poll request bootstrap", () => {
-  it("builds initial sync:poll with {0,0} when store is empty and persisted cursor is non-zero", () => {
-    const fromCursor = resolveBootstrapFromCursor({ metaSeq: 0, graphSeq: 39 }, { nodesCount: 0, linksCount: 0 });
-    const url = new URL(buildSyncPollUrl("http://127.0.0.1:8090", "mesh-explorer-graph-v1", fromCursor, { graph: 128, meta: 32 }));
-
-    expect(JSON.parse(url.searchParams.get("cursor") ?? "{}")).toEqual({ metaSeq: 0, graphSeq: 0 });
-  });
-
-  it("builds initial sync:poll with persisted cursor when store is non-empty", () => {
-    const fromCursor = resolveBootstrapFromCursor({ metaSeq: 0, graphSeq: 39 }, { nodesCount: 1, linksCount: 0 });
+  it("builds initial sync:poll with persisted cursor when snapshot cursor is empty", () => {
+    const fromCursor = resolveBootstrapFromCursor({ metaSeq: 0, graphSeq: 39 }, { cursor: { metaSeq: 0, graphSeq: 0 } });
     const url = new URL(buildSyncPollUrl("http://127.0.0.1:8090", "mesh-explorer-graph-v1", fromCursor, { graph: 128, meta: 32 }));
 
     expect(JSON.parse(url.searchParams.get("cursor") ?? "{}")).toEqual({ metaSeq: 0, graphSeq: 39 });
+  });
+
+  it("builds initial sync:poll with max(savedCursor, snapshotCursor)", () => {
+    const fromCursor = resolveBootstrapFromCursor({ metaSeq: 0, graphSeq: 39 }, { cursor: { metaSeq: 2, graphSeq: 41 } });
+    const url = new URL(buildSyncPollUrl("http://127.0.0.1:8090", "mesh-explorer-graph-v1", fromCursor, { graph: 128, meta: 32 }));
+
+    expect(JSON.parse(url.searchParams.get("cursor") ?? "{}")).toEqual({ metaSeq: 2, graphSeq: 41 });
   });
 });


### PR DESCRIPTION
### Motivation
- Restart cleanly after rollback and harden core sync/tx invariants (cursor resume, poll/subscribe policy, tx atomicity, idempotency) with minimal, targeted patches and tests. 
- “Refs #130 ”

### Description
- UI bootstrap: wire persisted local cursor into connect path and resolve the bootstrap cursor as `max(savedCursor, snapshotCursor)` via a new `resolveBootstrapFromCursor` policy, and normalize negative cursors to `ZERO_CURSOR` (files: `packages/mesh-explorer-ui/src/index.ts`, `packages/mesh-explorer-ui/src/bootstrapCursor.ts`).
- File-backed EventStore: change `FileBackedLocalEventStore.appendTx` to stage the next `SpaceState` in-memory, call `persistState()` and rollback the in-memory staging on persist failure to preserve commit-or-nothing observable state (file-backed atomic staging) (file: `packages/eventstore-local/src/FileBackedLocalEventStore.ts`).
- Tests: add/adjust unit tests that encode the intended invariants: durable cursor bootstrap tests and a regression test that simulates a persist failure and verifies no partial tx visibility and successful idempotent retry (files: `packages/mesh-explorer-ui/test/bootstrapCursor.test.ts`, `packages/mesh-explorer-ui/test/syncPollRequest.test.ts`, `packages/eventstore-local/test/fileBackedAtomicCommit.test.ts`).

### Testing
- Ran targeted unit tests with Vitest: `pnpm vitest run packages/mesh-explorer-ui/test/bootstrapCursor.test.ts packages/mesh-explorer-ui/test/syncPollRequest.test.ts packages/eventstore-local/test/fileBackedAtomicCommit.test.ts`, and the three tests completed green (all tests passed).
- Ran package-scoped eventstore tests: `pnpm --filter @mesh/eventstore-local test -- fileBackedAtomicCommit.test.ts` which passed after the staged-persist logic and simulated-failure test were implemented.
- Observed build attempt `pnpm --filter @mesh/eventstore-local build` failed in this environment due to workspace/type resolution for `@mesh/shared` (TypeScript errors unrelated to the runtime logic changes); this does not affect the unit-test results above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a39241c410832187000a98a0d708bd)