### PR TITLE
Prefer snapshot bootstrap when no durable local state; add decision helper and structured sync logs

### DIFF
--- a/packages/mesh-explorer-ui/src/bootstrapCursor.ts
+++ b/packages/mesh-explorer-ui/src/bootstrapCursor.ts
@@ -5,16 +5,59 @@ export const ZERO_CURSOR: Cursor = { metaSeq: 0, graphSeq: 0 };
 
 type StoreSnapshot = { cursor?: Cursor | null };
 
+export type BootstrapCursorDecisionInput = {
+  savedCursor: Cursor | null;
+  snapshot: StoreSnapshot;
+  stateDigest?: string | null;
+};
+
+export type BootstrapCursorDecision = {
+  bootstrapFrom: Cursor;
+  usedSavedCursor: boolean;
+  reason: "snapshot-only-no-state-digest" | "saved-vs-snapshot-with-state-digest";
+  // TODO(Option-A): replace this boolean gate by a verified digest match check.
+  optionAStateDigestMatched: boolean;
+};
+
+export function resolveBootstrapCursorDecision(input: BootstrapCursorDecisionInput): BootstrapCursorDecision {
+  const normalizedSaved = normalizeCursor(input.savedCursor);
+  const normalizedSnapshot = normalizeCursor(input.snapshot.cursor ?? null);
+  const normalizedDigest = normalizeStateDigest(input.stateDigest);
+
+  // Option B (current): poll is SoT; without durable local state proof, bootstrap from snapshot cursor.
+  if (normalizedDigest === null) {
+    return {
+      bootstrapFrom: normalizedSnapshot,
+      usedSavedCursor: false,
+      reason: "snapshot-only-no-state-digest",
+      optionAStateDigestMatched: false
+    };
+  }
+
+  // Option A placeholder: once we can verify digest<->cursor consistency, this path can be tightened.
+  const bootstrapFrom = compareCursor(normalizedSaved, normalizedSnapshot) >= 0 ? normalizedSaved : normalizedSnapshot;
+  return {
+    bootstrapFrom,
+    usedSavedCursor: compareCursor(bootstrapFrom, normalizedSaved) === 0,
+    reason: "saved-vs-snapshot-with-state-digest",
+    optionAStateDigestMatched: true
+  };
+}
+
 export function resolveBootstrapFromCursor(saved: Cursor | null, snapshot: StoreSnapshot): Cursor {
-  const normalizedSaved = normalizeCursor(saved);
-  const normalizedSnapshot = normalizeCursor(snapshot.cursor ?? null);
-  return compareCursor(normalizedSaved, normalizedSnapshot) >= 0 ? normalizedSaved : normalizedSnapshot;
+  return resolveBootstrapCursorDecision({ savedCursor: saved, snapshot, stateDigest: null }).bootstrapFrom;
 }
 
 function normalizeCursor(candidate: Cursor | null): Cursor {
   if (!candidate) return ZERO_CURSOR;
   if (compareCursor(candidate, ZERO_CURSOR) < 0) return ZERO_CURSOR;
   return candidate;
+}
+
+function normalizeStateDigest(stateDigest: string | null | undefined): string | null {
+  if (!stateDigest) return null;
+  const trimmed = stateDigest.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 export function nextMonotonicCursor(current: Cursor, candidate: Cursor): Cursor {

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -8,7 +8,7 @@ import {
   type GraphStore
 } from "./graphStore.js";
 import { compareCursor, persistCursorSafely, rotateAbortController } from "./syncGuards.js";
-import { nextMonotonicCursor, resolveBootstrapFromCursor, shouldPersistBootstrapCursor } from "./bootstrapCursor.js";
+import { nextMonotonicCursor, resolveBootstrapCursorDecision, shouldPersistBootstrapCursor } from "./bootstrapCursor.js";
 import { cursorStorageKey } from "./cursorStorage.js";
 import { buildSyncPollUrl } from "./syncPollRequest.js";
 import {
@@ -358,7 +358,17 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     const storageKey = cursorStorageKey(normalizedPrincipal, el.graphSpaceId.value);
     const savedCursor = readCursor(storageKey);
     const snapshotCursor = await bootstrapFromSnapshot(normalizedPrincipal);
-    const bootstrapCursor = resolveBootstrapFromCursor(savedCursor, { cursor: snapshotCursor });
+    const bootstrapDecision = resolveBootstrapCursorDecision({ savedCursor, snapshot: { cursor: snapshotCursor }, stateDigest: null });
+    const bootstrapCursor = bootstrapDecision.bootstrapFrom;
+    emitMeshDebugLog("BOOTSTRAP_DECISION", {
+      graphSpaceId: el.graphSpaceId.value,
+      principal: normalizedPrincipal,
+      savedCursor,
+      snapshotCursor,
+      bootstrapCursor,
+      decisionReason: bootstrapDecision.reason,
+      usedSavedCursor: bootstrapDecision.usedSavedCursor
+    });
     const replayResult = await pollReplayFromCursor(bootstrapCursor, sessionId, activeAbort.signal);
     if (sessionId !== syncSession) return;
     persistBootstrapCursor(storageKey, snapshotCursor, replayResult.cursor);
@@ -420,6 +430,13 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
                   if (advanced) {
                     store.applyGraphEvents(extractGraphEventsFromTxBundles(txBundles));
                     setLastSyncNow();
+                  } else {
+                    emitMeshDebugLog("SUBSCRIBE_DROP", {
+                      reason: "cursor-not-advanced",
+                      from: store.getState().cursor,
+                      candidate: next,
+                      txBundleCount: txBundles.length
+                    });
                   }
                   continue;
                 }
@@ -477,6 +494,14 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
           const nextCursor = payload.cursorAfter ?? cursor;
           const nextMonotonic = nextMonotonicCursor(cursor, nextCursor);
           const cursorUnchanged = cursorEq(nextMonotonic, cursor);
+          emitMeshDebugLog("APPLY_BATCH", {
+            source: "poll",
+            fromCursor: cursor,
+            toCursor: nextMonotonic,
+            graphEvents: graphEvents.length,
+            metaEvents: payload.meta?.length ?? 0,
+            cursorUnchanged
+          });
           if (!cursorUnchanged && graphEvents.length > 0) {
             graphEventsApplied += graphEvents.length;
             store.applyGraphEvents(graphEvents);

--- a/packages/mesh-explorer-ui/test/bootstrapCursor.test.ts
+++ b/packages/mesh-explorer-ui/test/bootstrapCursor.test.ts
@@ -1,23 +1,39 @@
 import { describe, expect, it } from "vitest";
 
 import { cursorStorageKey } from "../src/cursorStorage.js";
-import { nextMonotonicCursor, resolveBootstrapFromCursor, shouldPersistBootstrapCursor, ZERO_CURSOR } from "../src/bootstrapCursor.js";
+import {
+  nextMonotonicCursor,
+  resolveBootstrapCursorDecision,
+  resolveBootstrapFromCursor,
+  shouldPersistBootstrapCursor,
+  ZERO_CURSOR
+} from "../src/bootstrapCursor.js";
 
 describe("mesh explorer bootstrap cursor", () => {
   it("uses {0,0} when neither snapshot nor local cursor exists", () => {
     expect(resolveBootstrapFromCursor(null, { cursor: null })).toEqual({ metaSeq: 0, graphSeq: 0 });
   });
 
-  it("uses persisted cursor when snapshot cursor is behind", () => {
-    expect(resolveBootstrapFromCursor({ metaSeq: 2, graphSeq: 8 }, { cursor: { metaSeq: 1, graphSeq: 6 } })).toEqual({ metaSeq: 2, graphSeq: 8 });
-  });
-
   it("uses snapshot cursor when persisted cursor is absent", () => {
     expect(resolveBootstrapFromCursor(null, { cursor: { metaSeq: 2, graphSeq: 8 } })).toEqual({ metaSeq: 2, graphSeq: 8 });
   });
 
-  it("uses max(savedCursor, snapshotCursor) to guarantee durable resume monotonicity", () => {
+  it("ignores saved cursor when no local state digest exists (Option B)", () => {
     expect(resolveBootstrapFromCursor({ metaSeq: 3, graphSeq: 10 }, { cursor: { metaSeq: 4, graphSeq: 9 } })).toEqual({ metaSeq: 4, graphSeq: 9 });
+    expect(resolveBootstrapFromCursor({ metaSeq: 2, graphSeq: 8 }, { cursor: { metaSeq: 1, graphSeq: 6 } })).toEqual({ metaSeq: 1, graphSeq: 6 });
+  });
+
+
+  it("bootstrap decision picks snapshot=0 when saved cursor exists but no state digest", () => {
+    const decision = resolveBootstrapCursorDecision({
+      savedCursor: { metaSeq: 2, graphSeq: 8 },
+      snapshot: { cursor: { metaSeq: 0, graphSeq: 0 } },
+      stateDigest: null
+    });
+
+    expect(decision.bootstrapFrom).toEqual({ metaSeq: 0, graphSeq: 0 });
+    expect(decision.usedSavedCursor).toBe(false);
+    expect(decision.reason).toBe("snapshot-only-no-state-digest");
   });
 
   it("writes exact storage key format mesh.cursor.<principal>.<graphSpaceId>", () => {

--- a/packages/mesh-explorer-ui/test/syncPollRequest.test.ts
+++ b/packages/mesh-explorer-ui/test/syncPollRequest.test.ts
@@ -4,14 +4,14 @@ import { resolveBootstrapFromCursor } from "../src/bootstrapCursor.js";
 import { buildSyncPollUrl } from "../src/syncPollRequest.js";
 
 describe("sync poll request bootstrap", () => {
-  it("builds initial sync:poll with persisted cursor when snapshot cursor is empty", () => {
+  it("builds initial sync:poll from snapshot cursor when no state digest is available", () => {
     const fromCursor = resolveBootstrapFromCursor({ metaSeq: 0, graphSeq: 39 }, { cursor: { metaSeq: 0, graphSeq: 0 } });
     const url = new URL(buildSyncPollUrl("http://127.0.0.1:8090", "mesh-explorer-graph-v1", fromCursor, { graph: 128, meta: 32 }));
 
-    expect(JSON.parse(url.searchParams.get("cursor") ?? "{}")).toEqual({ metaSeq: 0, graphSeq: 39 });
+    expect(JSON.parse(url.searchParams.get("cursor") ?? "{}")).toEqual({ metaSeq: 0, graphSeq: 0 });
   });
 
-  it("builds initial sync:poll with max(savedCursor, snapshotCursor)", () => {
+  it("builds initial sync:poll with snapshot cursor when snapshot is ahead", () => {
     const fromCursor = resolveBootstrapFromCursor({ metaSeq: 0, graphSeq: 39 }, { cursor: { metaSeq: 2, graphSeq: 41 } });
     const url = new URL(buildSyncPollUrl("http://127.0.0.1:8090", "mesh-explorer-graph-v1", fromCursor, { graph: 128, meta: 32 }));
 

--- a/tests/e2e/mesh-explorer-sync-materialization.spec.ts
+++ b/tests/e2e/mesh-explorer-sync-materialization.spec.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { startMeshGraphServer, type MeshGraphServerHandle } from "../../apps/mesh-graph-server/src/index.js";
 import { createGraphStore, type Cursor, type GraphEvent, type GraphStore } from "../../packages/mesh-explorer-ui/src/graphStore.js";
+import { resolveBootstrapCursorDecision } from "../../packages/mesh-explorer-ui/src/bootstrapCursor.js";
 
 describe("mesh explorer sync materialization", { timeout: 30_000 }, () => {
   const cleanups: Array<() => Promise<void>> = [];
@@ -54,6 +55,39 @@ describe("mesh explorer sync materialization", { timeout: 30_000 }, () => {
     const links = Array.from(store.getState().linksById.values());
     expect(links.length).toBe(1);
     expect(links[0]).toMatchObject({ source: nodeIds[0], target: nodeIds[1], type: "depends" });
+  });
+
+  it("refresh preserves graph when saved cursor exists without durable state", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "mesh-graph-ui-"));
+    cleanups.push(async () => rm(storageDir, { recursive: true, force: true }));
+
+    const server: MeshGraphServerHandle = await startMeshGraphServer({ storageDir, port: 0 });
+    cleanups.push(async () => server.close());
+
+    await createNode(server.url, "alice", "refresh-a");
+    await createNode(server.url, "alice", "refresh-b");
+
+    const seededStore = createGraphStore();
+    const seededReplay = await bootstrapReplay(server.url, "alice", seededStore, { metaSeq: 0, graphSeq: 0 });
+    const nodeIds = Array.from(seededStore.getState().nodesById.keys());
+    await createLink(server.url, "alice", nodeIds[0]!, nodeIds[1]!, "depends");
+
+    const persistedCursor = seededReplay.cursor;
+    const snapshotCursor: Cursor = { metaSeq: 0, graphSeq: 0 };
+    const decision = resolveBootstrapCursorDecision({
+      savedCursor: persistedCursor,
+      snapshot: { cursor: snapshotCursor },
+      stateDigest: null
+    });
+
+    expect(decision.bootstrapFrom).toEqual(snapshotCursor);
+
+    const refreshedStore = createGraphStore();
+    const replayed = await bootstrapReplay(server.url, "alice", refreshedStore, decision.bootstrapFrom);
+
+    expect(replayed.graphEventsApplied).toBeGreaterThanOrEqual(3);
+    expect(refreshedStore.getState().nodesById.size).toBe(2);
+    expect(refreshedStore.getState().linksById.size).toBe(1);
   });
 
   it("reload bootstrap rebuilds nodes/links before subscribe", async () => {


### PR DESCRIPTION
### Motivation
- Ensure UI refresh reconstructs a correct graph when a `savedCursor` exists but there is no durable local state proof, by starting replay from the snapshot cursor (Option B).
- Avoid skipping events based on a local cursor when the local state has not been validated to the same cursor.
- Provide structured observability for bootstrap and sync decisions to make behavior auditable and debuggable.

### Description
- Add a structured bootstrap decision helper `resolveBootstrapCursorDecision` with an Option-B default that returns `bootstrapFrom = snapshotCursor` when no `stateDigest` is present and a TODO scaffold for Option A (digest validation).
- Wire `resolveBootstrapCursorDecision` into the UI `connectAndSync` path and emit a `BOOTSTRAP_DECISION` structured debug log containing the saved/snapshot/selected cursor and decision reason.
- Emit structured sync logs: `APPLY_BATCH` on poll batches (from/to cursor, counts, unchanged flag) and `SUBSCRIBE_DROP` when an SSE txBundle is ignored because the candidate cursor is not advanced.
- Update unit tests to reflect Option B behavior and add a unit test for the new decision API (savedCursor present, snapshot 0, no stateDigest => bootstrapFrom=0).
- Add an e2e test `refresh preserves graph when saved cursor exists without durable state` that creates nodes/links, performs a refresh decision with no digest, replays from snapshot, and asserts nodes/links are reconstructed.

### Testing
- Built the UI package with `pnpm --filter @mesh/mesh-explorer-ui build` and the build completed successfully (✅).
- Ran `pnpm vitest run packages/mesh-explorer-ui/test/bootstrapCursor.test.ts packages/mesh-explorer-ui/test/syncPollRequest.test.ts tests/e2e/mesh-explorer-sync-materialization.spec.ts`: the unit test suites passed but the e2e suite could not run to completion in this environment due to a module resolution failure for `@mesh/sync-local/internal` (⚠️).
- The change includes a TODO placeholder for Option A (stateDigest verification) and does not deliver digest verification in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a45f5776c08321830abc37dcdf6607)