### PR TITLE
fix(ui): make BOOTSTRAP_DECISION observable in dev console

### DIFF
--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -30,6 +30,7 @@ import { LayoutPanel } from "./ui/LayoutPanel.js";
 import { deriveLayoutParams, loadLayoutUiState, saveLayoutUiState, type LayoutUiState } from "./ui/layoutSettings.js";
 import { exportGraphFromState, parseExportedGraph, type ExportedGraphV1 } from "./devtools/graphIo.js";
 import { buildMultiDeletePlan } from "./deleteSelection.js";
+import { emitMeshDebugLogToSinks } from "./meshDebugLog.js";
 
 type Cursor = { metaSeq: number; graphSeq: number };
 type GraphData = { nodes: GraphNode[]; links: GraphLink[] };
@@ -1407,8 +1408,8 @@ async function wait(ms: number): Promise<void> {
 }
 
 function emitMeshDebugLog(message: string, detail?: unknown): void {
-  const dbgObj = (window as Window & { __meshDebug?: { log?: (message: string, detail?: unknown) => void } }).__meshDebug;
-  dbgObj?.log?.(message, detail);
+  const devMode = Boolean((import.meta as ImportMeta & { env?: { DEV?: boolean } }).env?.DEV);
+  emitMeshDebugLogToSinks(window, message, detail, { devMode });
 }
 
 function resolveConnectivityState(browserHint: ConnectivityStatus, networkHint: ConnectivityStatus): ConnectivityStatus {

--- a/packages/mesh-explorer-ui/src/meshDebugLog.ts
+++ b/packages/mesh-explorer-ui/src/meshDebugLog.ts
@@ -1,0 +1,16 @@
+type MeshDebugLogger = { log?: (message: string, detail?: unknown) => void };
+
+type MeshDebugWindow = Window & { __meshDebug?: MeshDebugLogger };
+
+type EmitMeshDebugLogOptions = {
+  devMode: boolean;
+  consoleInfo?: (message?: unknown, ...optionalParams: unknown[]) => void;
+};
+
+export function emitMeshDebugLogToSinks(targetWindow: Window, message: string, detail: unknown, options: EmitMeshDebugLogOptions): void {
+  const meshDebug = (targetWindow as MeshDebugWindow).__meshDebug;
+  meshDebug?.log?.(message, detail);
+  if (!options.devMode) return;
+  (options.consoleInfo ?? console.info)("[mesh-observe]", { message, detail });
+}
+

--- a/packages/mesh-explorer-ui/test/meshDebugLog.test.ts
+++ b/packages/mesh-explorer-ui/test/meshDebugLog.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { emitMeshDebugLogToSinks } from "../src/meshDebugLog.js";
+
+describe("emitMeshDebugLogToSinks", () => {
+  it("always sends structured log to __meshDebug collector", () => {
+    const log = vi.fn();
+    const fakeWindow = { __meshDebug: { log } } as unknown as Window;
+
+    emitMeshDebugLogToSinks(fakeWindow, "BOOTSTRAP_DECISION", { cursor: 42 }, { devMode: false });
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenCalledWith("BOOTSTRAP_DECISION", { cursor: 42 });
+  });
+
+  it("mirrors structured log to console.info in dev mode", () => {
+    const log = vi.fn();
+    const consoleInfo = vi.fn();
+    const fakeWindow = { __meshDebug: { log } } as unknown as Window;
+
+    emitMeshDebugLogToSinks(fakeWindow, "BOOTSTRAP_DECISION", { reason: "snapshot-reset" }, { devMode: true, consoleInfo });
+
+    expect(log).toHaveBeenCalledWith("BOOTSTRAP_DECISION", { reason: "snapshot-reset" });
+    expect(consoleInfo).toHaveBeenCalledTimes(1);
+    expect(consoleInfo).toHaveBeenCalledWith("[mesh-observe]", {
+      message: "BOOTSTRAP_DECISION",
+      detail: { reason: "snapshot-reset" }
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- The `BOOTSTRAP_DECISION` structured log is emitted from the UI but was only written to the in-memory collector `window.__meshDebug` and therefore not visible in the browser console or server sinks (loss of observability).【file: `packages/mesh-explorer-ui/src/index.ts` lines ~352-374】
- The goal is a minimal, safe change that preserves the structured collector while making the event visible in dev without a large refactor, preserving the observability/auditability invariant from the spec.【specs: `Observability/Auditability` guidance referenced】
- The change must be small, testable and only enable a console sink in development to avoid leaking structured debug output in production.【file: `packages/mesh-explorer-ui/src/index.ts` lines ~1410-1413】

### Description
- Add a small helper `emitMeshDebugLogToSinks` in `packages/mesh-explorer-ui/src/meshDebugLog.ts` that forwards to `window.__meshDebug.log(...)` and, when `devMode` is true, also mirrors the structured payload to `console.info` as `"[mesh-observe]"` with `{ message, detail }` (preserves structured form).【file: `packages/mesh-explorer-ui/src/meshDebugLog.ts` lines ~10-15】
- Wire the new helper into the existing `emitMeshDebugLog` in `packages/mesh-explorer-ui/src/index.ts` so calls like `emitMeshDebugLog("BOOTSTRAP_DECISION", ...)` keep the collector behavior and gain a dev-only console fallback (uses `import.meta.env.DEV`).【file: `packages/mesh-explorer-ui/src/index.ts` lines ~1410-1413】【file: `packages/mesh-explorer-ui/src/index.ts` lines ~352-374】
- Add unit tests `packages/mesh-explorer-ui/test/meshDebugLog.test.ts` that assert (1) the structured event is always delivered to `__meshDebug`, and (2) the console mirror is invoked when `devMode: true` with the expected structured object.【file: `packages/mesh-explorer-ui/test/meshDebugLog.test.ts`】
- No spec files were modified and the change is intentionally minimal and scoped to logging visibility only.【no changes under `specs/`】

### Testing
- Ran `pnpm vitest run packages/mesh-explorer-ui/test/meshDebugLog.test.ts` and it passed (`2 tests` passed).
- Ran `pnpm vitest run packages/mesh-explorer-ui/test/bootstrapCursor.test.ts` and it passed (`8 tests` passed) to confirm bootstrap decision logic remains intact.
- Attempted to run both the new test and the e2e suite together and observed an unrelated module resolution failure for `@mesh/sync-local/internal` when executing `tests/e2e/mesh-explorer-sync-materialization.spec.ts`, which is unrelated to this logging change (the unit tests that exercise logging and bootstrap logic passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a465055e5483218c127fe5ec1a7000)