### PR TITLE
Add strict subscribe convergence guard with poll fallback

### DIFF
--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -31,6 +31,7 @@ import { deriveLayoutParams, loadLayoutUiState, saveLayoutUiState, type LayoutUi
 import { exportGraphFromState, parseExportedGraph, type ExportedGraphV1 } from "./devtools/graphIo.js";
 import { buildMultiDeletePlan } from "./deleteSelection.js";
 import { emitMeshDebugLogToSinks } from "./meshDebugLog.js";
+import { evaluateSubscribeConvergence } from "./syncConvergenceGuard.js";
 
 type Cursor = { metaSeq: number; graphSeq: number };
 type GraphData = { nodes: GraphNode[]; links: GraphLink[] };
@@ -424,28 +425,39 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
               if (data.kind === "heartbeat") continue;
               if (data.kind === "txBundles") {
                 const txBundles = data.txBundlesVisible ?? [];
-                const cursorFromBundles = readCursorFromTxBundles(txBundles);
-                if (cursorFromBundles !== null) {
-                  const next = { ...store.getState().cursor, graphSeq: cursorFromBundles };
-                  const advanced = applyCursorIfAdvanced(storageKey, next, "sse");
-                  if (advanced) {
-                    store.applyGraphEvents(extractGraphEventsFromTxBundles(txBundles));
-                    setLastSyncNow();
-                  } else {
-                    emitMeshDebugLog("SUBSCRIBE_DROP", {
-                      reason: "cursor-not-advanced",
-                      from: store.getState().cursor,
-                      candidate: next,
-                      txBundleCount: txBundles.length
-                    });
-                  }
+                const fromCursor = store.getState().cursor;
+                const decision = evaluateSubscribeConvergence(fromCursor.graphSeq, txBundles);
+                if (decision.action === "fallback-poll") {
+                  emitMeshDebugLog("SUBSCRIBE_CURSOR_GUARD", {
+                    reason: decision.reason,
+                    fromCursor,
+                    expectedGraphSeq: decision.expectedGraphSeq,
+                    subscribePrincipalCursor: decision.subscribePrincipalCursor,
+                    txBundleCount: txBundles.length,
+                    graphEventsCount: decision.graphEventsCount
+                  });
+                  const replayResult = await pollReplayFromCursor(fromCursor, activeSessionId, signal);
+                  if (activeSessionId !== syncSession) return;
+                  persistBootstrapCursor(storageKey, fromCursor, replayResult.cursor);
                   continue;
                 }
-                const events = extractGraphEventsFromTxBundles(txBundles);
-                if (events.length > 0) {
-                  store.applyGraphEvents(events);
+
+                const graphEvents = extractGraphEventsFromTxBundles(txBundles);
+                const next = { ...fromCursor, graphSeq: decision.expectedGraphSeq };
+                const advanced = applyCursorIfAdvanced(storageKey, next, "sse");
+                if (advanced) {
+                  store.applyGraphEvents(graphEvents);
                   setLastSyncNow();
+                } else {
+                  emitMeshDebugLog("SUBSCRIBE_DROP", {
+                    reason: "cursor-not-advanced",
+                    from: fromCursor,
+                    candidate: next,
+                    txBundleCount: txBundles.length,
+                    graphEventsCount: graphEvents.length
+                  });
                 }
+                continue;
               }
             }
             if (activeSessionId === syncSession) {
@@ -1381,15 +1393,6 @@ function installTestHook(store: GraphStore, readContext: () => { projectId: stri
     }
   };
   (window as Window & { __meshDebug?: MeshDebugApi }).__meshDebug = meshDebug;
-}
-
-function readCursorFromTxBundles(txBundles: SyncTxBundle[]): number | null {
-  let maxCursor: number | null = null;
-  for (const bundle of txBundles) {
-    if (typeof bundle.principalCursor !== "number") continue;
-    maxCursor = maxCursor === null ? bundle.principalCursor : Math.max(maxCursor, bundle.principalCursor);
-  }
-  return maxCursor;
 }
 
 function cursorEq(a: Cursor, b: Cursor): boolean {

--- a/packages/mesh-explorer-ui/src/syncConvergenceGuard.ts
+++ b/packages/mesh-explorer-ui/src/syncConvergenceGuard.ts
@@ -1,0 +1,69 @@
+export type SubscribeTxBundle = {
+  principalCursor?: number;
+  txBundle?: { graphEvents?: unknown[]; metaEvents?: unknown[] };
+};
+
+export type SubscribeConvergenceDecision =
+  | {
+      action: "apply";
+      expectedGraphSeq: number;
+      graphEventsCount: number;
+      subscribePrincipalCursor: number | null;
+    }
+  | {
+      action: "fallback-poll";
+      reason: "missing-principal-cursor" | "principal-cursor-mismatch";
+      expectedGraphSeq: number;
+      graphEventsCount: number;
+      subscribePrincipalCursor: number | null;
+    };
+
+export function evaluateSubscribeConvergence(currentGraphSeq: number, txBundles: SubscribeTxBundle[]): SubscribeConvergenceDecision {
+  const graphEventsCount = countGraphEvents(txBundles);
+  const expectedGraphSeq = currentGraphSeq + graphEventsCount;
+  const subscribePrincipalCursor = readMaxPrincipalCursor(txBundles);
+
+  if (subscribePrincipalCursor === null) {
+    return {
+      action: "fallback-poll",
+      reason: "missing-principal-cursor",
+      expectedGraphSeq,
+      graphEventsCount,
+      subscribePrincipalCursor
+    };
+  }
+
+  if (subscribePrincipalCursor !== expectedGraphSeq) {
+    return {
+      action: "fallback-poll",
+      reason: "principal-cursor-mismatch",
+      expectedGraphSeq,
+      graphEventsCount,
+      subscribePrincipalCursor
+    };
+  }
+
+  return {
+    action: "apply",
+    expectedGraphSeq,
+    graphEventsCount,
+    subscribePrincipalCursor
+  };
+}
+
+function countGraphEvents(txBundles: SubscribeTxBundle[]): number {
+  let count = 0;
+  for (const bundle of txBundles) {
+    count += bundle.txBundle?.graphEvents?.length ?? 0;
+  }
+  return count;
+}
+
+function readMaxPrincipalCursor(txBundles: SubscribeTxBundle[]): number | null {
+  let maxCursor: number | null = null;
+  for (const bundle of txBundles) {
+    if (typeof bundle.principalCursor !== "number") continue;
+    maxCursor = maxCursor === null ? bundle.principalCursor : Math.max(maxCursor, bundle.principalCursor);
+  }
+  return maxCursor;
+}

--- a/packages/mesh-explorer-ui/test/syncConvergenceGuard.test.ts
+++ b/packages/mesh-explorer-ui/test/syncConvergenceGuard.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { evaluateSubscribeConvergence } from "../src/syncConvergenceGuard.js";
+
+describe("evaluateSubscribeConvergence", () => {
+  it("falls back to poll when subscribe principal cursor diverges from expected graph progression", () => {
+    const decision = evaluateSubscribeConvergence(0, [
+      {
+        principalCursor: 1,
+        txBundle: {
+          metaEvents: [{ type: "meta.only" }],
+          graphEvents: []
+        }
+      }
+    ]);
+
+    expect(decision).toEqual({
+      action: "fallback-poll",
+      reason: "principal-cursor-mismatch",
+      expectedGraphSeq: 0,
+      graphEventsCount: 0,
+      subscribePrincipalCursor: 1
+    });
+  });
+
+  it("falls back to poll when subscribe tx-bundle has no principal cursor", () => {
+    const decision = evaluateSubscribeConvergence(3, [
+      {
+        txBundle: {
+          graphEvents: [{ type: "graph.node.created" }]
+        }
+      }
+    ]);
+
+    expect(decision).toEqual({
+      action: "fallback-poll",
+      reason: "missing-principal-cursor",
+      expectedGraphSeq: 4,
+      graphEventsCount: 1,
+      subscribePrincipalCursor: null
+    });
+  });
+
+  it("applies subscribe batch when principal cursor matches expected graph seq", () => {
+    const decision = evaluateSubscribeConvergence(4, [
+      {
+        principalCursor: 6,
+        txBundle: {
+          graphEvents: [{ type: "graph.node.created" }, { type: "graph.node.created" }]
+        }
+      }
+    ]);
+
+    expect(decision).toEqual({
+      action: "apply",
+      expectedGraphSeq: 6,
+      graphEventsCount: 2,
+      subscribePrincipalCursor: 6
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent cursor divergence when `sync:subscribe` delivers batches with missing or inconsistent principal cursors by enforcing a strict guard before applying subscribe-delivered graph events.
- Keep `sync:poll` as the authoritative convergence path and avoid introducing multi-writer or architectural refactors by implementing a minimal safe patch in the UI sync loop.
- Improve observability for convergence incidents so fallback decisions are debuggable without changing server semantics.
- "Refs #134"

### Description
- Add `packages/mesh-explorer-ui/src/syncConvergenceGuard.ts` which implements `evaluateSubscribeConvergence(currentGraphSeq, txBundles)` and returns either an `apply` or `fallback-poll` decision based on expected graph progression and reported `principalCursor`.
- Integrate the guard into the client `subscribeLoop` in `packages/mesh-explorer-ui/src/index.ts` so that when `evaluateSubscribeConvergence` signals fallback the client emits `SUBSCRIBE_CURSOR_GUARD` and immediately runs authoritative `pollReplayFromCursor` from the durable local cursor; otherwise the batch is applied and the cursor advanced atomically via existing `applyCursorIfAdvanced`.
- Emit structured logs (`SUBSCRIBE_CURSOR_GUARD` and enhanced `SUBSCRIBE_DROP`) with context fields (`fromCursor`, `expectedGraphSeq`, `subscribePrincipalCursor`, `txBundleCount`, `graphEventsCount`) to aid incident diagnosis.
- Add focused unit tests at `packages/mesh-explorer-ui/test/syncConvergenceGuard.test.ts` that validate mismatch, missing-cursor, and happy-path apply decisions.

### Testing
- Ran the new unit tests: `pnpm vitest run packages/mesh-explorer-ui/test/syncConvergenceGuard.test.ts` and observed all tests pass (3/3 passed).
- Ran related UI unit tests: `pnpm vitest run packages/mesh-explorer-ui/test/syncPollRequest.test.ts packages/mesh-explorer-ui/test/meshDebugLog.test.ts` and observed all tests pass (4/4 passed).
- Built the UI package with `pnpm --filter @mesh/mesh-explorer-ui build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a472504bd08321a3ae0b7291a67420)