### PR TITLE
Fix sync:subscribe to honor from cursor

### DIFF
--- a/apps/mesh-graph-server/src/index.ts
+++ b/apps/mesh-graph-server/src/index.ts
@@ -480,7 +480,7 @@ async function handleRequest(
       writeJson(res, 410, { kind: "cursor_too_old", minReadableCursor: project.minReadableCursor, recommendedSnapshotId });
       return;
     }
-    await streamSubscribe(res, async (cursor) => gateway.syncPull(projectId, principal, cursor));
+    await streamSubscribe(res, from, async (cursor) => gateway.syncPull(projectId, principal, cursor));
     return;
   }
 
@@ -590,15 +590,26 @@ function isCursorTooOld(requested: Cursor, minReadable: Cursor): boolean {
 
 async function streamSubscribe(
   res: ServerResponse,
+  fromCursorVisible: number,
   syncPull: (fromCursorVisible: number) => Promise<{ txBundlesVisible: Array<{ principalCursor: number; txBundle: { graphEvents: unknown[] } }>; cursorAfterVisible: number }>
 ): Promise<void> {
   res.statusCode = 200;
   res.setHeader("content-type", "text/event-stream");
   res.setHeader("cache-control", "no-cache");
-  let cursor = 0;
+  let cursor = fromCursorVisible;
+  let subscribeFromLogged = false;
   const timer = setInterval(async () => {
     const pulled = await syncPull(cursor);
     if (pulled.txBundlesVisible.length > 0) {
+      if (process.env.NODE_ENV !== "production" && !subscribeFromLogged) {
+        subscribeFromLogged = true;
+        console.log(JSON.stringify({
+          kind: "SUBSCRIBE_FROM_APPLIED",
+          fromRaw: fromCursorVisible,
+          fromNormalized: cursor,
+          firstBundleCursor: pulled.txBundlesVisible[0]?.principalCursor ?? null
+        }));
+      }
       res.write(`data:${JSON.stringify({ kind: "txBundles", txBundlesVisible: pulled.txBundlesVisible })}\n\n`);
       cursor = pulled.cursorAfterVisible;
       res.write(`data:${JSON.stringify({ kind: "cursor", cursorVisible: cursor })}\n\n`);

--- a/apps/mesh-graph-server/test/projects-snapshots-retention.test.ts
+++ b/apps/mesh-graph-server/test/projects-snapshots-retention.test.ts
@@ -4,6 +4,32 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { startMeshGraphServer, type MeshGraphServerHandle } from "../src/index";
 
+async function readSseFrame(response: Response, timeoutMs = 5000): Promise<unknown> {
+  if (!response.body) throw new Error("missing SSE body");
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  const timeout = Date.now() + timeoutMs;
+
+  while (Date.now() < timeout) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const boundary = buffer.indexOf("\n\n");
+    if (boundary === -1) continue;
+    const frameText = buffer.slice(0, boundary);
+    buffer = buffer.slice(boundary + 2);
+    const dataLine = frameText
+      .split("\n")
+      .map((line) => line.trim())
+      .find((line) => line.startsWith("data:"));
+    if (!dataLine) continue;
+    return JSON.parse(dataLine.slice("data:".length));
+  }
+
+  throw new Error("timed out waiting for SSE frame");
+}
+
 describe("projects + snapshots + retention", () => {
   const startedServers: MeshGraphServerHandle[] = [];
   const headers = { "content-type": "application/json", "x-mesh-principal": "local-dev" };
@@ -98,5 +124,38 @@ describe("projects + snapshots + retention", () => {
     const oldPoll = await fetch(`${server.url}/v1/${server.graphSpaceId}/sync:poll?cursor=${encodeURIComponent(JSON.stringify({ metaSeq: 0, graphSeq: 0 }))}`, { headers });
     expect(oldPoll.status).toBe(410);
     await expect(oldPoll.json()).resolves.toMatchObject({ kind: "cursor_too_old" });
+  });
+
+  it("applies subscribe from cursor and does not replay history", async () => {
+    const storageDir = await mkdtemp(join(tmpdir(), "mesh-graph-server-subscribe-from-"));
+    const server = await startMeshGraphServer({ storageDir, port: 0 });
+    startedServers.push(server);
+
+    for (let idx = 1; idx <= 5; idx += 1) {
+      await fetch(`${server.url}/v1/${server.graphSpaceId}/graph:nodes`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ id: `N-${idx}`, label: `N-${idx}` })
+      });
+    }
+
+    const subscribeAbort = new AbortController();
+    const subscribe = await fetch(`${server.url}/v1/${server.graphSpaceId}/sync:subscribe?from=3`, {
+      headers,
+      signal: subscribeAbort.signal
+    });
+    expect(subscribe.status).toBe(200);
+
+    let frame = await readSseFrame(subscribe);
+    while ((frame as { kind?: string }).kind !== "txBundles") {
+      frame = await readSseFrame(subscribe);
+    }
+
+    const txBundles = (frame as { txBundlesVisible: Array<{ principalCursor: number }> }).txBundlesVisible;
+    expect(txBundles.length).toBeGreaterThan(0);
+    expect(txBundles[0]?.principalCursor).toBe(4);
+    expect(txBundles.every((bundle) => bundle.principalCursor > 3)).toBe(true);
+
+    subscribeAbort.abort();
   });
 });


### PR DESCRIPTION
### Motivation
- The `sync:subscribe` SSE path ignored the `from` query param and always started streaming from cursor `0`, causing replay of historical bundles when `from > 0`.
- `subscribe(from=X)` must deliver only bundles with `principalCursor > X` (no redelivery of already-visible history) while keeping `poll` as the source-of-truth.
- A minimal, targeted patch was requested to apply the `from` filter without refactoring the architecture.
- "Refs #134 "
### Description
- Pass the parsed `from` value from the HTTP handler into `streamSubscribe` so the SSE loop starts at the requested cursor instead of `0` by changing the call to `await streamSubscribe(res, from, ...)` and the function signature to accept `fromCursorVisible`.
- Initialize the SSE `cursor` to the provided `fromCursorVisible` and update it from `pulled.cursorAfterVisible` so subsequent pulls continue correctly from the first visible bundle after `from`.
- Add a dev-only structured log emitted once on first bundle delivery: `SUBSCRIBE_FROM_APPLIED { fromRaw, fromNormalized, firstBundleCursor }` (only when `NODE_ENV !== 'production'`).
- Add a regression test and helper in `apps/mesh-graph-server/test/projects-snapshots-retention.test.ts` that creates 5 txs, calls `sync:subscribe?from=3`, and asserts the first delivered `principalCursor` is `4` and no bundle has `principalCursor <= 3`.
- Modified files: `apps/mesh-graph-server/src/index.ts` and `apps/mesh-graph-server/test/projects-snapshots-retention.test.ts`.

### Testing
- Ran the server test file with `pnpm vitest run -c apps/mesh-graph-server/test/vitest.config.ts apps/mesh-graph-server/test/projects-snapshots-retention.test.ts` and the suite passed (4 tests, all passed).
- Ran the UI guard unit tests with `pnpm vitest run packages/mesh-explorer-ui/test/syncConvergenceGuard.test.ts` and the tests passed (3 tests, all passed).
- Built the graph server package with `pnpm -r --filter @mesh/graph-server... build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b6cbb1f88321822c80e23c19f4b3)