### PR TITLE
fix(conformance-tests): resolve check-no-todo path handling on Windows

### DIFF
--- a/packages/conformance-tests/scripts/check-no-todo.mjs
+++ b/packages/conformance-tests/scripts/check-no-todo.mjs
@@ -1,7 +1,10 @@
 import { readdir, readFile, stat } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const targetDir = new URL("../src", import.meta.url);
+const scriptPath = fileURLToPath(import.meta.url);
+const scriptDir = dirname(scriptPath);
+const sourceDir = resolve(scriptDir, "../src");
 const violations = [];
 
 const bannedPatterns = [
@@ -36,7 +39,14 @@ async function walk(dir) {
   }
 }
 
-const sourceDir = targetDir.pathname;
+if (!isAbsolute(sourceDir)) {
+  throw new Error(`Expected absolute source path, got: ${sourceDir}`);
+}
+
+if (process.platform === "win32" && sourceDir.includes("C:\\C:\\")) {
+  throw new Error(`Invalid Windows source path: ${sourceDir}`);
+}
+
 const sourceStats = await stat(sourceDir);
 if (!sourceStats.isDirectory()) {
   throw new Error(`Expected directory not found: ${sourceDir}`);


### PR DESCRIPTION
### Motivation
- The pretest script constructed a path from a file URL which could produce encoded spaces and double-drive prefixes like `C:\C:\...` on Windows, causing ENOENT failures.

### Description
- Replace URL-based path computation in `packages/conformance-tests/scripts/check-no-todo.mjs` with `fileURLToPath(import.meta.url)` plus `dirname(...)` and `resolve(...)` to obtain a robust absolute path.
- Add runtime self-checks that assert the resolved `sourceDir` is absolute and reject malformed Windows paths containing `C:\C:\`.
- Preserve the existing recursive scan and banned-pattern checks (`TODO`, `FIXME`, `assert(true)`, `expect(true).toBe(true)`); only path resolution and assertions were changed.

### Testing
- Ran `pnpm --filter @mesh/conformance-tests pretest` and it completed successfully in this environment.
- Linux CI behavior is unchanged by this patch, and Windows path handling is now guarded to avoid the previous `C:\C:\...` failure mode.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a592cf674c8321a35ad5d92317b4aa)