### PR TITLE
fix(conformance-tests): run vitest via node executable in env wrapper

### DIFF
--- a/packages/conformance-tests/scripts/run-vitest-with-env.mjs
+++ b/packages/conformance-tests/scripts/run-vitest-with-env.mjs
@@ -1,12 +1,14 @@
 import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
 
-const pnpmCommand = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+const require = createRequire(import.meta.url);
+const vitestEntrypoint = require.resolve("vitest/vitest.mjs");
 const env = {
   ...process.env,
   MESH_TX_VISIBILITY_POLICY: "acl",
 };
 
-const child = spawn(pnpmCommand, ["vitest", "run"], {
+const child = spawn(process.execPath, [vitestEntrypoint, "run", ...process.argv.slice(2)], {
   stdio: "inherit",
   env,
 });


### PR DESCRIPTION
### Motivation
- The `run-vitest-with-env.mjs` wrapper failed on Windows with `spawn EINVAL` because spawning `pnpm`/`pnpm.cmd` is not always resolvable in certain environments, so the launcher must not rely on spawning the `pnpm` binary. 
- Keep the patch minimal, preserve `MESH_TX_VISIBILITY_POLICY="acl"`, avoid reintroducing `cross-env`, and ensure cross-platform compatibility by launching Vitest via Node itself.

### Description
- Replace spawning of `pnpm`/`pnpm.cmd` with resolving Vitest's entrypoint via `createRequire(import.meta.url).resolve("vitest/vitest.mjs")` and spawn Node with `process.execPath` to run that entrypoint. 
- Invoke Node as `process.execPath` with arguments `[vitestEntrypoint, "run", ...process.argv.slice(2)]` so CLI args are forwarded. 
- Preserve environment overlay `MESH_TX_VISIBILITY_POLICY: "acl"` and keep `stdio: "inherit"` so output and signals are preserved. 
- Change is localized to `packages/conformance-tests/scripts/run-vitest-with-env.mjs` and does not touch test logic.

### Testing
- Ran `pnpm --filter @mesh/conformance-tests test`; the wrapper executed successfully but the full suite reported failures unrelated to this change due to unresolved local package entry issues (errors resolving `@mesh/conformance-harness`, `@mesh/projection-minimal`, `@mesh/sync-local`).
- Ran `pnpm vitest run packages/conformance-tests/src/ct_http_recovery.test.ts -t "CT-SYNC-4"` and it completed successfully. ✅
- Ran `node packages/conformance-tests/scripts/run-vitest-with-env.mjs packages/conformance-tests/src/ct_http_recovery.test.ts -t "CT-SYNC-4"` and it executed successfully using the updated wrapper. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5dcdf7a1c8321bbb58e68fa70f120)