### PR TITLE
fix(conformance-tests): use shell for vitest spawn on Windows

### DIFF
--- a/packages/conformance-tests/scripts/run-vitest-with-env.mjs
+++ b/packages/conformance-tests/scripts/run-vitest-with-env.mjs
@@ -24,6 +24,7 @@ const env = {
 const result = spawnSync(vitestBin, ["run", ...process.argv.slice(2)], {
   stdio: "inherit",
   env,
+  shell: process.platform === "win32",
 });
 
 if (result.error) {


### PR DESCRIPTION
### Motivation
- Fix Windows `spawnSync` EINVAL when invoking `.cmd` binaries from paths containing spaces by executing them via a shell.

### Description
- Add `shell: process.platform === "win32"` to the `spawnSync` options in `packages/conformance-tests/scripts/run-vitest-with-env.mjs` so `.cmd` executables are run through the shell and no other changes were made.

### Testing
- Ran `pnpm --filter @mesh/conformance-tests test` which invoked `run-vitest-with-env.mjs` and launched Vitest; the test run started and many tests passed but the process exited with failures due to package resolution errors unrelated to this change (e.g. `@mesh/conformance-harness`, `@mesh/projection-minimal`, `@mesh/sync-local`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5e257972483218e4900ddebb21dcc)