### PR TITLE
fix(conformance-tests): run vitest via cmd.exe with quoted path on Windows

### DIFF
--- a/packages/conformance-tests/scripts/run-vitest-with-env.mjs
+++ b/packages/conformance-tests/scripts/run-vitest-with-env.mjs
@@ -21,11 +21,28 @@ const env = {
   MESH_TX_VISIBILITY_POLICY: "acl",
 };
 
-const result = spawnSync(vitestBin, ["run", ...process.argv.slice(2)], {
-  stdio: "inherit",
-  env,
-  shell: process.platform === "win32",
-});
+const args = ["run", ...process.argv.slice(2)];
+const result =
+  process.platform === "win32"
+    ? spawnSync(
+        process.env.ComSpec || "cmd.exe",
+        [
+          "/d",
+          "/s",
+          "/c",
+          [vitestBin, ...args].map((arg) => `"${arg.replaceAll('"', '""')}"`).join(" "),
+        ],
+        {
+          stdio: "inherit",
+          env,
+          shell: false,
+        },
+      )
+    : spawnSync(vitestBin, args, {
+        stdio: "inherit",
+        env,
+        shell: false,
+      });
 
 if (result.error) {
   console.error(result.error);


### PR DESCRIPTION
### Motivation
- On Windows `spawnSync(vitestBin, ..., { shell: true })` can truncate `vitestBin` when the executable path contains spaces, causing the vitest wrapper to fail to locate/run the command.

### Description
- Update `packages/conformance-tests/scripts/run-vitest-with-env.mjs` to prepare `args` and avoid `shell:true` on Windows.
- On `win32`, invoke `cmd.exe` (`process.env.ComSpec || "cmd.exe"`) with `['/d','/s','/c', commandLine]` where `commandLine` is `vitestBin` plus args with each token fully quoted and internal quotes escaped. 
- On non-Windows platforms keep the direct `spawnSync(vitestBin, args, { shell: false })` behavior. 
- Changed file: `packages/conformance-tests/scripts/run-vitest-with-env.mjs`.

### Testing
- Ran `pnpm --filter @mesh/conformance-tests test`, which executed but failed due to pre-existing workspace package resolution errors for `@mesh/conformance-harness`, `@mesh/projection-minimal`, and `@mesh/sync-local` (these failures are unrelated to the wrapper change). 
- Ran `pnpm -r --filter @mesh/conformance-tests... test`, which produced the same workspace resolution failures and reported failure. 
- Windows-specific verification (running the command on a Windows host with spaces in the path) could not be performed in this Linux environment and should be validated in CI or on a Windows machine.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5e582393083219abb521bca79ee9b)