### PR TITLE
Fix cmd.exe quoting in conformance vitest wrapper

### DIFF
--- a/packages/conformance-tests/scripts/run-vitest-with-env.mjs
+++ b/packages/conformance-tests/scripts/run-vitest-with-env.mjs
@@ -22,6 +22,7 @@ const env = {
 };
 
 const args = ["run", ...process.argv.slice(2)];
+const quoteForCmd = (arg) => `"${arg.replaceAll('"', '""')}"`;
 const result =
   process.platform === "win32"
     ? spawnSync(
@@ -30,7 +31,7 @@ const result =
           "/d",
           "/s",
           "/c",
-          [vitestBin, ...args].map((arg) => `"${arg.replaceAll('"', '""')}"`).join(" "),
+          `"${[quoteForCmd(vitestBin), ...args.map(quoteForCmd)].join(" ")}"`,
         ],
         {
           stdio: "inherit",


### PR DESCRIPTION
### Motivation
- Fix Windows `cmd.exe` quoting in `packages/conformance-tests/scripts/run-vitest-with-env.mjs` so `vitest.cmd` paths with spaces are invoked correctly and avoid literal `\"` sequences that break execution.

### Description
- Add a `quoteForCmd` helper that wraps arguments in `"..."` and doubles internal quotes (`""`) and update the Windows `spawnSync` call to use `cmd.exe /d /s /c` with the entire command wrapped in an outer pair of quotes while leaving the non-Windows execution branch and `shell: false` unchanged.

### Testing
- Ran `pnpm --filter @mesh/conformance-tests test`, which exercised `node ./scripts/run-vitest-with-env.mjs` and showed many tests executed (overall `Tests 40 passed`) but the run failed overall due to 8 failed suites caused by Vite package entry resolution errors for `@mesh/conformance-harness`, `@mesh/projection-minimal`, and `@mesh/sync-local`.
- Ran `pnpm -r --filter @mesh/conformance-tests... test`, which ran workspace package tests and reported the same conformance-tests failures for the same package resolution reasons.
- Windows-specific invocation could not be executed in this Linux container, so direct `cmd.exe` runtime verification was not possible here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5e87c505c8321a3a21f44f62aa159)