### PR TITLE
Fix Windows process spawning in dump-api script

### DIFF
--- a/tools/ci/dump-api.mjs
+++ b/tools/ci/dump-api.mjs
@@ -24,8 +24,15 @@ function parseArgs(argv) {
 
 async function run(cmd, args, cwd = repoRoot) {
   await new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, { cwd, stdio: "inherit", env: process.env });
-    child.on("exit", (code) => {
+    const child = spawn(cmd, args, {
+      cwd,
+      stdio: "inherit",
+      env: process.env,
+      shell: process.platform === "win32",
+    });
+
+    child.once("error", reject);
+    child.once("exit", (code) => {
       if (code === 0) resolve();
       else reject(new Error(`Command failed: ${cmd} ${args.join(" ")} (exit ${code ?? "null"})`));
     });


### PR DESCRIPTION
### Motivation
- Ensure `spawn("pnpm", ...)` does not fail with `ENOENT` on Windows while preserving existing behavior on Linux/macOS.

### Description
- Update `run(cmd, args, cwd)` to use `shell: process.platform === "win32"` and add explicit `child.once("error", reject)` while preserving `cwd`, `stdio: "inherit"`, `env`, the Promise interface, and non-zero exit code handling.

### Testing
- Ran `node --check tools/ci/dump-api.mjs` which completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a72f0c4e9c83219335c1bb74d8d9e9)