### PR TITLE
chore(sync-local): stop using internal subpath in server imports

### DIFF
--- a/apps/mesh-graph-server/src/index.ts
+++ b/apps/mesh-graph-server/src/index.ts
@@ -5,7 +5,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from "node:ht
 import { join } from "node:path";
 import { FileBackedLocalEventStore } from "@mesh/eventstore-local";
 import { KernelMinimalImpl } from "@mesh/kernel-minimal";
-import { LocalSyncGateway } from "@mesh/sync-local/internal";
+import { LocalSyncGateway } from "@mesh/sync-local";
 import type { Command, CommandOutcome, Cursor, PrincipalContext } from "@mesh/shared";
 
 const GRAPH_SPACE_ID = "mesh-explorer-graph-v1";

--- a/apps/mesh-notes-server/src/index.ts
+++ b/apps/mesh-notes-server/src/index.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import { FileBackedLocalEventStore } from "@mesh/eventstore-local";
 import { KernelMinimalImpl } from "@mesh/kernel-minimal";
 import { SyncHttpReferenceServer } from "@mesh/sync-http";
-import { LocalSyncGateway } from "@mesh/sync-local/internal";
+import { LocalSyncGateway } from "@mesh/sync-local";
 import type { Command, CommandOutcome, PrincipalContext } from "@mesh/shared";
 
 const GRAPH_SPACE_ID = "notes-app-shared-space-v1";


### PR DESCRIPTION
### Motivation
- Prevent leaking internal APIs into the public contract by removing direct imports from `@mesh/sync-local/internal` in server code so the `StateDigest*` tooling remains internal/test-only and the public API boundary is preserved.

### Description
- Replace `@mesh/sync-local/internal` → `@mesh/sync-local` in `apps/mesh-graph-server/src/index.ts` and `apps/mesh-notes-server/src/index.ts` so servers use the stable public `LocalSyncGateway` entrypoint.

### Testing
- Ran `pnpm check:api-contract` which passed and confirmed no `./internal` exports in the generated `mesh__sync-local` contract; ran `pnpm -r --filter @mesh/conformance-tests... test` which completed successfully (all conformance tests passed); and built the affected servers with TypeScript (`tsc`) which also succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a73e66db1483219c58e0a0f7c69b9b)