### PR TITLE
Normalize API contract checker text to ignore EOL differences

### DIFF
--- a/tools/ci/check-api-contract.mjs
+++ b/tools/ci/check-api-contract.mjs
@@ -23,7 +23,12 @@ async function run(cmd, args, cwd = repoRoot) {
 }
 
 async function readText(filePath) {
-  return fs.readFile(filePath, "utf8");
+  return normalizeText(await fs.readFile(filePath, "utf8"));
+}
+
+function normalizeText(s) {
+  if (s.startsWith("\uFEFF")) s = s.slice(1);
+  return s.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }
 
 function simpleDiff(expected, actual, maxChanges = 20) {


### PR DESCRIPTION
### Motivation
- Fix false "API contract mismatch" reports caused by CRLF vs LF line ending differences between golden and generated files by normalizing text before comparison and stripping a possible UTF-8 BOM so the checker is cross-platform.
- "Refs #134"

### Description
- Add a `normalizeText` utility to `tools/ci/check-api-contract.mjs` that strips a leading `\uFEFF` and converts `CRLF`/`CR` to `LF`, and update `readText` to return normalized text so all `.d.ts` and `INDEX` reads/diffs operate on normalized strings without modifying golden files or changing mismatch semantics.

### Testing
- Ran `pnpm check:api-contract`, but the run failed during `dump-api.mjs` due to TypeScript module resolution errors unrelated to the normalization change, so the environment could not fully validate the EOL-only mismatch case; the command output is shown below.

```
> mesh-explorer-execution@0.1.0 check:api-contract /workspace/mesh-explorer-execution
> node tools/ci/check-api-contract.mjs

packages/kernel-minimal/src/KernelMinimal.ts(1,67): error TS2307: Cannot find module '@mesh/shared' or its corresponding type declarations.
packages/kernel-minimal/src/KernelMinimalImpl.ts(1,38): error TS2307: Cannot find module '@mesh/eventstore-local' or its corresponding type declarations.
packages/kernel-minimal/src/KernelMinimalImpl.ts(2,86): error TS2307: Cannot find module '@mesh/shared' or its corresponding type declarations.
Command failed: pnpm exec tsc -p /workspace/mesh-explorer-execution/packages/kernel-minimal/tsconfig.json --emitDeclarationOnly --declarationMap false --outDir /workspace/mesh-explorer-execution/.tmp/api-contract/mesh__kernel-minimal (exit 2)
Command failed: node tools/ci/dump-api.mjs --mode=generated --skip-build (exit 1)










































```

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a74f6beb348321b34de99b1838d020)