### PR TITLE
Harden Option A durable-cursor barrier for digest-strict sync client

### DIFF
--- a/packages/conformance-tests/expected-invariants.json
+++ b/packages/conformance-tests/expected-invariants.json
@@ -290,6 +290,26 @@
     "criticality": "Critical"
   },
   {
+    "invariantId": "CT-SD-5",
+    "surface": "Sync",
+    "criticality": "Critical"
+  },
+  {
+    "invariantId": "CT-SD-6",
+    "surface": "Sync",
+    "criticality": "Critical"
+  },
+  {
+    "invariantId": "CT-SD-7",
+    "surface": "Sync",
+    "criticality": "Critical"
+  },
+  {
+    "invariantId": "CT-SD-8",
+    "surface": "Sync",
+    "criticality": "Critical"
+  },
+  {
     "invariantId": "CT-SNAP-1",
     "surface": "Snapshot",
     "criticality": "Structural"

--- a/packages/conformance-tests/src/ct_state_digest_strict.test.ts
+++ b/packages/conformance-tests/src/ct_state_digest_strict.test.ts
@@ -141,6 +141,195 @@ describe("CT-SD-* StateDigest strict", () => {
     expect(clientB.getDurableCursor()).toBe(1);
     expect(clientB.getCandidateCursor()).toBe(1);
   });
+
+  it("[INV:CT-SD-5][SURF:Sync] durable cursor never advances before poll+digest validation", async ({ task }) => {
+    task.meta.invariantId = "CT-SD-5";
+    task.meta.surface = "Sync";
+    task.meta.oracle = "Durable cursor remains pinned to persisted value until poll+digest validation completes.";
+    task.meta.criticality = "Critical";
+
+    const store = new InMemoryLocalEventStore();
+    const graphSpaceId = "space-sd-5";
+    const principal = { principalId: "alice" };
+    const gateway = new LocalSyncGateway(store, { graphSpaceId });
+
+    await store.appendTx(graphSpaceId, { txId: "sd5-tx-1", metaEvents: [], graphEvents: [{ n: 1 }] }, makeIdem("sd5-1"));
+    await store.appendTx(graphSpaceId, { txId: "sd5-tx-2", metaEvents: [], graphEvents: [{ n: 2 }] }, makeIdem("sd5-2"));
+
+    const bootstrapClient = new StateDigestSyncClient(gateway, graphSpaceId, principal);
+    const first = await gateway.syncPull(graphSpaceId, principal, 0, { limitTx: 1 });
+    bootstrapClient.initializeDurableState(first.txBundlesVisible, 1);
+
+    const subscribeDelta = await gateway.syncPull(graphSpaceId, principal, 1, { limitTx: 8 });
+    bootstrapClient.ingestSubscribeTxBundles(subscribeDelta.txBundlesVisible);
+
+    expect(bootstrapClient.getCandidateCursor()).toBe(2);
+    expect(bootstrapClient.getDurableCursor()).toBe(1);
+
+    const persistedDurableCursor = bootstrapClient.getDurableCursor();
+    const reloadedClient = new StateDigestSyncClient(gateway, graphSpaceId, principal);
+    reloadedClient.initializeDurableState(first.txBundlesVisible, persistedDurableCursor);
+
+    expect(reloadedClient.getDurableCursor()).toBe(1);
+    expect(reloadedClient.getCandidateCursor()).toBe(1);
+  });
+
+  it("[INV:CT-SD-6][SURF:Sync] subscribe gap forces poll recovery and no partial candidate apply", async ({ task }) => {
+    task.meta.invariantId = "CT-SD-6";
+    task.meta.surface = "Sync";
+    task.meta.oracle = "Gap delivery during subscribe does not apply candidate state and forces poll recovery.";
+    task.meta.criticality = "Critical";
+
+    const store = new InMemoryLocalEventStore();
+    const graphSpaceId = "space-sd-6";
+    const principal = { principalId: "alice" };
+    const gateway = new LocalSyncGateway(store, { graphSpaceId });
+    const client = new StateDigestSyncClient(gateway, graphSpaceId, principal);
+
+    for (let idx = 1; idx <= 3; idx += 1) {
+      await store.appendTx(graphSpaceId, { txId: `sd6-tx-${idx}`, metaEvents: [], graphEvents: [{ idx }] }, makeIdem(`sd6-${idx}`));
+    }
+
+    const gapOnly = await gateway.syncPull(graphSpaceId, principal, 1, { limitTx: 1 });
+    const ingest = client.ingestSubscribeTxBundles(gapOnly.txBundlesVisible);
+    expect(ingest.accepted).toBe(0);
+    expect(client.getCandidateCursor()).toBe(0);
+    expect(ingest.requiresPoll).toBe(true);
+
+    await client.recoverByFullPoll();
+    const commit = await client.validateAndCommit();
+    const polled = await pollAll(gateway, graphSpaceId, principal);
+
+    expect(commit.committed).toBe(true);
+    expect(client.getDurableCursor()).toBe(polled.cursor);
+    expect(client.getDecisionLog().some((entry) => entry.reason === "subscribe_gap_detected")).toBe(true);
+    expect(client.getDecisionLog().some((entry) => entry.reason === "poll_recovery_triggered")).toBe(true);
+  });
+
+  it("[INV:CT-SD-7][SURF:Sync] storm fuzz converges with durable cursor barrier", async ({ task }) => {
+    task.meta.invariantId = "CT-SD-7";
+    task.meta.surface = "Sync";
+    task.meta.oracle = "Under drop/dup/reconnect storms, durable cursor advances only post-validation and converges to poll replay.";
+    task.meta.criticality = "Critical";
+
+    const store = new InMemoryLocalEventStore();
+    const graphSpaceId = "space-sd-7";
+    const principal = { principalId: "alice" };
+    const gateway = new LocalSyncGateway(store, { graphSpaceId });
+    const client = new StateDigestSyncClient(gateway, graphSpaceId, principal);
+
+    for (let idx = 1; idx <= 18; idx += 1) {
+      await store.appendTx(graphSpaceId, { txId: `sd7-tx-${idx}`, metaEvents: [{ idx }], graphEvents: [{ idx }] }, makeIdem(`sd7-${idx}`));
+    }
+
+    const rng = seededRng(1337);
+    let subscribeCursor = 0;
+
+    for (let step = 0; step < 48; step += 1) {
+      const pulled = await gateway.syncPull(graphSpaceId, principal, subscribeCursor, { limitTx: 3 });
+      if (pulled.txBundlesVisible.length > 0) {
+        subscribeCursor = pulled.cursorAfterVisible;
+      }
+
+      const planned = [...pulled.txBundlesVisible];
+      if (planned.length > 0 && rng() < 0.35) {
+        planned.shift();
+      }
+      if (planned.length > 0 && rng() < 0.4) {
+        planned.push(planned[planned.length - 1]!);
+      }
+      if (planned.length > 1 && rng() < 0.35) {
+        planned.reverse();
+      }
+
+      const beforeDurable = client.getDurableCursor();
+      client.ingestSubscribeTxBundles(planned);
+      const validation = await client.validateAndCommit();
+      expect(client.getDurableCursor()).toBeGreaterThanOrEqual(beforeDurable);
+
+      if (!validation.committed && validation.requiresPoll) {
+        await client.recoverByFullPoll();
+        const recovered = await client.validateAndCommit();
+        expect(recovered.committed).toBe(true);
+      }
+    }
+
+    const polled = await pollAll(gateway, graphSpaceId, principal);
+    const pollDigest = computeCanonicalStateDigest(graphSpaceId, principal, polled.state, polled.cursor);
+
+    expect(client.getDurableCursor()).toBe(polled.cursor);
+    expect(client.snapshotDigest().digest).toBe(pollDigest.digest);
+
+    const decisions = client.getDecisionLog();
+    const durableSteps = decisions.filter((entry) => entry.reason === "durable_cursor_advanced");
+    for (const step of durableSteps) {
+      expect(step.pollValidatedCursor).toBeGreaterThanOrEqual(step.candidateCursor);
+    }
+  });
+
+  it("[INV:CT-SD-8][SURF:Sync] mask/cursor non-leak sanity under principal-scoped digest", async ({ task }) => {
+    task.meta.invariantId = "CT-SD-8";
+    task.meta.surface = "Sync";
+    task.meta.oracle = "Principal-scoped digest and visible cursors only track visible transactions under masking policy.";
+    task.meta.criticality = "Critical";
+
+    process.env.MESH_TX_VISIBILITY_POLICY = "acl";
+    try {
+      const store = new InMemoryLocalEventStore();
+      const graphSpaceId = "space-sd-8";
+      const gateway = new LocalSyncGateway(store, { graphSpaceId });
+      const alice = { principalId: "alice" };
+      const bob = { principalId: "bob" };
+
+      await store.appendTx(
+        graphSpaceId,
+        {
+          txId: "sd8-tx-1",
+          metaEvents: [],
+          graphEvents: [{ name: "public-1", _acl: { "*": "allow" } }]
+        },
+        makeIdem("sd8-1")
+      );
+      await store.appendTx(
+        graphSpaceId,
+        {
+          txId: "sd8-tx-2",
+          metaEvents: [],
+          graphEvents: [{ name: "alice-only", _acl: { alice: "allow", bob: "mask" } }]
+        },
+        makeIdem("sd8-2")
+      );
+      await store.appendTx(
+        graphSpaceId,
+        {
+          txId: "sd8-tx-3",
+          metaEvents: [],
+          graphEvents: [{ name: "public-2", _acl: { "*": "allow" } }]
+        },
+        makeIdem("sd8-3")
+      );
+
+      const alicePoll = await pollAll(gateway, graphSpaceId, alice);
+      const bobPoll = await pollAll(gateway, graphSpaceId, bob);
+
+      expect(alicePoll.cursor).toBe(3);
+      expect(bobPoll.cursor).toBe(2);
+
+      const aliceClient = new StateDigestSyncClient(gateway, graphSpaceId, alice);
+      aliceClient.ingestSubscribeTxBundles((await gateway.syncPull(graphSpaceId, alice, 0, { limitTx: 16 })).txBundlesVisible);
+      await aliceClient.validateAndCommit();
+
+      const bobClient = new StateDigestSyncClient(gateway, graphSpaceId, bob);
+      bobClient.ingestSubscribeTxBundles((await gateway.syncPull(graphSpaceId, bob, 0, { limitTx: 16 })).txBundlesVisible);
+      await bobClient.validateAndCommit();
+
+      expect(aliceClient.getDurableCursor()).toBe(3);
+      expect(bobClient.getDurableCursor()).toBe(2);
+      expect(aliceClient.snapshotDigest().digest).not.toBe(bobClient.snapshotDigest().digest);
+    } finally {
+      delete process.env.MESH_TX_VISIBILITY_POLICY;
+    }
+  });
 });
 
 function makeIdem(key: string) {
@@ -148,5 +337,15 @@ function makeIdem(key: string) {
     actorId: "writer",
     idempotencyKey: key,
     payloadHash: key
+  };
+}
+
+function seededRng(seed: number): () => number {
+  let x = seed >>> 0;
+  return () => {
+    x ^= x << 13;
+    x ^= x >>> 17;
+    x ^= x << 5;
+    return (x >>> 0) / 0xffffffff;
   };
 }

--- a/packages/sync-local/src/internal/stateDigestClient.ts
+++ b/packages/sync-local/src/internal/stateDigestClient.ts
@@ -9,6 +9,26 @@ export interface CanonicalStateDigest {
   digest: string;
 }
 
+export type StateDigestDecisionReason =
+  | "durable_cursor_advanced"
+  | "subscribe_deduped"
+  | "subscribe_gap_detected"
+  | "subscribe_out_of_order"
+  | "subscribe_invalid_tx_bundle"
+  | "subscribe_blocked_requires_poll"
+  | "poll_not_caught_up"
+  | "digest_mismatch"
+  | "validation_failed_requires_poll"
+  | "poll_recovery_triggered"
+  | "poll_recovery_completed";
+
+export interface StateDigestDecision {
+  reason: StateDigestDecisionReason;
+  durableCursor: number;
+  candidateCursor: number;
+  pollValidatedCursor: number;
+}
+
 interface CanonicalStateDump {
   principalId: string;
   graphSpaceId: string;
@@ -48,8 +68,10 @@ export class StateDigestSyncClient {
   private durableState: Array<{ principalCursor: number; txBundle: TxBundle }> = [];
   private candidateCursor = 0;
   private candidateState: Array<{ principalCursor: number; txBundle: TxBundle }> = [];
+  private pollValidatedCursor = 0;
   private readonly seenTxIds = new Set<string>();
   private needsPoll = false;
+  private readonly decisions: StateDigestDecision[] = [];
 
   constructor(
     private readonly gateway: LocalSyncGateway,
@@ -65,11 +87,20 @@ export class StateDigestSyncClient {
     return this.candidateCursor;
   }
 
+  getPollValidatedCursor(): number {
+    return this.pollValidatedCursor;
+  }
+
+  getDecisionLog(): StateDigestDecision[] {
+    return [...this.decisions];
+  }
+
   initializeDurableState(state: Array<{ principalCursor: number; txBundle: TxBundle }>, cursor: number): void {
     this.durableState = [...state];
     this.durableCursor = cursor;
     this.candidateState = [...state];
     this.candidateCursor = cursor;
+    this.pollValidatedCursor = cursor;
     this.seenTxIds.clear();
     for (const tx of state) {
       this.seenTxIds.add(tx.txBundle.txId);
@@ -78,23 +109,35 @@ export class StateDigestSyncClient {
   }
 
   ingestSubscribeTxBundles(txBundlesVisible: VisibleTxBundle[]): { accepted: number; requiresPoll: boolean } {
+    if (this.needsPoll) {
+      this.recordDecision("subscribe_blocked_requires_poll");
+      return { accepted: 0, requiresPoll: true };
+    }
+
     let accepted = 0;
 
     for (const bundle of txBundlesVisible) {
+      if (!isWellFormedTxBundle(bundle.txBundle)) {
+        this.triggerPollRecovery("subscribe_invalid_tx_bundle");
+        break;
+      }
+
       if (bundle.principalCursor <= this.candidateCursor) {
         if (this.seenTxIds.has(bundle.txBundle.txId)) {
+          this.recordDecision("subscribe_deduped");
           continue;
         }
-        this.needsPoll = true;
+        this.triggerPollRecovery("subscribe_out_of_order");
         continue;
       }
 
       if (bundle.principalCursor !== this.candidateCursor + 1) {
-        this.needsPoll = true;
+        this.triggerPollRecovery("subscribe_gap_detected");
         break;
       }
 
       if (this.seenTxIds.has(bundle.txBundle.txId)) {
+        this.recordDecision("subscribe_deduped");
         continue;
       }
 
@@ -110,6 +153,13 @@ export class StateDigestSyncClient {
   async validateAndCommit(limitTx = 128): Promise<{ committed: boolean; requiresPoll: boolean; durableCursor: number }> {
     const polledDelta = await this.collectFromCursor(this.durableCursor, limitTx);
     const polledState = [...this.durableState, ...polledDelta.txs];
+    this.pollValidatedCursor = polledDelta.cursorAfter;
+
+    if (this.pollValidatedCursor < this.candidateCursor) {
+      this.triggerPollRecovery("poll_not_caught_up");
+      this.rollbackCandidateToDurable();
+      return { committed: false, requiresPoll: true, durableCursor: this.durableCursor };
+    }
 
     const candidateDigest = computeCanonicalStateDigest(this.graphSpaceId, this.principal, this.candidateState, this.candidateCursor);
     const polledDigest = computeCanonicalStateDigest(this.graphSpaceId, this.principal, polledState, polledDelta.cursorAfter);
@@ -119,25 +169,29 @@ export class StateDigestSyncClient {
     if (canCommit) {
       this.durableCursor = this.candidateCursor;
       this.durableState = [...this.candidateState];
+      this.recordDecision("durable_cursor_advanced");
       return { committed: true, requiresPoll: false, durableCursor: this.durableCursor };
     }
 
-    this.needsPoll = true;
-    this.candidateCursor = this.durableCursor;
-    this.candidateState = [...this.durableState];
+    this.triggerPollRecovery("digest_mismatch");
+    this.recordDecision("validation_failed_requires_poll");
+    this.rollbackCandidateToDurable();
     return { committed: false, requiresPoll: true, durableCursor: this.durableCursor };
   }
 
   async recoverByFullPoll(limitTx = 128): Promise<{ cursor: number; digest: CanonicalStateDigest }> {
+    this.recordDecision("poll_recovery_triggered");
     const full = await this.collectFromCursor(0, limitTx);
     this.candidateState = [...full.txs];
     this.candidateCursor = full.cursorAfter;
+    this.pollValidatedCursor = full.cursorAfter;
     this.seenTxIds.clear();
     for (const tx of this.candidateState) {
       this.seenTxIds.add(tx.txBundle.txId);
     }
     const digest = computeCanonicalStateDigest(this.graphSpaceId, this.principal, this.candidateState, this.candidateCursor);
     this.needsPoll = false;
+    this.recordDecision("poll_recovery_completed");
     return { cursor: full.cursorAfter, digest };
   }
 
@@ -163,4 +217,36 @@ export class StateDigestSyncClient {
 
     return { txs, cursorAfter: cursor };
   }
+
+  private triggerPollRecovery(reason: StateDigestDecisionReason): void {
+    this.needsPoll = true;
+    this.recordDecision(reason);
+  }
+
+  private rollbackCandidateToDurable(): void {
+    this.candidateCursor = this.durableCursor;
+    this.candidateState = [...this.durableState];
+    this.seenTxIds.clear();
+    for (const tx of this.candidateState) {
+      this.seenTxIds.add(tx.txBundle.txId);
+    }
+  }
+
+  private recordDecision(reason: StateDigestDecisionReason): void {
+    this.decisions.push({
+      reason,
+      durableCursor: this.durableCursor,
+      candidateCursor: this.candidateCursor,
+      pollValidatedCursor: this.pollValidatedCursor
+    });
+  }
+}
+
+function isWellFormedTxBundle(txBundle: TxBundle): boolean {
+  return (
+    typeof txBundle.txId === "string" &&
+    txBundle.txId.length > 0 &&
+    Array.isArray(txBundle.metaEvents) &&
+    Array.isArray(txBundle.graphEvents)
+  );
 }


### PR DESCRIPTION
### Motivation
- Enforce Option A invariant that `durableCursor` never advances without authoritative poll+digest validation and ensure robust behavior under reconnect/drop/dup storms. 
- Prevent partial or leaking candidate state when subscribe delivers gaps, out-of-order frames, malformed bundles or duplicates. 
- Make recovery decisions observable so conformance tests can prove the durable-commit barrier and recovery triggers. 

### Description
- Strengthened `StateDigestSyncClient` by explicitly tracking `durableCursor`, `candidateCursor`, and `pollValidatedCursor`, and requiring poll+digest alignment before advancing durable state. 
- Added subscribe-side hardening to detect gaps, out-of-order bundles, malformed tx bundles and dedupe redeliveries, where any divergence triggers poll recovery and rollback of candidate state without advancing `durableCursor`. 
- Introduced observable decision reasons/log (`StateDigestDecision` / `getDecisionLog`) and helper functions (`triggerPollRecovery`, `rollbackCandidateToDurable`, `isWellFormedTxBundle`) to record why recovery/rollback occurs. 
- Added critical conformance tests `CT-SD-5..CT-SD-8` (in `packages/conformance-tests/src/ct_state_digest_strict.test.ts`) and registered them in `packages/conformance-tests/expected-invariants.json`. 

### Testing
- Built the workspace with `pnpm -r build` and the build succeeded. 
- Ran the state-digest strict suite with `pnpm --filter @mesh/conformance-tests test -- ct_state_digest_strict.test.ts` and observed all tests in that file pass (8 tests). 
- Ran the full conformance test run for the package with `pnpm -r --filter @mesh/conformance-tests... test` and `pnpm --filter @mesh/conformance-tests test -- ct_state_digest_strict.test.ts -t "CT-SD-(5|6|7|8)"`, and all targeted CT-SD tests and the conformance suite passed (19 files, 85 tests). 
- Verified API contract with `pnpm check:api-contract` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a751be18f0832190d9866f36088269)