### PR TITLE
CI: enforce conformance critical gate across Linux and Windows

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -14,17 +14,17 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Enable corepack
+        run: corepack enable
       - name: Validate conformance workflow invariants
         run: pnpm ci:validate-workflows
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         mesh_backend: [inmemory, persistent]
     env:
       MESH_BACKEND: ${{ matrix.mesh_backend }}
@@ -37,9 +37,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - name: Enable corepack
+        run: corepack enable
       - name: Prune pnpm store
         run: pnpm store prune
       - name: Install
@@ -55,26 +54,36 @@ jobs:
       - name: Check reasonCodes policy
         run: pnpm check:reasoncodes-policy
       - name: Enforce conformance test hygiene
-        if: matrix.mesh_backend == 'inmemory'
+        if: matrix.mesh_backend == 'inmemory' && matrix.os == 'ubuntu-latest'
         run: node tools/ci/check-patterns.mjs --root packages/conformance-tests/src --no-default-patterns --pattern "TODO" --pattern "skip\("
-      - name: Test (${{ matrix.mesh_backend }})
-        run: pnpm test
+      - name: Run conformance tests (${{ matrix.mesh_backend }})
+        run: pnpm -r --filter @mesh/conformance-tests... test
+      - name: Generate conformance evidence (${{ matrix.mesh_backend }})
+        run: pnpm --filter @mesh/conformance-tests posttest
+      - name: Mirror evidence paths for CI artifacts (${{ matrix.mesh_backend }})
+        shell: bash
+        run: |
+          mkdir -p packages/conformance-tests
+          cp artifacts/conformance-evidence.runtime.json packages/conformance-tests/conformance-evidence.runtime.json
+          cp artifacts/conformance-evidence.critical.md packages/conformance-tests/conformance-evidence.critical.md
       - name: Critical gate (${{ matrix.mesh_backend }})
         run: pnpm --filter @mesh/conformance-tests check:critical
       - name: Artifacts up-to-date
-        if: matrix.mesh_backend == 'inmemory'
+        if: matrix.mesh_backend == 'inmemory' && matrix.os == 'ubuntu-latest'
         run: pnpm --filter @mesh/conformance-tests check:artifacts-clean
       - name: Upload conformance evidence artifacts
         if: always() && matrix.mesh_backend == 'inmemory'
         uses: actions/upload-artifact@v4
         with:
-          name: conformance-artifacts
+          name: conformance-artifacts-${{ matrix.os }}-${{ matrix.mesh_backend }}
           path: |
             artifacts/conformance-evidence.md
             artifacts/conformance-evidence.critical.md
             artifacts/conformance-evidence.json
             artifacts/conformance-evidence.persistent.md
             artifacts/conformance-evidence.runtime.json
+            packages/conformance-tests/conformance-evidence.critical.md
+            packages/conformance-tests/conformance-evidence.runtime.json
             **/*.log
             **/*dump*.json
             **/vitest*.xml

--- a/scripts/ci/validate-conformance-workflow.mjs
+++ b/scripts/ci/validate-conformance-workflow.mjs
@@ -106,7 +106,7 @@ if (!hasBuildStep && !hasBuildInTest) {
 
 checkRequiredPattern(
   workflowContent,
-  /pnpm\s+(?:--filter\s+@mesh\/conformance-tests\s+test|test)\b/m,
+  /pnpm\s+(?:(?:-r\s+)?--filter\s+@mesh\/conformance-tests(?:\.\.\.)?\s+test|test)\b/m,
   'Missing step: pnpm test OR pnpm --filter @mesh/conformance-tests test',
 );
 
@@ -185,7 +185,7 @@ if (workflowFiles.includes(NIGHTLY_FILE)) {
 
   checkRequiredPattern(
     nightlyContent,
-    /pnpm\s+(?:--filter\s+@mesh\/conformance-tests\s+test|test)\b/m,
+    /pnpm\s+(?:(?:-r\s+)?--filter\s+@mesh\/conformance-tests(?:\.\.\.)?\s+test|test)\b/m,
     'Missing step in conformance-nightly.yml: pnpm test OR pnpm --filter @mesh/conformance-tests test',
   );
 


### PR DESCRIPTION
### Motivation

- Ensure Critical conformance gates run on both Linux and Windows runners and make conformance evidence reliably available for debugging.
- Use stable, cross-platform commands and bootstrapping so the CI is robust to runner differences and does not rely on fragile shell behavior.

### Description

- Run the `test` job as a matrix over `os: [ubuntu-latest, windows-latest]` by switching `runs-on` to `matrix.os` and adding the OS matrix entry.
- Replace the `pnpm/action-setup` usage with a stable `corepack enable` step so `pnpm` is available consistently on both runners.
- Use a stable recursive filter test invocation `pnpm -r --filter @mesh/conformance-tests... test` and add an explicit evidence generation step `pnpm --filter @mesh/conformance-tests posttest` to produce evidence files deterministically.
- Mirror evidence files into `packages/conformance-tests/` (`conformance-evidence.runtime.json` and `conformance-evidence.critical.md`) and include those paths in the uploaded artifact set, and change artifact names to include `${{ matrix.os }}` and `${{ matrix.mesh_backend }}`.
- Restrict the test-hygiene check to run only on `ubuntu-latest` to avoid Windows path/tooling false positives, and update `scripts/ci/validate-conformance-workflow.mjs` to accept the new recursive filtered `pnpm` invocation form (including optional `-r` and the `...` suffix) for both primary and nightly workflow checks.

### Testing

- Ran `pnpm ci:validate-workflows` which executed `scripts/ci/validate-conformance-workflow.mjs` and it passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8a9ade4588321aa3a8b437f5dee57)