### PR TITLE
Stabilize conformance CI: pin Node/pnpm and add determinism check

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,5 +1,8 @@
 name: Conformance
 
+env:
+  NODE_VERSION: 20.11.1
+
 on:
   pull_request:
   push:
@@ -13,9 +16,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: ${{ env.NODE_VERSION }}
       - name: Enable corepack
         run: corepack enable
+      - name: Activate pnpm from packageManager
+        run: corepack install
+      - name: Show runtime versions
+        run: |
+          node --version
+          pnpm --version
       - name: Validate conformance workflow invariants
         run: pnpm ci:validate-workflows
 
@@ -32,13 +41,28 @@ jobs:
       MESH_CHAOS_SEEDS: "1,2,3,4,5"
       MESH_CHAOS_STEPS: "200"
       MESH_CHAOS_BACKEND: "inmemory"
+      TZ: UTC
+      LANG: C
+      LC_ALL: C
+      TMPDIR: ${{ github.workspace }}/.tmp
+      TMP: ${{ github.workspace }}\\.tmp
+      TEMP: ${{ github.workspace }}\\.tmp
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: ${{ env.NODE_VERSION }}
       - name: Enable corepack
         run: corepack enable
+      - name: Activate pnpm from packageManager
+        run: corepack install
+      - name: Show runtime versions
+        run: |
+          node --version
+          pnpm --version
+      - name: Prepare stable temp directory
+        shell: bash
+        run: mkdir -p "${GITHUB_WORKSPACE}/.tmp"
       - name: Prune pnpm store
         run: pnpm store prune
       - name: Install
@@ -57,9 +81,16 @@ jobs:
         if: matrix.mesh_backend == 'inmemory' && matrix.os == 'ubuntu-latest'
         run: node tools/ci/check-patterns.mjs --root packages/conformance-tests/src --no-default-patterns --pattern "TODO" --pattern "skip\("
       - name: Run conformance tests (${{ matrix.mesh_backend }})
+        if: !(matrix.mesh_backend == 'inmemory' && matrix.os == 'ubuntu-latest')
         run: pnpm -r --filter @mesh/conformance-tests... test
       - name: Generate conformance evidence (${{ matrix.mesh_backend }})
+        if: !(matrix.mesh_backend == 'inmemory' && matrix.os == 'ubuntu-latest')
         run: pnpm --filter @mesh/conformance-tests posttest
+      - name: Stability check (determinism)
+        if: matrix.mesh_backend == 'inmemory' && matrix.os == 'ubuntu-latest'
+        env:
+          MESH_STABILITY_ITERATIONS: "3"
+        run: pnpm ci:check-determinism
       - name: Mirror evidence paths for CI artifacts (${{ matrix.mesh_backend }})
         shell: bash
         run: |
@@ -67,6 +98,7 @@ jobs:
           cp artifacts/conformance-evidence.runtime.json packages/conformance-tests/conformance-evidence.runtime.json
           cp artifacts/conformance-evidence.critical.md packages/conformance-tests/conformance-evidence.critical.md
       - name: Critical gate (${{ matrix.mesh_backend }})
+        if: !(matrix.mesh_backend == 'inmemory' && matrix.os == 'ubuntu-latest')
         run: pnpm --filter @mesh/conformance-tests check:critical
       - name: Artifacts up-to-date
         if: matrix.mesh_backend == 'inmemory' && matrix.os == 'ubuntu-latest'

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "mesh-explorer-execution",
   "private": true,
   "version": "0.1.0",
+  "engines": {
+    "node": "20.11.1"
+  },
+  "packageManager": "pnpm@9.15.4",
   "scripts": {
     "build": "pnpm -r build",
     "test": "pnpm -r build && pnpm --filter @mesh/conformance-tests test",
@@ -32,7 +36,8 @@
     "webapp": "pnpm --dir apps/mesh-explorer-webapp dev",
     "desktop": "pnpm --dir apps/mesh-explorer-desktop start",
     "check:lockfile-clean": "node scripts/ci/check-lockfile-clean.mjs",
-    "repair:win-rollup": "node scripts/repair-windows-rollup.mjs"
+    "repair:win-rollup": "node scripts/repair-windows-rollup.mjs",
+    "ci:check-determinism": "node tools/ci/check-determinism.mjs"
   },
   "devDependencies": {
     "typescript": "^5.6.3",

--- a/tools/ci/check-determinism.mjs
+++ b/tools/ci/check-determinism.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+const ITERATIONS = Number.parseInt(process.env.MESH_STABILITY_ITERATIONS ?? '3', 10);
+const EVIDENCE_FILES = [
+  'artifacts/conformance-evidence.runtime.json',
+  'artifacts/conformance-evidence.critical.md',
+];
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    stdio: 'inherit',
+    env: process.env,
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`Command failed (${result.status ?? 'no-status'}): ${command} ${args.join(' ')}`);
+  }
+}
+
+function hashFile(path) {
+  const content = readFileSync(path);
+  return createHash('sha256').update(content).digest('hex');
+}
+
+function collectHashes() {
+  return Object.fromEntries(
+    EVIDENCE_FILES.map((path) => {
+      if (!existsSync(path)) {
+        throw new Error(`Missing evidence file: ${path}`);
+      }
+      return [path, hashFile(path)];
+    }),
+  );
+}
+
+function deleteEvidenceFiles() {
+  for (const path of EVIDENCE_FILES) {
+    rmSync(path, { force: true });
+  }
+}
+
+if (!Number.isInteger(ITERATIONS) || ITERATIONS < 2) {
+  throw new Error(`MESH_STABILITY_ITERATIONS must be an integer >= 2 (got ${process.env.MESH_STABILITY_ITERATIONS ?? 'undefined'})`);
+}
+
+let baselineHashes;
+for (let iteration = 1; iteration <= ITERATIONS; iteration += 1) {
+  console.log(`\n[determinism] Iteration ${iteration}/${ITERATIONS}`);
+  deleteEvidenceFiles();
+
+  run('pnpm', ['-r', '--filter', '@mesh/conformance-tests...', 'test']);
+  run('pnpm', ['--filter', '@mesh/conformance-tests', 'posttest']);
+  run('pnpm', ['--filter', '@mesh/conformance-tests', 'check:critical']);
+
+  const hashes = collectHashes();
+  for (const [file, hash] of Object.entries(hashes)) {
+    console.log(`[determinism] ${file} sha256=${hash}`);
+  }
+
+  if (!baselineHashes) {
+    baselineHashes = hashes;
+    continue;
+  }
+
+  for (const path of EVIDENCE_FILES) {
+    if (hashes[path] !== baselineHashes[path]) {
+      throw new Error(
+        `Determinism check failed for ${path}: baseline=${baselineHashes[path]} current=${hashes[path]} (iteration ${iteration})`,
+      );
+    }
+  }
+}
+
+console.log(`\n[determinism] All ${ITERATIONS} iterations produced identical evidence hashes.`);


### PR DESCRIPTION
### Motivation
- Prevent false-green CI by removing variable toolchain resolution (`lts/*`) and reducing OS/locale/temp divergences that can make evidence non-deterministic.
- Detect flaky evidence by rerunning the critical conformance flow and comparing byte-level hashes of produced artifacts.

### Description
- Pin Node runtime in the Conformance workflow via a shared `NODE_VERSION: 20.11.1` and replace `lts/*` with `${{ env.NODE_VERSION }}` in both jobs.  
- Declare the toolchain truth in `package.json` by adding `"engines.node": "20.11.1"` and `"packageManager": "pnpm@9.15.4"`, and add `ci:check-determinism` script.  
- Normalize CI environment variables `TZ`, `LANG`, `LC_ALL`, and stable temp dir variables for matrix jobs and create the stable temp directory at runtime.  
- Add explicit Corepack activation (`corepack enable` + `corepack install`) and runtime logging (`node --version`, `pnpm --version`) in workflow steps.  
- Add `tools/ci/check-determinism.mjs`, a script that reruns the conformance critical flow N times (`MESH_STABILITY_ITERATIONS`, default 3), computes SHA256 of `artifacts/conformance-evidence.runtime.json` and `artifacts/conformance-evidence.critical.md`, and fails the job if any run fails or hashes diverge; wire this check into the `ubuntu-latest` + `inmemory` matrix leg while keeping single-run flow for other legs.

### Testing
- Ran `node scripts/ci/validate-conformance-workflow.mjs`, which passed and validated the workflow changes.  
- Performed a syntax/check run `node --check tools/ci/check-determinism.mjs`, which succeeded.  
- Attempt to execute `pnpm ci:validate-workflows` was blocked in this environment because Corepack failed to download the pinned `pnpm` tarball due to a network/proxy restriction, so a full `pnpm`-backed CI run was not performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a990ce17a083219b7ce22815be7c61)