### PR TITLE
fix(conformance-tests): pass Vitest reporter as file URL

### DIFF
--- a/packages/conformance-tests/scripts/generate-evidence.mjs
+++ b/packages/conformance-tests/scripts/generate-evidence.mjs
@@ -1,6 +1,6 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { execSync } from "node:child_process";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -9,7 +9,8 @@ const repoRoot = path.resolve(__dirname, "../../..");
 const testsRoot = path.resolve(repoRoot, "packages/conformance-tests/src");
 const artifactsDir = path.resolve(repoRoot, "artifacts");
 const expectedInvariantsPath = path.resolve(repoRoot, "packages/conformance-tests/expected-invariants.json");
-const evidenceReporterPath = path.resolve(repoRoot, "packages/conformance-tests/scripts/evidence-meta-reporter.mjs");
+const reporterPath = path.resolve(__dirname, "evidence-meta-reporter.mjs");
+const reporterUrl = pathToFileURL(reporterPath).href;
 const runtimeMetaPath = path.resolve(artifactsDir, "conformance-evidence.runtime.meta.json");
 
 const testPattern = /it\(\s*"([^"\n]+)"\s*,/g;
@@ -64,7 +65,7 @@ function runCommand(cmd, env = {}) {
 
 function collectRuntimeMeta(backendEnv) {
   runCommand(
-    `pnpm exec vitest run packages/conformance-tests/src --reporter ${evidenceReporterPath}`,
+    `pnpm exec vitest run packages/conformance-tests/src --reporter ${reporterUrl}`,
     { MESH_EVIDENCE_META_PATH: runtimeMetaPath, MESH_BACKEND: backendEnv, MESH_TX_VISIBILITY_POLICY: "acl" }
   );
 


### PR DESCRIPTION
### Motivation
- Ensure Vitest can load the custom reporter on Windows and Linux by passing a `file://` URL instead of a raw absolute Windows path which Vitest may treat as a module specifier.

### Description
- Updated `packages/conformance-tests/scripts/generate-evidence.mjs` to resolve the reporter relative to the script using `import.meta.url`, convert the path to a file URL with `pathToFileURL(...)`, and pass that URL to Vitest via `--reporter`.

### Testing
- Ran `node --check packages/conformance-tests/scripts/generate-evidence.mjs`, which succeeded; running `pnpm --filter @mesh/conformance-tests posttest` failed in this environment because `vitest` is not available via `pnpm exec` (environmental limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9c2b665748321a043a713f1843480)