### PR TITLE
Harden bootstrap replay cursor convergence and restart guards

### DIFF
--- a/packages/mesh-explorer-ui/src/bootstrapCursor.ts
+++ b/packages/mesh-explorer-ui/src/bootstrapCursor.ts
@@ -21,7 +21,7 @@ export type BootstrapCursorDecision = {
     | "snapshot-only-schema-version-mismatch"
     | "snapshot-only-cursor-mismatch"
     | "snapshot-only-digest-mismatch"
-    | "saved-cursor-cache-verified";
+    | "snapshot-cursor-cache-verified";
   invalidateBootstrapCache: boolean;
 };
 
@@ -47,12 +47,12 @@ export function resolveBootstrapCursorDecision(input: BootstrapCursorDecisionInp
     };
   }
 
-  if (compareCursor(normalizeCursor(input.bootstrapCache.cursor), normalizedSaved) !== 0) {
+  if (compareCursor(normalizeCursor(input.bootstrapCache.cursor), normalizedSnapshot) !== 0) {
     return {
       bootstrapFrom: normalizedSnapshot,
       usedSavedCursor: false,
       reason: "snapshot-only-cursor-mismatch",
-      invalidateBootstrapCache: false
+      invalidateBootstrapCache: true
     };
   }
 
@@ -67,9 +67,9 @@ export function resolveBootstrapCursorDecision(input: BootstrapCursorDecisionInp
   }
 
   return {
-    bootstrapFrom: normalizedSaved,
+    bootstrapFrom: normalizedSnapshot,
     usedSavedCursor: true,
-    reason: "saved-cursor-cache-verified",
+    reason: "snapshot-cursor-cache-verified",
     invalidateBootstrapCache: false
   };
 }

--- a/packages/mesh-explorer-ui/test/bootstrapConvergence.test.ts
+++ b/packages/mesh-explorer-ui/test/bootstrapConvergence.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { createGraphStore, type Cursor, type GraphEvent } from "../src/graphStore.js";
+import { hydrateStoreFromProjection, makeBootstrapCacheRecord, type BootstrapProjection } from "../src/bootstrapCache.js";
+import { nextMonotonicCursor, resolveBootstrapCursorDecision, shouldPersistBootstrapCursor } from "../src/bootstrapCursor.js";
+
+const AUTHORITY_EVENTS: GraphEvent[] = [
+  { type: "graph.node.created", node: { id: "n1", label: "A" } },
+  { type: "graph.node.created", node: { id: "n2", label: "B" } },
+  { type: "graph.link.created", link: { id: "l1", source: "n1", target: "n2", type: "depends" } }
+];
+
+function replayFrom(cursor: Cursor, store = createGraphStore()): { cursor: Cursor; state: ReturnType<typeof normalizeState> } {
+  const start = Math.max(0, cursor.graphSeq);
+  const events = AUTHORITY_EVENTS.slice(start);
+  if (events.length > 0) store.applyGraphEvents(events);
+  store.setCursor({ metaSeq: 0, graphSeq: AUTHORITY_EVENTS.length });
+  return { cursor: store.getState().cursor, state: normalizeState(store) };
+}
+
+function normalizeState(store: ReturnType<typeof createGraphStore>) {
+  const state = store.getState();
+  return {
+    nodes: Array.from(state.nodesById.values()).sort((a, b) => a.id.localeCompare(b.id)),
+    links: Array.from(state.linksById.values()).sort((a, b) => a.id.localeCompare(b.id))
+  };
+}
+
+describe("bootstrap convergence guards", () => {
+  it("multi-replica restarts with asymmetric local state converge to same cursor+state", () => {
+    const snapshotProjection: BootstrapProjection = {
+      version: 1,
+      nodes: [
+        { id: "n1", label: "A" },
+        { id: "n2", label: "B" }
+      ],
+      links: []
+    };
+    const snapshotCursor = { metaSeq: 0, graphSeq: 2 };
+
+    const replicaAStore = createGraphStore();
+    const replicaACache = makeBootstrapCacheRecord(snapshotCursor, snapshotProjection);
+    const decisionA = resolveBootstrapCursorDecision({
+      savedCursor: snapshotCursor,
+      snapshot: { cursor: snapshotCursor },
+      bootstrapCache: replicaACache
+    });
+    hydrateStoreFromProjection(replicaAStore, replicaACache.projection);
+    replicaAStore.setCursor(decisionA.bootstrapFrom);
+    const finalA = replayFrom(decisionA.bootstrapFrom, replicaAStore);
+
+    const replicaBStore = createGraphStore();
+    const staleCache = makeBootstrapCacheRecord({ metaSeq: 0, graphSeq: 1 }, { version: 1, nodes: [{ id: "n1", label: "A" }], links: [] });
+    staleCache.schemaVersion += 1;
+    const decisionB = resolveBootstrapCursorDecision({
+      savedCursor: { metaSeq: 0, graphSeq: 1 },
+      snapshot: { cursor: snapshotCursor },
+      bootstrapCache: staleCache
+    });
+    // invalid cache path falls back to snapshot-derived bootstrap.
+    hydrateStoreFromProjection(replicaBStore, snapshotProjection);
+    replicaBStore.setCursor(decisionB.bootstrapFrom);
+    const finalB = replayFrom(decisionB.bootstrapFrom, replicaBStore);
+
+    expect(finalA.cursor).toEqual(finalB.cursor);
+    expect(finalA.state).toEqual(finalB.state);
+  });
+
+  it("anchors replay start cursor to accepted snapshot cursor", () => {
+    const decision = resolveBootstrapCursorDecision({
+      savedCursor: { metaSeq: 0, graphSeq: 8 },
+      snapshot: { cursor: { metaSeq: 0, graphSeq: 2 } },
+      bootstrapCache: makeBootstrapCacheRecord(
+        { metaSeq: 0, graphSeq: 2 },
+        { version: 1, nodes: [{ id: "n1", label: "A" }], links: [] }
+      )
+    });
+
+    expect(decision.bootstrapFrom).toEqual({ metaSeq: 0, graphSeq: 2 });
+  });
+
+  it("does not finalize bootstrap cache state before replay completion", () => {
+    const fromCursor = { metaSeq: 0, graphSeq: 2 };
+    expect(shouldPersistBootstrapCursor(fromCursor, fromCursor, fromCursor)).toBe(false);
+    expect(shouldPersistBootstrapCursor(fromCursor, { metaSeq: 0, graphSeq: 3 }, { metaSeq: 0, graphSeq: 3 })).toBe(true);
+  });
+
+  it("keeps applied cursor monotonic across restart cycles", () => {
+    let durable = { metaSeq: 0, graphSeq: 3 };
+
+    const restart1Candidate = { metaSeq: 0, graphSeq: 2 };
+    durable = nextMonotonicCursor(durable, restart1Candidate);
+    expect(durable).toEqual({ metaSeq: 0, graphSeq: 3 });
+
+    const restart2Candidate = { metaSeq: 0, graphSeq: 4 };
+    durable = nextMonotonicCursor(durable, restart2Candidate);
+    expect(durable).toEqual({ metaSeq: 0, graphSeq: 4 });
+  });
+});

--- a/packages/mesh-explorer-ui/test/bootstrapCursor.test.ts
+++ b/packages/mesh-explorer-ui/test/bootstrapCursor.test.ts
@@ -19,7 +19,7 @@ describe("mesh explorer bootstrap cursor", () => {
     expect(resolveBootstrapFromCursor(null, { cursor: { metaSeq: 2, graphSeq: 8 } })).toEqual({ metaSeq: 2, graphSeq: 8 });
   });
 
-  it("CT-A1 savedCursor + valid digest => bootstrapFrom savedCursor", () => {
+  it("CT-A1 cache+snapshot verified => bootstrapFrom snapshot cursor", () => {
     const projection = {
       version: 1 as const,
       nodes: [{ id: "n1", label: "node-1" }],
@@ -32,9 +32,9 @@ describe("mesh explorer bootstrap cursor", () => {
       bootstrapCache: cache
     });
 
-    expect(decision.bootstrapFrom).toEqual({ metaSeq: 2, graphSeq: 8 });
+    expect(decision.bootstrapFrom).toEqual({ metaSeq: 0, graphSeq: 0 });
     expect(decision.usedSavedCursor).toBe(true);
-    expect(decision.reason).toBe("saved-cursor-cache-verified");
+    expect(decision.reason).toBe("snapshot-cursor-cache-verified");
   });
 
   it("CT-A2 digest mismatch => snapshot fallback", () => {
@@ -53,6 +53,24 @@ describe("mesh explorer bootstrap cursor", () => {
     expect(decision.bootstrapFrom).toEqual({ metaSeq: 1, graphSeq: 4 });
     expect(decision.usedSavedCursor).toBe(false);
     expect(decision.reason).toBe("snapshot-only-digest-mismatch");
+    expect(decision.invalidateBootstrapCache).toBe(true);
+  });
+
+  it("CT-A2b cursor mismatch => invalidate + snapshot fallback", () => {
+    const cache = makeBootstrapCacheRecord(
+      { metaSeq: 2, graphSeq: 8 },
+      { version: 1, nodes: [{ id: "n1", label: "node-1" }], links: [] }
+    );
+
+    const decision = resolveBootstrapCursorDecision({
+      savedCursor: { metaSeq: 2, graphSeq: 8 },
+      snapshot: { cursor: { metaSeq: 1, graphSeq: 4 } },
+      bootstrapCache: cache
+    });
+
+    expect(decision.bootstrapFrom).toEqual({ metaSeq: 1, graphSeq: 4 });
+    expect(decision.usedSavedCursor).toBe(false);
+    expect(decision.reason).toBe("snapshot-only-cursor-mismatch");
     expect(decision.invalidateBootstrapCache).toBe(true);
   });
 


### PR DESCRIPTION
### Motivation
- Prevent local cache/saved-cursor from becoming an authority during restart and ensure replay always anchors to the accepted snapshot cursor to avoid multi-replica divergence.
- Make cache cursor mismatches deterministic by invalidating stale cache paths so replay/fallback ordering is explicit.
- Provide small, focused tests that assert multi-replica convergence, replay anchor correctness, no early cache finalization, and cursor monotonicity across restarts.

### Description
- Updated `packages/mesh-explorer-ui/src/bootstrapCursor.ts` to anchor the replay start to the accepted snapshot cursor and to treat cache-vs-snapshot cursor mismatches as an invalidation (set `invalidateBootstrapCache: true`) while making the bootstrap-from cursor explicit via the decision return value and new reason string `snapshot-cursor-cache-verified`.
- Adjusted semantics so a verified cache still uses the snapshot-derived cursor as the explicit replay anchor (`bootstrapFrom`), eliminating saved-local-cursor authority during replay startup.
- Updated `packages/mesh-explorer-ui/test/bootstrapCursor.test.ts` to reflect snapshot-anchored semantics and added an explicit test for cursor-mismatch invalidation (`CT-A2b`).
- Added `packages/mesh-explorer-ui/test/bootstrapConvergence.test.ts` with focused convergence tests that simulate asymmetric replica restart conditions and assert final canonical cursor and normalized state equality, replay start anchoring, replay-before-finalization gating (`shouldPersistBootstrapCursor`), and monotonic restart progression.

### Testing
- Ran `pnpm --filter @mesh/mesh-explorer-ui build` which completed successfully and verified TypeScript compilation of the modified package.
- Attempted to run unit tests with `pnpm exec vitest ...` and `pnpm dlx vitest ...` but test execution was blocked in this environment due to missing workspace `vitest` binary and registry authorization errors (403), so the new/updated tests were added but not executed here.
- Commit recorded with message `Harden bootstrap replay cursor convergence guards` and changes staged/committed for `packages/mesh-explorer-ui/src/bootstrapCursor.ts`, `packages/mesh-explorer-ui/test/bootstrapCursor.test.ts`, and the new `packages/mesh-explorer-ui/test/bootstrapConvergence.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae11981bc88321be1c2fe3b22bc657)