### PR TITLE
Harden bootstrap cache writes behind replay completion

### DIFF
--- a/packages/mesh-explorer-ui/src/bootstrapCursor.ts
+++ b/packages/mesh-explorer-ui/src/bootstrapCursor.ts
@@ -88,7 +88,8 @@ export function nextMonotonicCursor(current: Cursor, candidate: Cursor): Cursor 
   return compareCursor(candidate, current) > 0 ? candidate : current;
 }
 
-export function shouldPersistBootstrapCursor(fromCursor: Cursor, finalCursor: Cursor, currentCursor: Cursor): boolean {
+export function shouldPersistBootstrapCursor(fromCursor: Cursor, finalCursor: Cursor, currentCursor: Cursor, replayComplete: boolean): boolean {
+  if (!replayComplete) return false;
   if (compareCursor(finalCursor, fromCursor) <= 0) return false;
   if (compareCursor(finalCursor, currentCursor) < 0) return false;
   return true;

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -136,6 +136,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   let lastTopologySignature = "";
   let lastCurvatureByLinkId = new Map<string, number>();
   let activeSyncSubscriptions = 0;
+  let bootstrapReplayPending = false;
 
   const uiState: CanvasUiState = {
     camera: cameraInfo,
@@ -372,6 +373,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     const snapshot = await fetchSnapshot(normalizedPrincipal);
     const snapshotCursor = snapshot.cursor;
     const bootstrapDecision = resolveBootstrapCursorDecision({ savedCursor, snapshot: { cursor: snapshotCursor }, bootstrapCache });
+    bootstrapReplayPending = true;
     if (bootstrapDecision.invalidateBootstrapCache) {
       clearBootstrapCacheRecord(bootstrapCacheKey, (key) => localStorage.removeItem(key));
     }
@@ -393,8 +395,12 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       usedSavedCursor: bootstrapDecision.usedSavedCursor
     });
     const replayResult = await pollReplayFromCursor(bootstrapCursor, sessionId, activeAbort.signal);
-    if (sessionId !== syncSession) return;
-    persistBootstrapCursor(storageKey, bootstrapCacheKey, snapshotCursor, replayResult.cursor);
+    if (sessionId !== syncSession) {
+      bootstrapReplayPending = false;
+      return;
+    }
+    bootstrapReplayPending = false;
+    persistBootstrapCursor(storageKey, bootstrapCacheKey, snapshotCursor, replayResult.cursor, !bootstrapReplayPending);
     setConnectionStatus("connected (poll-only)");
     void subscribeLoop(sessionId, activeAbort.signal);
 
@@ -461,7 +467,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
                   });
                   const replayResult = await pollReplayFromCursor(fromCursor, activeSessionId, signal);
                   if (activeSessionId !== syncSession) return;
-                  persistBootstrapCursor(storageKey, bootstrapCacheKey, fromCursor, replayResult.cursor);
+                  persistBootstrapCursor(storageKey, bootstrapCacheKey, fromCursor, replayResult.cursor, !bootstrapReplayPending);
                   continue;
                 }
 
@@ -1061,6 +1067,14 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     source: "poll" | "sse",
     graphEvents: GraphEvent[]
   ): boolean {
+    if (bootstrapReplayPending) {
+      emitMeshDebugLog("BOOTSTRAP_CACHE_WRITE_DEFERRED", {
+        source,
+        candidate,
+        reason: "replay-pending"
+      });
+      return false;
+    }
     const current = store.getState().cursor;
     if (compareCursor(candidate, current) <= 0) {
       emitMeshDebugLog("cursor-regression", { source, current, candidate });
@@ -1074,9 +1088,15 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     return true;
   }
 
-  function persistBootstrapCursor(storageKey: string, bootstrapCacheKey: string, fromCursor: Cursor, finalCursor: Cursor): void {
+  function persistBootstrapCursor(
+    storageKey: string,
+    bootstrapCacheKey: string,
+    fromCursor: Cursor,
+    finalCursor: Cursor,
+    replayComplete: boolean
+  ): void {
     const current = store.getState().cursor;
-    if (!shouldPersistBootstrapCursor(fromCursor, finalCursor, current)) return;
+    if (!shouldPersistBootstrapCursor(fromCursor, finalCursor, current, replayComplete)) return;
     store.setCursor(finalCursor);
     persistDurableBootstrapState(storageKey, bootstrapCacheKey, finalCursor, createProjectionSnapshot(store));
   }

--- a/packages/mesh-explorer-ui/test/bootstrapConvergence.test.ts
+++ b/packages/mesh-explorer-ui/test/bootstrapConvergence.test.ts
@@ -81,8 +81,11 @@ describe("bootstrap convergence guards", () => {
 
   it("does not finalize bootstrap cache state before replay completion", () => {
     const fromCursor = { metaSeq: 0, graphSeq: 2 };
-    expect(shouldPersistBootstrapCursor(fromCursor, fromCursor, fromCursor)).toBe(false);
-    expect(shouldPersistBootstrapCursor(fromCursor, { metaSeq: 0, graphSeq: 3 }, { metaSeq: 0, graphSeq: 3 })).toBe(true);
+    const convergedCursor = { metaSeq: 0, graphSeq: 3 };
+
+    expect(shouldPersistBootstrapCursor(fromCursor, fromCursor, fromCursor, true)).toBe(false);
+    expect(shouldPersistBootstrapCursor(fromCursor, convergedCursor, convergedCursor, false)).toBe(false);
+    expect(shouldPersistBootstrapCursor(fromCursor, convergedCursor, convergedCursor, true)).toBe(true);
   });
 
   it("keeps applied cursor monotonic across restart cycles", () => {

--- a/packages/mesh-explorer-ui/test/bootstrapCursor.test.ts
+++ b/packages/mesh-explorer-ui/test/bootstrapCursor.test.ts
@@ -104,10 +104,11 @@ describe("mesh explorer bootstrap cursor", () => {
     expect(nextMonotonicCursor({ metaSeq: 0, graphSeq: 4 }, { metaSeq: 0, graphSeq: 6 })).toEqual({ metaSeq: 0, graphSeq: 6 });
   });
 
-  it("persists bootstrap cursor only when it advanced and remains monotonic", () => {
-    expect(shouldPersistBootstrapCursor({ metaSeq: 0, graphSeq: 0 }, { metaSeq: 0, graphSeq: 5 }, { metaSeq: 0, graphSeq: 5 })).toBe(true);
-    expect(shouldPersistBootstrapCursor({ metaSeq: 0, graphSeq: 5 }, { metaSeq: 0, graphSeq: 5 }, { metaSeq: 0, graphSeq: 5 })).toBe(false);
-    expect(shouldPersistBootstrapCursor({ metaSeq: 0, graphSeq: 0 }, { metaSeq: 0, graphSeq: 5 }, { metaSeq: 0, graphSeq: 6 })).toBe(false);
+  it("persists bootstrap cursor only when replay converged, advanced, and remains monotonic", () => {
+    expect(shouldPersistBootstrapCursor({ metaSeq: 0, graphSeq: 0 }, { metaSeq: 0, graphSeq: 5 }, { metaSeq: 0, graphSeq: 5 }, false)).toBe(false);
+    expect(shouldPersistBootstrapCursor({ metaSeq: 0, graphSeq: 0 }, { metaSeq: 0, graphSeq: 5 }, { metaSeq: 0, graphSeq: 5 }, true)).toBe(true);
+    expect(shouldPersistBootstrapCursor({ metaSeq: 0, graphSeq: 5 }, { metaSeq: 0, graphSeq: 5 }, { metaSeq: 0, graphSeq: 5 }, true)).toBe(false);
+    expect(shouldPersistBootstrapCursor({ metaSeq: 0, graphSeq: 0 }, { metaSeq: 0, graphSeq: 5 }, { metaSeq: 0, graphSeq: 6 }, true)).toBe(false);
   });
 
   it("normalizes negative cursors to zero cursor", () => {


### PR DESCRIPTION
### Motivation

- Prevent unsafe early persistence of bootstrap cache that can occur when a snapshot is loaded and the cache is written before replay convergence.  
- Enforce an explicit phase boundary between “bootstrap loaded but replay pending” and “replay complete, cache write allowed”.  
- Preserve existing fast-path behavior while ensuring the cache is never finalized before replay reaches the admissible cursor.

### Description

- Introduce an explicit `bootstrapReplayPending` flag in the UI bootstrap flow and set it at bootstrap start and clear it only after `pollReplayFromCursor` returns for the active session.  
- Add a write-guard that defers/rejects durable cache/cursor persistence attempts while `bootstrapReplayPending` is true and emits a `BOOTSTRAP_CACHE_WRITE_DEFERRED` debug log.  
- Harden the persistence policy by extending `shouldPersistBootstrapCursor(...)` with a `replayComplete` boolean parameter that must be true before finalization is allowed.  
- Update call sites (`persistBootstrapCursor`, `applyCursorIfAdvanced`, subscribe fallback path) and tests to pass and verify the replay completion guard instead of relying on timing/implicit ordering.

Files changed (key):
- `packages/mesh-explorer-ui/src/index.ts` — add `bootstrapReplayPending` flag, guard writes, pass replay-complete state into persistence calls.  
- `packages/mesh-explorer-ui/src/bootstrapCursor.ts` — require `replayComplete` in `shouldPersistBootstrapCursor`.  
- `packages/mesh-explorer-ui/test/bootstrapConvergence.test.ts` and `packages/mesh-explorer-ui/test/bootstrapCursor.test.ts` — update assertions to cover replay-pending vs replay-complete cases.

Why this preserves invariants: the change is a narrowly scoped write barrier that does not change the authority model (EventStore remains canonical), keeps snapshots/caches non-authoritative, maintains monotone cursor progression, and only gates persistence until replay deterministically reaches the target cursor.

### Testing

- Ran a package-level build: `pnpm --filter @mesh/mesh-explorer-ui build` succeeded and the modified package compiles cleanly.  
- Updated unit test assertions were compiled as part of the package build; the tests themselves were not executed in this environment because global test tooling installation was restricted.  
- Attempted workspace build `pnpm -r build` failed in this environment due to a missing dev dependency (`vite`) in unrelated `apps/mesh-explorer-webapp`, but this did not affect the touched package which built successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aee29d60988321820ce2bb08de9982)