### PR TITLE
Implement Phase 20.4 ghost update protection in runtime sync ingestion

### DIFF
--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -8,6 +8,7 @@ import {
   type GraphStore
 } from "./graphStore.js";
 import { compareCursor, rotateAbortController } from "./syncGuards.js";
+import { applyGuardedSyncBatch, type IngestibleGraphEvent } from "./syncIngestion.js";
 import { nextMonotonicCursor, resolveBootstrapCursorDecision, shouldPersistBootstrapCursor } from "./bootstrapCursor.js";
 import { bootstrapCacheStorageKey, cursorStorageKey } from "./cursorStorage.js";
 import { buildSyncPollUrl } from "./syncPollRequest.js";
@@ -43,7 +44,7 @@ import {
 
 type Cursor = { metaSeq: number; graphSeq: number };
 type GraphData = { nodes: GraphNode[]; links: GraphLink[] };
-type SyncTxBundle = { principalCursor?: number; txBundle?: { graphEvents?: unknown[]; metaEvents?: unknown[] } };
+type SyncTxBundle = { principalCursor?: number; txBundle?: { txId?: string; graphEvents?: unknown[]; metaEvents?: unknown[] } };
 type SyncFrame =
   | { kind: "heartbeat"; cursorVisible?: number }
   | { kind: "cursor"; cursorVisible?: number }
@@ -52,7 +53,7 @@ type SyncFrame =
 
 type SyncPollPayload = {
   meta?: Array<{ payload?: unknown }>;
-  graph?: Array<{ payload?: unknown }>;
+  graph?: Array<{ eventId?: string; payload?: unknown }>;
   cursorAfter?: Cursor;
 };
 
@@ -137,6 +138,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   let lastCurvatureByLinkId = new Map<string, number>();
   let activeSyncSubscriptions = 0;
   let bootstrapReplayPending = false;
+  const syncIngestionState = { cursor: { metaSeq: 0, graphSeq: 0 }, seenEventIdsByGraphSpace: new Map<string, Set<string>>() };
 
   const uiState: CanvasUiState = {
     camera: cameraInfo,
@@ -362,6 +364,8 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
   async function connectAndSync(sessionId: number): Promise<void> {
     activeAbort = rotateAbortController(activeAbort);
     store.resetProjection();
+    syncIngestionState.cursor = { metaSeq: 0, graphSeq: 0 };
+    syncIngestionState.seenEventIdsByGraphSpace.clear();
     canvasRenderer?.clearTransientUiState();
     resetAutoFitState();
     setConnectionStatus("connecting");
@@ -385,6 +389,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     }
 
     const bootstrapCursor = bootstrapDecision.bootstrapFrom;
+    syncIngestionState.cursor = bootstrapCursor;
     emitMeshDebugLog("BOOTSTRAP_DECISION", {
       graphSpaceId: el.graphSpaceId.value,
       principal: normalizedPrincipal,
@@ -532,7 +537,13 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
           }
           const payload = (await response.json()) as SyncPollPayload;
           markNetworkConnectivity("online", "poll-success");
-          const graphEvents = (payload.graph ?? []).map((entry) => asGraphEvent(entry.payload)).filter((event): event is GraphEvent => event !== null);
+          const graphEvents = (payload.graph ?? [])
+            .map((entry) => {
+              const event = asGraphEvent(entry.payload);
+              if (!event || typeof entry.eventId !== "string" || !entry.eventId) return null;
+              return { eventId: entry.eventId, event };
+            })
+            .filter((entry): entry is IngestibleGraphEvent => entry !== null);
           const nextCursor = payload.cursorAfter ?? cursor;
           const nextMonotonic = nextMonotonicCursor(cursor, nextCursor);
           const cursorUnchanged = cursorEq(nextMonotonic, cursor);
@@ -544,10 +555,12 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
             metaEvents: payload.meta?.length ?? 0,
             cursorUnchanged
           });
-          if (!cursorUnchanged && graphEvents.length > 0) {
-            graphEventsApplied += graphEvents.length;
-            store.applyGraphEvents(graphEvents);
-            setLastSyncNow();
+          if (!cursorUnchanged) {
+            const advanced = applyCursorIfAdvanced(storageKey, bootstrapCacheKey, nextMonotonic, "poll", graphEvents);
+            if (advanced) {
+              graphEventsApplied += graphEvents.length;
+              setLastSyncNow();
+            }
           }
           cursor = nextMonotonic;
           if ((payload.meta?.length ?? 0) === 0 && (payload.graph?.length ?? 0) === 0 || cursorUnchanged) break;
@@ -1064,8 +1077,8 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     storageKey: string,
     bootstrapCacheKey: string,
     candidate: Cursor,
-    source: "poll" | "sse",
-    graphEvents: GraphEvent[]
+    source: "poll" | "sse" | "replay",
+    graphEvents: IngestibleGraphEvent[]
   ): boolean {
     if (bootstrapReplayPending) {
       emitMeshDebugLog("BOOTSTRAP_CACHE_WRITE_DEFERRED", {
@@ -1080,9 +1093,16 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       emitMeshDebugLog("cursor-regression", { source, current, candidate });
       return false;
     }
-    if (graphEvents.length > 0) {
-      store.applyGraphEvents(graphEvents);
-    }
+    const result = applyGuardedSyncBatch({
+      graphSpaceId: el.graphSpaceId.value,
+      state: syncIngestionState,
+      source,
+      candidateCursor: candidate,
+      events: graphEvents,
+      applyGraphEvents: (events) => store.applyGraphEvents(events),
+      log: (message, detail) => emitMeshDebugLog(message, detail)
+    });
+    if (!result.cursorAdvanced) return false;
     store.setCursor(candidate);
     persistDurableBootstrapState(storageKey, bootstrapCacheKey, candidate, createProjectionSnapshot(store));
     return true;
@@ -1380,16 +1400,29 @@ async function *parseSse(body: ReadableStream<Uint8Array>): AsyncIterable<SyncFr
   }
 }
 
-function extractGraphEventsFromTxBundles(txBundles: SyncTxBundle[]): GraphEvent[] {
-  const output: GraphEvent[] = [];
+function extractGraphEventsFromTxBundles(txBundles: SyncTxBundle[]): IngestibleGraphEvent[] {
+  const output: IngestibleGraphEvent[] = [];
   for (const item of txBundles) {
     const graphEvents = item.txBundle?.graphEvents ?? [];
-    for (const raw of graphEvents) {
+    const txId = item.txBundle?.txId ?? "unknown";
+    for (let index = 0; index < graphEvents.length; index += 1) {
+      const raw = graphEvents[index];
       const event = asGraphEvent(raw);
-      if (event) output.push(event);
+      if (!event) continue;
+      const eventId = resolveEventId(raw, txId, index);
+      output.push({ eventId, event });
     }
   }
   return output;
+}
+
+
+function resolveEventId(value: unknown, txId: string, index: number): string {
+  if (value && typeof value === "object" && "eventId" in value) {
+    const maybeEventId = (value as { eventId?: unknown }).eventId;
+    if (typeof maybeEventId === "string" && maybeEventId) return maybeEventId;
+  }
+  return `${txId}-graph-${index + 1}`;
 }
 
 function asGraphEvent(value: unknown): GraphEvent | null {

--- a/packages/mesh-explorer-ui/src/syncIngestion.ts
+++ b/packages/mesh-explorer-ui/src/syncIngestion.ts
@@ -1,0 +1,72 @@
+import { compareCursor } from "./syncGuards.js";
+import type { GraphEvent } from "./graphStore.js";
+
+export type Cursor = { metaSeq: number; graphSeq: number };
+
+export type IngestibleGraphEvent = { eventId: string; event: GraphEvent };
+
+export type SyncIngestionState = {
+  cursor: Cursor;
+  seenEventIdsByGraphSpace: Map<string, Set<string>>;
+};
+
+export type SyncIngestionResult = {
+  appliedCount: number;
+  duplicateCount: number;
+  cursorAdvanced: boolean;
+  nextCursor: Cursor;
+};
+
+export function applyGuardedSyncBatch(params: {
+  graphSpaceId: string;
+  state: SyncIngestionState;
+  source: "poll" | "sse" | "replay";
+  candidateCursor: Cursor;
+  events: IngestibleGraphEvent[];
+  applyGraphEvents: (events: GraphEvent[]) => void;
+  log: (message: string, detail: Record<string, unknown>) => void;
+}): SyncIngestionResult {
+  const { graphSpaceId, state, source, candidateCursor, events, applyGraphEvents, log } = params;
+  if (compareCursor(candidateCursor, state.cursor) <= 0) {
+    log("SYNC_STALE_BATCH_IGNORED", { source, graphSpaceId, current: state.cursor, candidate: candidateCursor, events: events.length });
+    return { appliedCount: 0, duplicateCount: 0, cursorAdvanced: false, nextCursor: state.cursor };
+  }
+
+  const seen = ensureGraphSpaceDedup(state.seenEventIdsByGraphSpace, graphSpaceId);
+  const uniqueEvents: GraphEvent[] = [];
+  let duplicateCount = 0;
+
+  for (const entry of events) {
+    if (seen.has(entry.eventId)) {
+      duplicateCount += 1;
+      log("SYNC_DUPLICATE_EVENT_IGNORED", { source, graphSpaceId, eventId: entry.eventId });
+      continue;
+    }
+    seen.add(entry.eventId);
+    uniqueEvents.push(entry.event);
+  }
+
+  if (uniqueEvents.length > 0) {
+    applyGraphEvents(uniqueEvents);
+    log("SYNC_EVENTS_APPLIED", { source, graphSpaceId, appliedCount: uniqueEvents.length, duplicateCount });
+  }
+
+  const previousCursor = state.cursor;
+  state.cursor = candidateCursor;
+  log("SYNC_CURSOR_ADVANCED", { source, graphSpaceId, previousCursor, nextCursor: candidateCursor });
+
+  return {
+    appliedCount: uniqueEvents.length,
+    duplicateCount,
+    cursorAdvanced: true,
+    nextCursor: candidateCursor
+  };
+}
+
+export function ensureGraphSpaceDedup(map: Map<string, Set<string>>, graphSpaceId: string): Set<string> {
+  const existing = map.get(graphSpaceId);
+  if (existing) return existing;
+  const created = new Set<string>();
+  map.set(graphSpaceId, created);
+  return created;
+}

--- a/packages/mesh-explorer-ui/test/syncIngestion.test.ts
+++ b/packages/mesh-explorer-ui/test/syncIngestion.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import type { GraphEvent } from "../src/graphStore.js";
+import { applyGuardedSyncBatch, type SyncIngestionState } from "../src/syncIngestion.js";
+
+function nodeCreated(id: string): GraphEvent {
+  return { type: "graph.node.created", node: { id, label: id } };
+}
+
+describe("sync ingestion dedup across transports", () => {
+  it("duplicate delivered by subscribe then poll applies once", () => {
+    const applied: GraphEvent[] = [];
+    const state: SyncIngestionState = { cursor: { metaSeq: 0, graphSeq: 0 }, seenEventIdsByGraphSpace: new Map() };
+
+    const sse = applyGuardedSyncBatch({
+      graphSpaceId: "space-a",
+      state,
+      source: "sse",
+      candidateCursor: { metaSeq: 0, graphSeq: 1 },
+      events: [{ eventId: "e-1", event: nodeCreated("n1") }],
+      applyGraphEvents: (events) => applied.push(...events),
+      log: () => undefined
+    });
+
+    const poll = applyGuardedSyncBatch({
+      graphSpaceId: "space-a",
+      state,
+      source: "poll",
+      candidateCursor: { metaSeq: 0, graphSeq: 2 },
+      events: [{ eventId: "e-1", event: nodeCreated("n1") }],
+      applyGraphEvents: (events) => applied.push(...events),
+      log: () => undefined
+    });
+
+    expect(sse.appliedCount).toBe(1);
+    expect(poll.appliedCount).toBe(0);
+    expect(poll.duplicateCount).toBe(1);
+    expect(applied).toHaveLength(1);
+    expect(state.cursor.graphSeq).toBe(2);
+  });
+
+  it("overlapping poll/subscribe batches converge to deterministic state", () => {
+    const run = (order: Array<"poll" | "sse">): string[] => {
+      const state: SyncIngestionState = { cursor: { metaSeq: 0, graphSeq: 0 }, seenEventIdsByGraphSpace: new Map() };
+      const applied: string[] = [];
+      for (const source of order) {
+        const events = source === "poll"
+          ? [
+              { eventId: "e-1", event: nodeCreated("n1") },
+              { eventId: "e-2", event: nodeCreated("n2") }
+            ]
+          : [
+              { eventId: "e-1", event: nodeCreated("n1") },
+              { eventId: "e-2", event: nodeCreated("n2") },
+              { eventId: "e-3", event: nodeCreated("n3") }
+            ];
+        const candidateCursor = source === "poll" ? { metaSeq: 0, graphSeq: 2 } : { metaSeq: 0, graphSeq: 3 };
+        applyGuardedSyncBatch({
+          graphSpaceId: "space-a",
+          state,
+          source,
+          candidateCursor,
+          events,
+          applyGraphEvents: (batch) => {
+            for (const event of batch) {
+              if (event.type === "graph.node.created") applied.push(event.node.id);
+            }
+          },
+          log: () => undefined
+        });
+      }
+      return applied.sort();
+    };
+
+    expect(run(["poll", "sse"])).toEqual(run(["sse", "poll"]));
+  });
+
+  it("replay after already applied events produces no ghost update and cursor monotone", () => {
+    const state: SyncIngestionState = { cursor: { metaSeq: 0, graphSeq: 0 }, seenEventIdsByGraphSpace: new Map() };
+    const applied: GraphEvent[] = [];
+
+    applyGuardedSyncBatch({
+      graphSpaceId: "space-a",
+      state,
+      source: "poll",
+      candidateCursor: { metaSeq: 0, graphSeq: 2 },
+      events: [
+        { eventId: "e-1", event: nodeCreated("n1") },
+        { eventId: "e-2", event: nodeCreated("n2") }
+      ],
+      applyGraphEvents: (events) => applied.push(...events),
+      log: () => undefined
+    });
+
+    const replay = applyGuardedSyncBatch({
+      graphSpaceId: "space-a",
+      state,
+      source: "replay",
+      candidateCursor: { metaSeq: 0, graphSeq: 3 },
+      events: [
+        { eventId: "e-1", event: nodeCreated("n1") },
+        { eventId: "e-2", event: nodeCreated("n2") }
+      ],
+      applyGraphEvents: (events) => applied.push(...events),
+      log: () => undefined
+    });
+
+    expect(replay.appliedCount).toBe(0);
+    expect(replay.duplicateCount).toBe(2);
+    expect(state.cursor.graphSeq).toBe(3);
+    expect(applied).toHaveLength(2);
+  });
+
+  it("mixed poll/subscribe/replay permutations converge to identical normalized state", () => {
+    const permutations: Array<Array<"poll" | "sse" | "replay">> = [
+      ["poll", "sse", "replay"],
+      ["sse", "replay", "poll"],
+      ["replay", "poll", "sse"]
+    ];
+
+    const snapshots = permutations.map((order) => {
+      const state: SyncIngestionState = { cursor: { metaSeq: 0, graphSeq: 0 }, seenEventIdsByGraphSpace: new Map() };
+      const nodes = new Set<string>();
+      for (const source of order) {
+        const candidateCursor = source === "poll" ? { metaSeq: 0, graphSeq: 1 } : source === "sse" ? { metaSeq: 0, graphSeq: 2 } : { metaSeq: 0, graphSeq: 3 };
+        const events = [
+          { eventId: "e-1", event: nodeCreated("n1") },
+          { eventId: "e-2", event: nodeCreated("n2") }
+        ];
+        applyGuardedSyncBatch({
+          graphSpaceId: "space-a",
+          state,
+          source,
+          candidateCursor,
+          events,
+          applyGraphEvents: (batch) => {
+            for (const event of batch) {
+              if (event.type === "graph.node.created") nodes.add(event.node.id);
+            }
+          },
+          log: () => undefined
+        });
+      }
+      return JSON.stringify({ cursor: state.cursor, nodes: [...nodes].sort() });
+    });
+
+    expect(new Set(snapshots).size).toBe(1);
+  });
+});


### PR DESCRIPTION
### Motivation

- Prevent duplicate (ghost) state transitions when the same canonical event is delivered over mixed transport paths (poll / subscribe / pull/replay). 
- Enforce identity deduplication by canonical `eventId` scoped per `graphSpaceId` and ensure idempotent projection application and deterministic final state. 
- Keep cursor progression monotone and centralize deduplication in the shared runtime ingestion/apply path so all transports converge to the same final state.

### Description

- Added a new shared ingestion guard `applyGuardedSyncBatch` in `packages/mesh-explorer-ui/src/syncIngestion.ts` that rejects stale/regressive batches, deduplicates incoming events by `eventId` scoped to `graphSpaceId`, and emits debug logs for stale batches, duplicate drops, applied events, and cursor advances. 
- Routed poll/subscribe/replay ingestion through the same guarded apply routine by updating `applyCursorIfAdvanced`, `poll` handling and subscribe tx-bundle extraction in `packages/mesh-explorer-ui/src/index.ts`, so all sources use the centralized dedup/apply path. 
- Preserved canonical `eventId` when present in poll payloads and derived a stable fallback `eventId` from `txId` + index for subscribe/pull tx-bundle graph events via `extractGraphEventsFromTxBundles` and `resolveEventId`. 
- Introduced in-memory `syncIngestionState` (cursor + `seenEventIdsByGraphSpace`) and reset/seed it at connection/bootstrap boundaries to maintain monotone cursor progression for the session. 
- Added targeted unit tests in `packages/mesh-explorer-ui/test/syncIngestion.test.ts` that exercise duplicate subscribe→poll delivery, overlapping poll/subscribe convergence, replay no-ghost updates, mixed permutations, and cursor monotonicity.

### Testing

- Ran unit tests with `pnpm vitest run packages/mesh-explorer-ui/test/syncIngestion.test.ts`, which passed. 
- Executed extended test runs `pnpm vitest run packages/mesh-explorer-ui/test/syncIngestion.test.ts packages/mesh-explorer-ui/test/syncConvergenceGuard.test.ts packages/mesh-explorer-ui/test/meshDebugLog.test.ts`, all of which passed. 
- Built the UI package with `pnpm --filter @mesh/mesh-explorer-ui build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af33840f308321a1ef76d64f6045ed)