### PR TITLE
Add local transport proxy for runtime subscribe-fault injection (pass/fail/hang/close)

### DIFF
--- a/docs/HOW_TO_transport_proxy.md
+++ b/docs/HOW_TO_transport_proxy.md
@@ -1,0 +1,44 @@
+# Mesh Transport Proxy — Quick How-To
+
+## Purpose
+Local dev/test proxy for deterministic `sync:subscribe` transport failures (`pass`, `fail`, `hang`, `close`) without changing canonical backend logic.
+
+## Start
+```bash
+pnpm dev:transport-proxy
+```
+
+Defaults:
+- Proxy: `http://127.0.0.1:8091`
+- Upstream: `http://127.0.0.1:8090`
+
+Optional env:
+```bash
+MESH_TRANSPORT_PROXY_HOST=127.0.0.1 \
+MESH_TRANSPORT_PROXY_PORT=8091 \
+MESH_TRANSPORT_PROXY_UPSTREAM=http://127.0.0.1:8090 \
+MESH_TRANSPORT_PROXY_CLOSE_DELAY_MS=200 \
+pnpm dev:transport-proxy
+```
+
+## Check current mode
+```bash
+curl http://127.0.0.1:8091/__test/transport/state
+```
+
+## Change fault mode
+```bash
+curl -X POST http://127.0.0.1:8091/__test/transport/mode \
+  -H 'content-type: application/json' \
+  -d '{"subscribeMode":"hang"}'
+```
+
+Modes:
+- `pass`
+- `fail`
+- `hang`
+- `close`
+
+## Two-tab test
+- Tab A: backend direct (`http://127.0.0.1:8090`)
+- Tab B: backend through proxy (`http://127.0.0.1:8091`)

--- a/docs/validation/transport-proxy-manual-checklist.md
+++ b/docs/validation/transport-proxy-manual-checklist.md
@@ -1,0 +1,38 @@
+# Transport Proxy Manual Validation Checklist
+
+1. Start canonical backend on `127.0.0.1:8090`.
+2. Start proxy on `127.0.0.1:8091` (`pnpm dev:transport-proxy`).
+3. Open Tab A against `:8090`, Tab B against `:8091`.
+4. Confirm `curl http://127.0.0.1:8091/__test/transport/state` reports `subscribeMode: "pass"`.
+
+## Pass mode
+1. Keep mode as `pass`.
+2. Trigger mutation in Tab A.
+3. Verify Tab B gets normal subscribe updates.
+4. Check proxy logs for intercepted subscribe pass-through.
+
+## Fail mode
+1. `POST /__test/transport/mode` with `{"subscribeMode":"fail"}`.
+2. Reconnect subscribe from Tab B.
+3. Verify deterministic non-2xx response.
+4. Verify non-subscribe routes still work via proxy.
+
+## Hang mode
+1. Set mode to `hang`.
+2. Trigger subscribe from Tab B.
+3. Verify request stays pending and no events delivered.
+4. Trigger mutation in Tab A; verify no pushed update in Tab B.
+5. Verify non-subscribe routes still work.
+
+## Close mode
+1. Set mode to `close`.
+2. Trigger subscribe from Tab B.
+3. Verify stream starts then terminates deterministically.
+4. Trigger mutation in Tab A and verify no continued push on closed stream.
+
+## Toggle without restart + edge cases
+1. Change `hang -> pass` without restarting proxy; confirm state endpoint changes immediately.
+2. Reconnect subscribe and verify normal behavior in `pass` mode.
+3. Set same mode twice and verify idempotent success.
+4. Submit unsupported mode and verify stable `INVALID_SUBSCRIBE_MODE` error.
+5. Confirm Tab A direct backend behavior is unaffected by proxy modes.

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "desktop": "pnpm --dir apps/mesh-explorer-desktop start",
     "check:lockfile-clean": "node scripts/ci/check-lockfile-clean.mjs",
     "repair:win-rollup": "node scripts/repair-windows-rollup.mjs",
-    "ci:check-determinism": "node tools/ci/check-determinism.mjs"
+    "ci:check-determinism": "node tools/ci/check-determinism.mjs",
+    "dev:transport-proxy": "node tools/mesh-transport-proxy/src/index.mjs",
+    "test:transport-proxy": "vitest run tools/mesh-transport-proxy/src/proxy.test.mjs"
   },
   "devDependencies": {
     "typescript": "^5.6.3",

--- a/tools/mesh-transport-proxy/README.md
+++ b/tools/mesh-transport-proxy/README.md
@@ -1,0 +1,15 @@
+# Mesh Transport Proxy (dev/test only)
+
+Standalone local proxy that forwards traffic to canonical backend while allowing runtime fault injection for `GET /v1/{graphSpaceId}/sync:subscribe`.
+
+- Default host/port: `127.0.0.1:8091`
+- Default upstream: `http://127.0.0.1:8090`
+- Control endpoints:
+  - `GET /__test/transport/state`
+  - `POST /__test/transport/mode`
+
+Fault modes:
+- `pass`: transparent proxy
+- `fail`: deterministic `503` JSON failure for subscribe
+- `hang`: keep subscribe request open without upstream stream
+- `close`: proxy subscribe, then close stream after `MESH_TRANSPORT_PROXY_CLOSE_DELAY_MS` (default `200`)

--- a/tools/mesh-transport-proxy/src/index.mjs
+++ b/tools/mesh-transport-proxy/src/index.mjs
@@ -1,0 +1,28 @@
+import { MeshTransportProxy } from "./proxy.mjs";
+
+const host = process.env.MESH_TRANSPORT_PROXY_HOST ?? "127.0.0.1";
+const port = Number(process.env.MESH_TRANSPORT_PROXY_PORT ?? "8091");
+const upstreamBaseUrl = process.env.MESH_TRANSPORT_PROXY_UPSTREAM ?? "http://127.0.0.1:8090";
+const closeDelayMs = Number(process.env.MESH_TRANSPORT_PROXY_CLOSE_DELAY_MS ?? "200");
+
+const proxy = new MeshTransportProxy({
+  host,
+  port,
+  upstreamBaseUrl,
+  closeDelayMs
+});
+
+const shutdown = async (signal) => {
+  console.info(`[transport-proxy] received ${signal}, shutting down`);
+  await proxy.close();
+  process.exit(0);
+};
+
+process.on("SIGINT", () => {
+  void shutdown("SIGINT");
+});
+process.on("SIGTERM", () => {
+  void shutdown("SIGTERM");
+});
+
+void proxy.listen();

--- a/tools/mesh-transport-proxy/src/proxy.mjs
+++ b/tools/mesh-transport-proxy/src/proxy.mjs
@@ -1,0 +1,259 @@
+import http from "node:http";
+
+export const SUBSCRIBE_MODES = ["pass", "fail", "hang", "close"];
+
+const SUBSCRIBE_ROUTE_PATTERN = /^\/v1\/[^/]+\/sync:subscribe$/;
+
+export function isSubscribeRequest(req) {
+  if (req.method !== "GET" || !req.url) {
+    return false;
+  }
+
+  const parsedUrl = new URL(req.url, "http://localhost");
+  return SUBSCRIBE_ROUTE_PATTERN.test(parsedUrl.pathname);
+}
+
+export function isSubscribeMode(value) {
+  return typeof value === "string" && SUBSCRIBE_MODES.includes(value);
+}
+
+export class MeshTransportProxy {
+  constructor(options) {
+    this.options = options;
+    this.logger = options.logger ?? console;
+    this.subscribeMode = "pass";
+    this.activeSubscribeStreams = new Set();
+
+    this.server = http.createServer((req, res) => {
+      void this.handleRequest(req, res);
+    });
+  }
+
+  async listen() {
+    await new Promise((resolve, reject) => {
+      this.server.once("error", reject);
+      this.server.listen(this.options.port, this.options.host, () => {
+        this.server.removeListener("error", reject);
+        resolve();
+      });
+    });
+
+    this.logger.info(
+      `[transport-proxy] listening on http://${this.options.host}:${this.address().port} -> ${this.options.upstreamBaseUrl}`
+    );
+  }
+
+  address() {
+    return this.server.address();
+  }
+
+  async close() {
+    for (const stream of this.activeSubscribeStreams) {
+      this.closeStream(stream);
+    }
+
+    await new Promise((resolve, reject) => {
+      this.server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+
+  getState() {
+    return {
+      ok: true,
+      subscribeMode: this.subscribeMode,
+      upstreamBaseUrl: this.options.upstreamBaseUrl
+    };
+  }
+
+  setMode(nextMode) {
+    if (this.subscribeMode === nextMode) {
+      this.logger.info(`[transport-proxy] mode unchanged=${nextMode}`);
+      return { ok: true, subscribeMode: this.subscribeMode };
+    }
+
+    const previousMode = this.subscribeMode;
+    this.subscribeMode = nextMode;
+    this.logger.info(`[transport-proxy] mode ${previousMode} -> ${nextMode}`);
+
+    if (nextMode === "close") {
+      for (const stream of this.activeSubscribeStreams) {
+        if (stream.clientResponse.writableEnded || stream.clientResponse.destroyed) {
+          continue;
+        }
+        stream.closeTimer = setTimeout(() => this.closeStream(stream), this.options.closeDelayMs);
+      }
+    }
+
+    return { ok: true, subscribeMode: this.subscribeMode };
+  }
+
+  async handleRequest(req, res) {
+    if (req.url === "/__test/transport/state" && req.method === "GET") {
+      this.sendJson(res, 200, this.getState());
+      return;
+    }
+
+    if (req.url === "/__test/transport/mode" && req.method === "POST") {
+      await this.handleSetMode(req, res);
+      return;
+    }
+
+    if (isSubscribeRequest(req)) {
+      this.logger.info(`[transport-proxy] subscribe request mode=${this.subscribeMode} url=${req.url}`);
+      await this.handleSubscribeRequest(req, res);
+      return;
+    }
+
+    this.forwardRequest(req, res);
+  }
+
+  async handleSetMode(req, res) {
+    const body = await this.readJsonBody(req);
+
+    if (!isSubscribeMode(body?.subscribeMode)) {
+      this.sendJson(res, 400, {
+        ok: false,
+        error: {
+          code: "INVALID_SUBSCRIBE_MODE",
+          message: "subscribeMode must be one of: pass, fail, hang, close"
+        }
+      });
+      return;
+    }
+
+    this.sendJson(res, 200, this.setMode(body.subscribeMode));
+  }
+
+  async handleSubscribeRequest(req, res) {
+    switch (this.subscribeMode) {
+      case "pass": {
+        this.forwardRequest(req, res, { trackSubscribeStream: true });
+        return;
+      }
+      case "fail": {
+        this.sendJson(res, 503, {
+          ok: false,
+          error: {
+            code: "SUBSCRIBE_TRANSPORT_FAULT",
+            mode: "fail",
+            message: "sync:subscribe blocked by transport proxy"
+          }
+        });
+        return;
+      }
+      case "hang": {
+        res.writeHead(200, {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+          connection: "keep-alive"
+        });
+
+        const stream = { clientResponse: res };
+        this.activeSubscribeStreams.add(stream);
+        req.on("close", () => {
+          this.activeSubscribeStreams.delete(stream);
+        });
+        res.on("close", () => {
+          this.activeSubscribeStreams.delete(stream);
+        });
+        return;
+      }
+      case "close": {
+        this.forwardRequest(req, res, { trackSubscribeStream: true, forceClose: true });
+      }
+    }
+  }
+
+  forwardRequest(req, res, options) {
+    const upstreamUrl = new URL(req.url ?? "/", this.options.upstreamBaseUrl);
+    const upstreamReq = http.request(upstreamUrl, {
+      method: req.method,
+      headers: req.headers
+    });
+
+    let activeStream;
+    if (options?.trackSubscribeStream) {
+      activeStream = { clientResponse: res, upstreamRequest: upstreamReq };
+      this.activeSubscribeStreams.add(activeStream);
+      res.on("close", () => {
+        this.activeSubscribeStreams.delete(activeStream);
+      });
+    }
+
+    upstreamReq.on("response", (upstreamRes) => {
+      res.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers);
+      upstreamRes.pipe(res);
+
+      if (activeStream) {
+        activeStream.upstreamResponse = upstreamRes;
+        if (options?.forceClose) {
+          activeStream.closeTimer = setTimeout(() => this.closeStream(activeStream), this.options.closeDelayMs);
+        }
+      }
+    });
+
+    upstreamReq.on("error", (error) => {
+      this.logger.error(`[transport-proxy] upstream error: ${error.message}`);
+      if (!res.headersSent) {
+        this.sendJson(res, 502, {
+          ok: false,
+          error: {
+            code: "UPSTREAM_PROXY_ERROR",
+            message: "Unable to reach upstream backend"
+          }
+        });
+        return;
+      }
+      res.destroy(error);
+    });
+
+    req.on("aborted", () => {
+      upstreamReq.destroy();
+    });
+
+    req.pipe(upstreamReq);
+  }
+
+  closeStream(stream) {
+    if (stream.closeTimer) {
+      clearTimeout(stream.closeTimer);
+    }
+
+    stream.upstreamResponse?.destroy();
+    stream.upstreamRequest?.destroy();
+    stream.clientResponse.destroy();
+    this.activeSubscribeStreams.delete(stream);
+  }
+
+  async readJsonBody(req) {
+    const chunks = [];
+    for await (const chunk of req) {
+      chunks.push(chunk);
+    }
+
+    if (chunks.length === 0) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+    } catch {
+      return null;
+    }
+  }
+
+  sendJson(res, statusCode, payload) {
+    const body = JSON.stringify(payload);
+    res.writeHead(statusCode, {
+      "content-type": "application/json; charset=utf-8",
+      "content-length": Buffer.byteLength(body)
+    });
+    res.end(body);
+  }
+}

--- a/tools/mesh-transport-proxy/src/proxy.test.mjs
+++ b/tools/mesh-transport-proxy/src/proxy.test.mjs
@@ -1,0 +1,151 @@
+import http from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { MeshTransportProxy, isSubscribeRequest } from "./proxy.mjs";
+
+const closeables = [];
+
+afterEach(async () => {
+  while (closeables.length > 0) {
+    const closeable = closeables.pop();
+    if (closeable) {
+      await closeable.close();
+    }
+  }
+});
+
+function createUpstreamServer() {
+  const server = http.createServer((req, res) => {
+    if (req.url?.startsWith("/v1/test/sync:subscribe")) {
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      res.write("data: ok\n\n");
+      return;
+    }
+
+    if (req.url === "/health") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+      return;
+    }
+
+    res.writeHead(404);
+    res.end();
+  });
+
+  return new Promise((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve({
+        baseUrl: `http://127.0.0.1:${server.address().port}`,
+        close: async () => {
+          await new Promise((resolveClose, rejectClose) => {
+            server.close((error) => {
+              if (error) {
+                rejectClose(error);
+                return;
+              }
+              resolveClose();
+            });
+          });
+        }
+      });
+    });
+    server.once("error", reject);
+  });
+}
+
+async function createProxy(upstreamBaseUrl) {
+  const proxy = new MeshTransportProxy({
+    host: "127.0.0.1",
+    port: 0,
+    upstreamBaseUrl,
+    closeDelayMs: 20,
+    logger: { info: () => undefined, warn: () => undefined, error: () => undefined }
+  });
+
+  await proxy.listen();
+  return {
+    baseUrl: `http://127.0.0.1:${proxy.address().port}`,
+    proxy
+  };
+}
+
+describe("isSubscribeRequest", () => {
+  it("matches only GET /v1/{graphSpaceId}/sync:subscribe", () => {
+    expect(isSubscribeRequest({ method: "GET", url: "/v1/a/sync:subscribe?cursor=1" })).toBe(true);
+    expect(isSubscribeRequest({ method: "POST", url: "/v1/a/sync:subscribe" })).toBe(false);
+    expect(isSubscribeRequest({ method: "GET", url: "/v1/a/sync:poll" })).toBe(false);
+  });
+});
+
+describe("MeshTransportProxy control + routing", () => {
+  it("returns stable state shape and validates mode input", async () => {
+    const upstream = await createUpstreamServer();
+    closeables.push(upstream);
+    const { baseUrl, proxy } = await createProxy(upstream.baseUrl);
+    closeables.push(proxy);
+
+    const stateResponse = await fetch(`${baseUrl}/__test/transport/state`);
+    expect(stateResponse.status).toBe(200);
+    await expect(stateResponse.json()).resolves.toEqual({
+      ok: true,
+      subscribeMode: "pass",
+      upstreamBaseUrl: upstream.baseUrl
+    });
+
+    const invalidResponse = await fetch(`${baseUrl}/__test/transport/mode`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ subscribeMode: "bogus" })
+    });
+
+    expect(invalidResponse.status).toBe(400);
+    await expect(invalidResponse.json()).resolves.toMatchObject({
+      ok: false,
+      error: { code: "INVALID_SUBSCRIBE_MODE" }
+    });
+  });
+
+  it("keeps non-target routes as pass-through across mode changes", async () => {
+    const upstream = await createUpstreamServer();
+    closeables.push(upstream);
+    const { baseUrl, proxy } = await createProxy(upstream.baseUrl);
+    closeables.push(proxy);
+
+    for (const subscribeMode of ["pass", "hang", "fail", "close"]) {
+      await fetch(`${baseUrl}/__test/transport/mode`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ subscribeMode })
+      });
+
+      const response = await fetch(`${baseUrl}/health`);
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ ok: true });
+    }
+  });
+
+  it("applies runtime mode updates without restart", async () => {
+    const upstream = await createUpstreamServer();
+    closeables.push(upstream);
+    const { baseUrl, proxy } = await createProxy(upstream.baseUrl);
+    closeables.push(proxy);
+
+    await fetch(`${baseUrl}/__test/transport/mode`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ subscribeMode: "fail" })
+    });
+
+    const failSubscribe = await fetch(`${baseUrl}/v1/test/sync:subscribe`);
+    expect(failSubscribe.status).toBe(503);
+
+    await fetch(`${baseUrl}/__test/transport/mode`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ subscribeMode: "pass" })
+    });
+
+    const passSubscribe = await fetch(`${baseUrl}/v1/test/sync:subscribe`);
+    expect(passSubscribe.status).toBe(200);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a local dev/test-only proxy to simulate deterministic transport faults for `GET /v1/{graphSpaceId}/sync:subscribe` without changing canonical backend logic.
- Enable runtime toggling of fault modes so testers can switch behavior without restarting the proxy and observe transport-layer effects.
- Keep fault-injection strictly in tooling (no production runtime code changes) and ensure non-target routes remain transparent.

### Description
- Added a standalone proxy under `tools/mesh-transport-proxy/` that forwards all traffic to an upstream and only intercepts subscribe requests; files added: `tools/mesh-transport-proxy/src/proxy.mjs`, `tools/mesh-transport-proxy/src/index.mjs`, `tools/mesh-transport-proxy/src/proxy.test.mjs`, and `tools/mesh-transport-proxy/README.md`.
- Exposed local control endpoints `GET /__test/transport/state` (atomic status) and `POST /__test/transport/mode` (atomic mode change) and added a short how-to `docs/HOW_TO_transport_proxy.md` and manual checklist `docs/validation/transport-proxy-manual-checklist.md`.
- Route matching is pathname-based using the regex `^/v1/[^/]+/sync:subscribe$` plus `GET` method, so matching is robust to query/cursor parameters while avoiding brittle full-URL checks.
- Implemented the required modes: `pass` (transparent proxy), `fail` (deterministic `503` JSON), `hang` (accept then keep connection open without upstream stream), and `close` (proxy then close the stream after a configurable delay via `MESH_TRANSPORT_PROXY_CLOSE_DELAY_MS`).
- Added root convenience scripts in `package.json`: `dev:transport-proxy` to run the proxy and `test:transport-proxy` to run the focused tests.

### Testing
- Ran unit/integration-style tests with `pnpm test:transport-proxy`, which executed `tools/mesh-transport-proxy/src/proxy.test.mjs` and passed (4 tests passed).
- Launched the proxy locally with `pnpm dev:transport-proxy` and validated the state endpoint via `curl http://127.0.0.1:8091/__test/transport/state`, which returned `{"ok":true,"subscribeMode":"pass","upstreamBaseUrl":"http://127.0.0.1:8090"}`.
- Tests cover `isSubscribeRequest` matching, control endpoint shapes and validation, non-target pass-through across modes, and runtime toggling (mode change applied without restart).

Known limitation: `close` is implemented as a deterministic delay-based close (configurable via `MESH_TRANSPORT_PROXY_CLOSE_DELAY_MS`, default `200ms`), so the exact close timing depends on local scheduling and response-open timing; this is documented in the README/HOW-TO.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af4a5de8048321bde7827675aced05)