### PR TITLE
Make web proxy dev setup portable via Vite modes and add dev:lab orchestration

### DIFF
--- a/apps/mesh-explorer-webapp/package.json
+++ b/apps/mesh-explorer-webapp/package.json
@@ -8,8 +8,8 @@
     "dev": "pnpm dev:normal",
     "build": "vite build",
     "preview": "vite preview",
-    "dev:normal": "vite --host 127.0.0.1 --port 5173 --strictPort",
-    "dev:proxy": "MESH_SUBSCRIBE_BASE_URL=http://127.0.0.1:8091 vite --host 127.0.0.1 --port 5174 --strictPort"
+    "dev:normal": "vite --mode development",
+    "dev:proxy": "vite --mode proxy"
   },
   "dependencies": {
     "@mesh/mesh-explorer-ui": "workspace:*"

--- a/apps/mesh-explorer-webapp/src/main.ts
+++ b/apps/mesh-explorer-webapp/src/main.ts
@@ -2,4 +2,13 @@ import { mountMeshExplorerUi } from "@mesh/mesh-explorer-ui";
 
 const root = document.querySelector("#app");
 if (!root) throw new Error("Missing #app");
+
+if (import.meta.env.DEV) {
+  console.info("[mesh-explorer-webapp] dev routing", {
+    mode: import.meta.env.MODE,
+    apiBaseUrl: import.meta.env.MESH_API_BASE_URL,
+    subscribeBaseUrl: import.meta.env.MESH_SUBSCRIBE_BASE_URL
+  });
+}
+
 mountMeshExplorerUi(root as HTMLElement);

--- a/apps/mesh-explorer-webapp/vite.config.ts
+++ b/apps/mesh-explorer-webapp/vite.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, loadEnv } from "vite";
+
+const DEFAULT_API_BASE_URL = "http://127.0.0.1:8090";
+const DEFAULT_SUBSCRIBE_BASE_URL = "http://127.0.0.1:8090";
+const PROXY_SUBSCRIBE_BASE_URL = "http://127.0.0.1:8091";
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "MESH_");
+  const isProxyMode = mode === "proxy";
+  const apiBaseUrl = env.MESH_API_BASE_URL || DEFAULT_API_BASE_URL;
+  const subscribeBaseUrl = env.MESH_SUBSCRIBE_BASE_URL || (isProxyMode ? PROXY_SUBSCRIBE_BASE_URL : DEFAULT_SUBSCRIBE_BASE_URL);
+
+  return {
+    envPrefix: ["VITE_", "MESH_"],
+    server: {
+      host: "127.0.0.1",
+      port: isProxyMode ? 5174 : 5173,
+      strictPort: true
+    },
+    define: {
+      "import.meta.env.MESH_API_BASE_URL": JSON.stringify(apiBaseUrl),
+      "import.meta.env.MESH_SUBSCRIBE_BASE_URL": JSON.stringify(subscribeBaseUrl)
+    }
+  };
+});

--- a/docs/HOW_TO_transport_proxy.md
+++ b/docs/HOW_TO_transport_proxy.md
@@ -4,6 +4,12 @@
 Local dev/test proxy for deterministic `sync:subscribe` transport failures (`pass`, `fail`, `hang`, `close`) without changing canonical backend logic.
 
 ## Start services
+One-command lab startup:
+```bash
+pnpm dev:lab
+```
+
+Or run each process separately:
 ```bash
 pnpm graph-server
 pnpm dev:transport-proxy
@@ -14,8 +20,13 @@ pnpm dev:web:proxy
 Defaults:
 - Backend: `http://127.0.0.1:8090`
 - Proxy: `http://127.0.0.1:8091` (upstream `:8090`)
-- Web app normal dev: `http://127.0.0.1:5173`
-- Web app proxy dev: `http://127.0.0.1:5174`
+- Web app normal dev (`vite --mode development`): `http://127.0.0.1:5173`
+- Web app proxy dev (`vite --mode proxy`): `http://127.0.0.1:5174`
+
+Webapp mode/env mapping (`apps/mesh-explorer-webapp/vite.config.ts`):
+- `development` mode defaults: `MESH_API_BASE_URL=http://127.0.0.1:8090`, `MESH_SUBSCRIBE_BASE_URL=http://127.0.0.1:8090`
+- `proxy` mode defaults: `MESH_API_BASE_URL=http://127.0.0.1:8090`, `MESH_SUBSCRIBE_BASE_URL=http://127.0.0.1:8091`
+- Optional overrides: `MESH_API_BASE_URL` and `MESH_SUBSCRIBE_BASE_URL` environment variables
 
 Optional proxy env:
 ```bash
@@ -29,6 +40,13 @@ pnpm dev:transport-proxy
 ## Two-tab workflow
 - Tab A: `http://127.0.0.1:5173` (API/poll/subscribe direct to `:8090`)
 - Tab B: `http://127.0.0.1:5174` (API/poll direct to `:8090`, subscribe via proxy `:8091`)
+
+## Dev routing visibility signal
+In dev mode, the web app prints startup routing config in browser console:
+- `[mesh-explorer-webapp] dev routing`
+- Includes `mode`, `apiBaseUrl`, and `subscribeBaseUrl`
+
+Use this to confirm whether a tab is normal or proxy-backed.
 
 ## Browser control UI (dev/test only)
 Open:

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "dev:transport-proxy": "node tools/mesh-transport-proxy/src/index.mjs",
     "test:transport-proxy": "vitest run tools/mesh-transport-proxy/src/proxy.test.mjs",
     "dev:web": "pnpm --dir apps/mesh-explorer-webapp dev:normal",
-    "dev:web:proxy": "pnpm --dir apps/mesh-explorer-webapp dev:proxy"
+    "dev:web:proxy": "pnpm --dir apps/mesh-explorer-webapp dev:proxy",
+    "dev:lab": "node scripts/dev-lab.mjs"
   },
   "devDependencies": {
     "typescript": "^5.6.3",

--- a/scripts/dev-lab.mjs
+++ b/scripts/dev-lab.mjs
@@ -1,0 +1,57 @@
+import { spawn } from "node:child_process";
+
+const processes = [
+  { name: "backend", color: "\x1b[32m", command: "pnpm", args: ["graph-server"] },
+  { name: "proxy", color: "\x1b[35m", command: "pnpm", args: ["dev:transport-proxy"] },
+  { name: "web", color: "\x1b[36m", command: "pnpm", args: ["dev:web"] },
+  { name: "web-proxy", color: "\x1b[33m", command: "pnpm", args: ["dev:web:proxy"] }
+];
+
+const reset = "\x1b[0m";
+const children = [];
+let shuttingDown = false;
+
+function prefix(name, color, chunk) {
+  const lines = chunk.toString().split(/\r?\n/);
+  return lines
+    .filter((line) => line.length > 0)
+    .map((line) => `${color}[${name}]${reset} ${line}`)
+    .join("\n");
+}
+
+function shutdown(code = 0) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  for (const child of children) {
+    if (!child.killed) child.kill("SIGTERM");
+  }
+  setTimeout(() => process.exit(code), 150);
+}
+
+for (const proc of processes) {
+  const child = spawn(proc.command, proc.args, {
+    env: process.env,
+    stdio: ["inherit", "pipe", "pipe"],
+    shell: process.platform === "win32"
+  });
+  children.push(child);
+
+  child.stdout.on("data", (chunk) => {
+    const text = prefix(proc.name, proc.color, chunk);
+    if (text) process.stdout.write(`${text}\n`);
+  });
+  child.stderr.on("data", (chunk) => {
+    const text = prefix(proc.name, proc.color, chunk);
+    if (text) process.stderr.write(`${text}\n`);
+  });
+
+  child.on("exit", (code) => {
+    if (!shuttingDown && code && code !== 0) {
+      console.error(`${proc.color}[${proc.name}]${reset} exited with code ${code}. Stopping dev lab.`);
+      shutdown(code);
+    }
+  });
+}
+
+process.on("SIGINT", () => shutdown(0));
+process.on("SIGTERM", () => shutdown(0));


### PR DESCRIPTION
### Motivation
- Remove shell-specific inline env injection in dev scripts so dev commands work cross-platform (Windows + POSIX) and keep dev routing logic where Vite users expect it. 
- Provide a single, repeatable command to launch the manual two-tab proxy test stack for easier local validation.

### Description
- Moved webapp dev routing and port logic into `apps/mesh-explorer-webapp/vite.config.ts` using Vite `mode` and `loadEnv` to produce deterministic defaults (`development` -> port `5173`, subscribe `:8090`; `proxy` -> port `5174`, subscribe `:8091`) while allowing `MESH_*` env overrides. 
- Replaced inline env script hacks with portable scripts in `apps/mesh-explorer-webapp/package.json`: `dev:normal` -> `vite --mode development` and `dev:proxy` -> `vite --mode proxy`. 
- Added a minimal dev-only runtime visibility signal in `apps/mesh-explorer-webapp/src/main.ts` that logs `mode`, `apiBaseUrl`, and `subscribeBaseUrl` to the browser console when `import.meta.env.DEV` is true. 
- Added one-command orchestration `pnpm dev:lab` at the repo root implemented by `scripts/dev-lab.mjs` which starts backend, transport proxy, normal web, and proxy-backed web with prefixed logs and coordinated shutdown. 
- Updated documentation `docs/HOW_TO_transport_proxy.md` to document the mode-based setup, two-tab URLs, and the dev-console routing visibility check.

### Testing
- Ran `pnpm --dir apps/mesh-explorer-webapp predev` to build required local packages and it completed successfully (OK). 
- Ran proxy unit tests with `pnpm test:transport-proxy` and the suite passed (5 tests) (OK). 
- Verified dev servers start: `pnpm dev:web` reached Vite ready on `http://127.0.0.1:5173` and `pnpm dev:web:proxy` reached Vite ready on `http://127.0.0.1:5174` during short-timeout checks (servers reported ready before timeout) (OK). 
- Verified `pnpm dev:lab` starts all four processes and they reported expected listening addresses (`:8090`, `:8091`, `:5173`, `:5174`) during a timed run (OK).

Known limitations: node engine mismatch warnings were observed in the test container (repo requests Node `20.11.1` while environment used `v22.x`) but the dev commands still reached ready state; earlier attempts to add an external orchestrator package failed to fetch in this environment, so orchestration was implemented with a small `scripts/dev-lab.mjs` script and no new external dependencies were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af59b5d5148321968f882316283166)