### PR TITLE
Fix dev/proxy routing env isolation for subscribe URL

### DIFF
--- a/apps/mesh-explorer-webapp/src/devRouting.test.ts
+++ b/apps/mesh-explorer-webapp/src/devRouting.test.ts
@@ -1,6 +1,46 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveDevRoutingConfig, resolveRoutingDiagnostic } from "./devRouting";
+import { resolveDevRoutingConfig, resolveModeScopedRoutingEnv, resolveRoutingDiagnostic } from "./devRouting";
+
+describe("resolveModeScopedRoutingEnv", () => {
+  it("ignores ambient generic overrides in development mode", () => {
+    const resolved = resolveModeScopedRoutingEnv("development", {
+      MESH_API_BASE_URL: "http://127.0.0.1:9000",
+      MESH_SUBSCRIBE_BASE_URL: "http://127.0.0.1:9001"
+    });
+
+    expect(resolved).toEqual({
+      MESH_API_BASE_URL: undefined,
+      MESH_SUBSCRIBE_BASE_URL: undefined
+    });
+  });
+
+  it("uses generic overrides in proxy mode", () => {
+    const resolved = resolveModeScopedRoutingEnv("proxy", {
+      MESH_API_BASE_URL: "http://127.0.0.1:9000",
+      MESH_SUBSCRIBE_BASE_URL: "http://127.0.0.1:9001"
+    });
+
+    expect(resolved).toEqual({
+      MESH_API_BASE_URL: "http://127.0.0.1:9000",
+      MESH_SUBSCRIBE_BASE_URL: "http://127.0.0.1:9001"
+    });
+  });
+
+  it("prefers mode-scoped overrides when provided", () => {
+    const development = resolveModeScopedRoutingEnv("development", {
+      MESH_SUBSCRIBE_BASE_URL: "http://127.0.0.1:9001",
+      MESH_SUBSCRIBE_BASE_URL_DEVELOPMENT: "http://127.0.0.1:8090"
+    });
+    const proxy = resolveModeScopedRoutingEnv("proxy", {
+      MESH_SUBSCRIBE_BASE_URL: "http://127.0.0.1:9001",
+      MESH_SUBSCRIBE_BASE_URL_PROXY: "http://127.0.0.1:8091"
+    });
+
+    expect(development.MESH_SUBSCRIBE_BASE_URL).toBe("http://127.0.0.1:8090");
+    expect(proxy.MESH_SUBSCRIBE_BASE_URL).toBe("http://127.0.0.1:8091");
+  });
+});
 
 describe("resolveDevRoutingConfig", () => {
   it("uses development defaults", () => {
@@ -22,6 +62,18 @@ describe("resolveDevRoutingConfig", () => {
     });
     expect(resolved.apiBaseUrl).toBe("http://127.0.0.1:9000");
     expect(resolved.subscribeBaseUrl).toBe("http://127.0.0.1:9001");
+  });
+
+  it("keeps development and proxy resolution isolated when run sequentially", () => {
+    const ambientProxyEnv = {
+      MESH_SUBSCRIBE_BASE_URL: "http://127.0.0.1:8091"
+    };
+
+    const proxy = resolveDevRoutingConfig("proxy", resolveModeScopedRoutingEnv("proxy", ambientProxyEnv));
+    const development = resolveDevRoutingConfig("development", resolveModeScopedRoutingEnv("development", ambientProxyEnv));
+
+    expect(proxy.subscribeBaseUrl).toBe("http://127.0.0.1:8091");
+    expect(development.subscribeBaseUrl).toBe("http://127.0.0.1:8090");
   });
 });
 

--- a/apps/mesh-explorer-webapp/src/devRouting.ts
+++ b/apps/mesh-explorer-webapp/src/devRouting.ts
@@ -15,6 +15,22 @@ export const PROXY_ROUTING_DEFAULTS: DevRoutingDefaults = {
   subscribeBaseUrl: "http://127.0.0.1:8091"
 };
 
+function readModeScopedOverride(
+  env: Record<string, string | undefined>,
+  baseKey: "MESH_API_BASE_URL" | "MESH_SUBSCRIBE_BASE_URL",
+  mode: string
+): string | undefined {
+  const suffix = mode === "proxy" ? "PROXY" : "DEVELOPMENT";
+  return env[`${baseKey}_${suffix}`] ?? (mode === "proxy" ? env[baseKey] : undefined);
+}
+
+export function resolveModeScopedRoutingEnv(mode: string, env: Record<string, string | undefined>): Record<string, string | undefined> {
+  return {
+    MESH_API_BASE_URL: readModeScopedOverride(env, "MESH_API_BASE_URL", mode),
+    MESH_SUBSCRIBE_BASE_URL: readModeScopedOverride(env, "MESH_SUBSCRIBE_BASE_URL", mode)
+  };
+}
+
 export function resolveDevRoutingConfig(mode: string, env: Record<string, string | undefined>): DevRoutingDefaults {
   const defaults = mode === "proxy" ? PROXY_ROUTING_DEFAULTS : DEVELOPMENT_ROUTING_DEFAULTS;
   return {

--- a/apps/mesh-explorer-webapp/vite.config.ts
+++ b/apps/mesh-explorer-webapp/vite.config.ts
@@ -1,11 +1,12 @@
 import { defineConfig, loadEnv } from "vite";
 
-import { resolveDevRoutingConfig } from "./src/devRouting";
+import { resolveDevRoutingConfig, resolveModeScopedRoutingEnv } from "./src/devRouting";
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "MESH_");
+  const routingEnv = resolveModeScopedRoutingEnv(mode, env);
   const isProxyMode = mode === "proxy";
-  const { apiBaseUrl, subscribeBaseUrl } = resolveDevRoutingConfig(mode, env);
+  const { apiBaseUrl, subscribeBaseUrl } = resolveDevRoutingConfig(mode, routingEnv);
 
   return {
     envPrefix: ["VITE_", "MESH_"],


### PR DESCRIPTION
### Motivation
- The development web entry was intermittently resolving `subscribeBaseUrl` to the proxy transport (`:8091`) because ambient `MESH_SUBSCRIBE_BASE_URL` from the environment leaked into the normal dev entry. 
- The intent is to deterministically isolate mode-specific env wiring so `development` never inherits proxy-only overrides while `proxy` mode can still be explicitly configured.

### Description
- Added a mode-aware env projection `resolveModeScopedRoutingEnv(mode, env)` in `apps/mesh-explorer-webapp/src/devRouting.ts` that prefers `MESH_*_PROXY` or `MESH_*_DEVELOPMENT` and prevents generic ambient `MESH_*` from contaminating `development` mode.
- Changed `apps/mesh-explorer-webapp/vite.config.ts` to call `resolveModeScopedRoutingEnv(...)` on the `loadEnv(...)` output before computing the routing config so Vite-defined `import.meta.env.MESH_*` values are mode-scoped.
- Added focused tests in `apps/mesh-explorer-webapp/src/devRouting.test.ts` to cover mode-scoped overrides, precedence, and sequential isolation behavior.
- Files changed: `apps/mesh-explorer-webapp/src/devRouting.ts`, `apps/mesh-explorer-webapp/vite.config.ts`, and `apps/mesh-explorer-webapp/src/devRouting.test.ts`.
- Root cause: passing `loadEnv(...)` directly to routing resolution allowed a generic `MESH_SUBSCRIBE_BASE_URL` to be used by the `development` entry; the fix enforces explicit mode-scoped env projection so `development` ignores generic proxy overrides.
- Effect: normal entry (`pnpm dev:web` / `:5173`) now resolves `subscribeBaseUrl` to `http://127.0.0.1:8090`, and proxy entry (`pnpm dev:web:proxy` / `:5174`) resolves `subscribeBaseUrl` to `http://127.0.0.1:8091`.

### Testing
- OK: `pnpm vitest run apps/mesh-explorer-webapp/src/devRouting.test.ts` — all tests passed (`8 passed`).
- OK: workspace build with prebuilt UI packages via `pnpm -r --filter @mesh/mesh-explorer-webapp... build` — produced a successful `apps/mesh-explorer-webapp` build.
- OK: `pnpm test:transport-proxy` — transport-proxy tests passed.
- Known limitation: running `pnpm --dir apps/mesh-explorer-webapp build` in a cold workspace (without dependent packages prebuilt) fails due to unrelated workspace package entry resolution, but the workspace-filtered build succeeds and reproduces the final artifact as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b038553b988321baab60e68f114fef)