### PR TITLE
Make transport proxy mode changes runtime-effective for active sync:subscribe SSE streams

### DIFF
--- a/docs/HOW_TO_transport_proxy.md
+++ b/docs/HOW_TO_transport_proxy.md
@@ -74,6 +74,10 @@ Modes:
 - `hang`
 - `close`
 
+Runtime behavior note:
+- Switching to `hang`, `fail`, or `close` immediately terminates any active `sync:subscribe` stream, so the new mode is visible right away on reconnect/new subscribe.
+- You no longer need a manual `close` pre-step before toggling between `pass` / `hang` / `fail`.
+
 ## Invariant
 
 Normal dev entry must never route subscribe through proxy.

--- a/docs/validation/transport-proxy-manual-checklist.md
+++ b/docs/validation/transport-proxy-manual-checklist.md
@@ -12,15 +12,15 @@
 4. Check proxy logs for intercepted subscribe pass-through.
 
 ## Fail mode
-1. `POST /__test/transport/mode` with `{"subscribeMode":"fail"}`.
-2. Reconnect subscribe from Tab B.
-3. Verify deterministic non-2xx response.
+1. Keep an active subscribe stream open in Tab B, then `POST /__test/transport/mode` with `{"subscribeMode":"fail"}`.
+2. Verify the active stream is terminated immediately (no manual `close` detour).
+3. Reconnect subscribe from Tab B and verify deterministic non-2xx response.
 4. Verify non-subscribe routes still work via proxy.
 
 ## Hang mode
-1. Set mode to `hang`.
-2. Trigger subscribe from Tab B.
-3. Verify request stays pending and no events delivered.
+1. Keep an active subscribe stream open in Tab B, then set mode to `hang`.
+2. Verify the active stream is terminated immediately (no manual `close` detour).
+3. Trigger subscribe from Tab B and verify request stays pending with no events delivered.
 4. Trigger mutation in Tab A; verify no pushed update in Tab B.
 5. Verify non-subscribe routes still work.
 

--- a/tools/mesh-transport-proxy/src/proxy.mjs
+++ b/tools/mesh-transport-proxy/src/proxy.mjs
@@ -154,6 +154,9 @@ export class MeshTransportProxy {
       this.closeStream(stream);
     }
 
+    this.server.closeAllConnections?.();
+    this.server.closeIdleConnections?.();
+
     await new Promise((resolve, reject) => {
       this.server.close((error) => {
         if (error) {
@@ -181,15 +184,12 @@ export class MeshTransportProxy {
 
     const previousMode = this.subscribeMode;
     this.subscribeMode = nextMode;
-    this.logger.info(`[transport-proxy] mode ${previousMode} -> ${nextMode}`);
+    const activeCount = this.activeSubscribeStreams.size;
+    this.logger.info(`[transport-proxy] mode ${previousMode} -> ${nextMode} activeSubscribeStreams=${activeCount}`);
 
-    if (nextMode === "close") {
-      for (const stream of this.activeSubscribeStreams) {
-        if (stream.clientResponse.writableEnded || stream.clientResponse.destroyed) {
-          continue;
-        }
-        stream.closeTimer = setTimeout(() => this.closeStream(stream), this.options.closeDelayMs);
-      }
+    if (nextMode !== "pass") {
+      this.logger.info(`[transport-proxy] terminating active subscribe streams count=${activeCount} mode=${nextMode}`);
+      this.terminateActiveSubscribeStreams(`mode:${nextMode}`);
     }
 
     return { ok: true, subscribeMode: this.subscribeMode };
@@ -261,14 +261,7 @@ export class MeshTransportProxy {
           connection: "keep-alive"
         });
 
-        const stream = { clientResponse: res };
-        this.activeSubscribeStreams.add(stream);
-        req.on("close", () => {
-          this.activeSubscribeStreams.delete(stream);
-        });
-        res.on("close", () => {
-          this.activeSubscribeStreams.delete(stream);
-        });
+        this.trackSubscribeStream({ clientResponse: res, clientRequest: req });
         return;
       }
       case "close": {
@@ -286,10 +279,10 @@ export class MeshTransportProxy {
 
     let activeStream;
     if (options?.trackSubscribeStream) {
-      activeStream = { clientResponse: res, upstreamRequest: upstreamReq };
-      this.activeSubscribeStreams.add(activeStream);
-      res.on("close", () => {
-        this.activeSubscribeStreams.delete(activeStream);
+      activeStream = this.trackSubscribeStream({
+        clientRequest: req,
+        clientResponse: res,
+        upstreamRequest: upstreamReq
       });
     }
 
@@ -299,6 +292,7 @@ export class MeshTransportProxy {
 
       if (activeStream) {
         activeStream.upstreamResponse = upstreamRes;
+        upstreamRes.on("close", () => this.activeSubscribeStreams.delete(activeStream));
         if (options?.forceClose) {
           activeStream.closeTimer = setTimeout(() => this.closeStream(activeStream), this.options.closeDelayMs);
         }
@@ -336,6 +330,30 @@ export class MeshTransportProxy {
     stream.upstreamRequest?.destroy();
     stream.clientResponse.destroy();
     this.activeSubscribeStreams.delete(stream);
+  }
+
+  terminateActiveSubscribeStreams(reason) {
+    for (const stream of this.activeSubscribeStreams) {
+      if (stream.clientResponse.writableEnded || stream.clientResponse.destroyed) {
+        this.activeSubscribeStreams.delete(stream);
+        continue;
+      }
+      this.logger.info(`[transport-proxy] force-closing subscribe stream reason=${reason}`);
+      this.closeStream(stream);
+    }
+  }
+
+  trackSubscribeStream(stream) {
+    this.activeSubscribeStreams.add(stream);
+
+    const cleanup = () => {
+      this.activeSubscribeStreams.delete(stream);
+    };
+
+    stream.clientRequest?.on("aborted", cleanup);
+    stream.clientResponse?.on("close", cleanup);
+
+    return stream;
   }
 
   async readJsonBody(req) {

--- a/tools/mesh-transport-proxy/src/proxy.test.mjs
+++ b/tools/mesh-transport-proxy/src/proxy.test.mjs
@@ -37,6 +37,8 @@ function createUpstreamServer() {
       resolve({
         baseUrl: `http://127.0.0.1:${server.address().port}`,
         close: async () => {
+          server.closeAllConnections?.();
+          server.closeIdleConnections?.();
           await new Promise((resolveClose, rejectClose) => {
             server.close((error) => {
               if (error) {
@@ -53,13 +55,81 @@ function createUpstreamServer() {
   });
 }
 
-async function createProxy(upstreamBaseUrl) {
+function readOneChunk(stream) {
+  return new Promise((resolve, reject) => {
+    const onData = (chunk) => {
+      cleanup();
+      resolve(chunk);
+    };
+    const onEnd = () => {
+      cleanup();
+      resolve(null);
+    };
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+
+    const cleanup = () => {
+      stream.off("data", onData);
+      stream.off("end", onEnd);
+      stream.off("error", onError);
+    };
+
+    stream.on("data", onData);
+    stream.on("end", onEnd);
+    stream.on("error", onError);
+  });
+}
+
+function openRawSse(baseUrl, path = "/v1/test/sync:subscribe") {
+  const url = new URL(path, baseUrl);
+  return new Promise((resolve, reject) => {
+    const req = http.request(url, { method: "GET" }, (res) => {
+      resolve({ req, res });
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+function setMode(baseUrl, subscribeMode) {
+  return fetch(`${baseUrl}/__test/transport/mode`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ subscribeMode })
+  });
+}
+
+
+
+
+
+
+async function closeFetchResponse(response) {
+  if (response.body) {
+    await response.body.cancel();
+  }
+}
+
+async function waitForActiveStreamCount(proxy, expected, timeoutMs = 300) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    if (proxy.activeSubscribeStreams.size === expected) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  expect(proxy.activeSubscribeStreams.size).toBe(expected);
+}
+
+async function createProxy(upstreamBaseUrl, logger = { info: () => undefined, warn: () => undefined, error: () => undefined }) {
   const proxy = new MeshTransportProxy({
     host: "127.0.0.1",
     port: 0,
     upstreamBaseUrl,
     closeDelayMs: 20,
-    logger: { info: () => undefined, warn: () => undefined, error: () => undefined }
+    logger
   });
 
   await proxy.listen();
@@ -124,8 +194,6 @@ describe("MeshTransportProxy control + routing", () => {
     }
   });
 
-
-
   it("serves a minimal dev/test browser control UI", async () => {
     const upstream = await createUpstreamServer();
     closeables.push(upstream);
@@ -150,22 +218,80 @@ describe("MeshTransportProxy control + routing", () => {
     const { baseUrl, proxy } = await createProxy(upstream.baseUrl);
     closeables.push(proxy);
 
-    await fetch(`${baseUrl}/__test/transport/mode`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ subscribeMode: "fail" })
-    });
+    await setMode(baseUrl, "fail");
 
     const failSubscribe = await fetch(`${baseUrl}/v1/test/sync:subscribe`);
     expect(failSubscribe.status).toBe(503);
 
-    await fetch(`${baseUrl}/__test/transport/mode`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ subscribeMode: "pass" })
-    });
+    await setMode(baseUrl, "pass");
 
     const passSubscribe = await fetch(`${baseUrl}/v1/test/sync:subscribe`);
     expect(passSubscribe.status).toBe(200);
+    await closeFetchResponse(passSubscribe);
+  });
+
+  it("terminates active subscribe streams for non-pass mode transitions", async () => {
+    const proxy = new MeshTransportProxy({
+      host: "127.0.0.1",
+      port: 0,
+      upstreamBaseUrl: "http://127.0.0.1:8090",
+      closeDelayMs: 20,
+      logger: { info: () => undefined, warn: () => undefined, error: () => undefined }
+    });
+
+    const makeStream = () => {
+      const stream = {
+        clientResponse: {
+          writableEnded: false,
+          destroyed: false,
+          destroy: () => {
+            stream.clientResponse.destroyed = true;
+          }
+        },
+        upstreamRequest: { destroy: () => undefined },
+        upstreamResponse: { destroy: () => undefined }
+      };
+      return stream;
+    };
+
+    proxy.activeSubscribeStreams.add(makeStream());
+    proxy.setMode("hang");
+    expect(proxy.activeSubscribeStreams.size).toBe(0);
+
+    proxy.activeSubscribeStreams.add(makeStream());
+    proxy.setMode("fail");
+    expect(proxy.activeSubscribeStreams.size).toBe(0);
+
+    proxy.activeSubscribeStreams.add(makeStream());
+    proxy.setMode("close");
+    expect(proxy.activeSubscribeStreams.size).toBe(0);
+  });
+
+  it("logs mode transitions with active subscribe stream handling", async () => {
+    const logs = [];
+    const logger = {
+      info: (message) => logs.push(String(message)),
+      warn: () => undefined,
+      error: () => undefined
+    };
+
+    const upstream = await createUpstreamServer();
+    closeables.push(upstream);
+    const { baseUrl, proxy } = await createProxy(upstream.baseUrl, logger);
+    closeables.push(proxy);
+
+    const active = await openRawSse(baseUrl);
+    expect(active.res.statusCode).toBe(200);
+    await readOneChunk(active.res);
+    await waitForActiveStreamCount(proxy, 1);
+
+    const modeResponse = await setMode(baseUrl, "fail");
+    expect(modeResponse.status).toBe(200);
+    await waitForActiveStreamCount(proxy, 0);
+    active.req.destroy();
+
+    expect(logs.some((line) => line.includes("mode pass -> fail activeSubscribeStreams=1"))).toBe(true);
+    expect(logs.some((line) => line.includes("terminating active subscribe streams count=1 mode=fail"))).toBe(true);
+    expect(logs.some((line) => line.includes("force-closing subscribe stream reason=mode:fail"))).toBe(true);
   });
 });


### PR DESCRIPTION
### Motivation
- The proxy only applied `subscribeMode` semantics at new request time, so switching modes like `hang`/`fail` did not affect already-active `sync:subscribe` SSE connections. 
- The goal is to make mode toggles runtime-effective for active subscribe streams so `hang`, `fail`, `close`, and `pass` are observable immediately without a manual `close` detour. 
- Keep the change limited to the dev/test transport proxy surface and preserve non-subscribe routing semantics.
- Refs #183
### Description
- Track active subscribe streams with an explicit `activeSubscribeStreams` set and a `trackSubscribeStream(stream)` helper so each `sync:subscribe` connection is registered and cleaned up on lifecycle events. (changed: `tools/mesh-transport-proxy/src/proxy.mjs`).
- On mode transitions, compute active count and, for any non-`pass` target mode, call `terminateActiveSubscribeStreams(reason)` which force-closes tracked streams and logs the operations; `setMode` now logs `activeSubscribeStreams` and termination events. (changed: `setMode`, added `terminateActiveSubscribeStreams`).
- Centralized handling for `hang` and pass-through subscribe behavior: `handleSubscribeRequest` uses `trackSubscribeStream` for hanging responses and `forwardRequest` uses tracked streams for proxied subscribe flows; `closeStream` cleans timers and destroys upstream/client handles. (changed: `handleSubscribeRequest`, `forwardRequest`, `closeStream`).
- Added focused tests that exercise runtime toggles and logging (`tools/mesh-transport-proxy/src/proxy.test.mjs`) and updated docs/checklist to state that `hang`/`fail`/`close` immediately affect active `sync:subscribe` streams (`docs/HOW_TO_transport_proxy.md`, `docs/validation/transport-proxy-manual-checklist.md`).

### Testing
- Ran the proxy test suite with `pnpm test:transport-proxy` which executes `tools/mesh-transport-proxy/src/proxy.test.mjs`; all tests passed locally (7 tests). 
- New tests verify that non-`pass` transitions terminate active streams and that transition logging contains active-stream handling messages, and these tests passed. 
- Test run shows a Node engine warning (environment mismatch) but the test assertions succeeded despite the warning.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0771af1c48321b43729390a75c5dd)