### PR TITLE
Persist bootstrap cache after snapshot-only bootstrap replay

### DIFF
--- a/packages/mesh-explorer-ui/src/bootstrapCache.ts
+++ b/packages/mesh-explorer-ui/src/bootstrapCache.ts
@@ -14,6 +14,8 @@ export type BootstrapCacheRecord = {
   schemaVersion: number;
   snapshotVersion?: number;
   projectionVersion?: number;
+  graphSpaceId?: string;
+  principal?: string;
   cursor: Cursor;
   stateDigest: string;
   projection: BootstrapProjection;
@@ -47,11 +49,17 @@ export function computeStateDigest(projection: BootstrapProjection): string {
   return fnv1a64Hex(stableStringify(canonicalProjection));
 }
 
-export function makeBootstrapCacheRecord(cursor: Cursor, projection: BootstrapProjection): BootstrapCacheRecord {
+export function makeBootstrapCacheRecord(
+  cursor: Cursor,
+  projection: BootstrapProjection,
+  metadata?: { graphSpaceId: string; principal: string }
+): BootstrapCacheRecord {
   return {
     schemaVersion: BOOTSTRAP_CACHE_SCHEMA_VERSION,
     snapshotVersion: BOOTSTRAP_SNAPSHOT_VERSION,
     projectionVersion: BOOTSTRAP_PROJECTION_VERSION,
+    graphSpaceId: metadata?.graphSpaceId,
+    principal: metadata?.principal,
     cursor,
     stateDigest: computeStateDigest(projection),
     projection
@@ -85,6 +93,12 @@ export function readBootstrapCacheRecord(storageKey: string, read: (key: string)
     }
     if (!("projectionVersion" in parsed) || (parsed.projectionVersion !== undefined && typeof parsed.projectionVersion !== "number")) {
       parsed.projectionVersion = undefined;
+    }
+    if (!("graphSpaceId" in parsed) || (parsed.graphSpaceId !== undefined && typeof parsed.graphSpaceId !== "string")) {
+      parsed.graphSpaceId = undefined;
+    }
+    if (!("principal" in parsed) || (parsed.principal !== undefined && typeof parsed.principal !== "string")) {
+      parsed.principal = undefined;
     }
     if (!isCursor(parsed.cursor)) return null;
     if (typeof parsed.stateDigest !== "string" || parsed.stateDigest.trim().length === 0) return null;

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -422,7 +422,22 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       finalCursor: replayResult.cursor,
       graphEventsApplied: replayResult.graphEventsApplied
     });
-    persistBootstrapCursor(storageKey, bootstrapCacheKey, snapshotCursor, replayResult.cursor, !bootstrapReplayPending);
+    const bootstrapCachePersisted = persistBootstrapCursor(
+      storageKey,
+      bootstrapCacheKey,
+      snapshotCursor,
+      replayResult.cursor,
+      !bootstrapReplayPending,
+      bootstrapDecision.reason === "snapshot-only-cache-missing",
+      el.graphSpaceId.value,
+      normalizedPrincipal
+    );
+    if (bootstrapCachePersisted && bootstrapDecision.reason === "snapshot-only-cache-missing") {
+      emitMeshDebugLog("BOOTSTRAP_CACHE_PERSISTED", {
+        cursor: replayResult.cursor,
+        projectionVersion: BOOTSTRAP_PROJECTION_VERSION
+      });
+    }
     setConnectionStatus("connected (poll-only)");
     void subscribeLoop(sessionId, activeAbort.signal);
 
@@ -490,7 +505,16 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
                   });
                   const replayResult = await pollReplayFromCursor(fromCursor, activeSessionId, signal, "pull");
                   if (activeSessionId !== syncSession) return;
-                  persistBootstrapCursor(storageKey, bootstrapCacheKey, fromCursor, replayResult.cursor, !bootstrapReplayPending);
+                  persistBootstrapCursor(
+                    storageKey,
+                    bootstrapCacheKey,
+                    fromCursor,
+                    replayResult.cursor,
+                    !bootstrapReplayPending,
+                    false,
+                    el.graphSpaceId.value,
+                    normalizedPrincipal
+                  );
                   continue;
                 }
 
@@ -1128,7 +1152,14 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       });
       return true;
     }
-    persistDurableBootstrapState(storageKey, bootstrapCacheKey, candidate, createProjectionSnapshot(store));
+    persistDurableBootstrapState(
+      storageKey,
+      bootstrapCacheKey,
+      candidate,
+      createProjectionSnapshot(store),
+      el.graphSpaceId.value,
+      normalizedPrincipal
+    );
     emitMeshDebugLog("BOOTSTRAP_CACHE_WRITE_COMMITTED", {
       source,
       cursor: candidate
@@ -1158,16 +1189,30 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     bootstrapCacheKey: string,
     fromCursor: Cursor,
     finalCursor: Cursor,
-    replayComplete: boolean
-  ): void {
+    replayComplete: boolean,
+    forcePersist: boolean,
+    graphSpaceId: string,
+    principal: string
+  ): boolean {
     const current = store.getState().cursor;
-    if (!shouldPersistBootstrapCursor(fromCursor, finalCursor, current, replayComplete)) return;
+    const shouldPersist = forcePersist
+      ? replayComplete && compareCursor(finalCursor, current) >= 0
+      : shouldPersistBootstrapCursor(fromCursor, finalCursor, current, replayComplete);
+    if (!shouldPersist) return false;
     store.setCursor(finalCursor);
-    persistDurableBootstrapState(storageKey, bootstrapCacheKey, finalCursor, createProjectionSnapshot(store));
+    persistDurableBootstrapState(
+      storageKey,
+      bootstrapCacheKey,
+      finalCursor,
+      createProjectionSnapshot(store),
+      graphSpaceId,
+      principal
+    );
     emitMeshDebugLog("BOOTSTRAP_CACHE_WRITE_COMMITTED", {
       source: "bootstrap-finalize",
       cursor: finalCursor
     });
+    return true;
   }
 
   function setRendererMode(mode: "canvas-2d" | "fallback-json"): void {
@@ -1419,9 +1464,11 @@ function persistDurableBootstrapState(
   cursorStorage: string,
   cacheStorage: string,
   cursor: Cursor,
-  projection: ReturnType<typeof createProjectionSnapshot>
+  projection: ReturnType<typeof createProjectionSnapshot>,
+  graphSpaceId: string,
+  principal: string
 ): void {
-  const record = makeBootstrapCacheRecord(cursor, projection);
+  const record = makeBootstrapCacheRecord(cursor, projection, { graphSpaceId, principal });
   persistBootstrapCacheRecord(cacheStorage, cursorStorage, record, (key, value) => localStorage.setItem(key, value));
 }
 

--- a/packages/mesh-explorer-ui/test/bootstrapCache.test.ts
+++ b/packages/mesh-explorer-ui/test/bootstrapCache.test.ts
@@ -94,4 +94,29 @@ describe("bootstrap cache digest", () => {
     expect(read?.projectionVersion).toBe(BOOTSTRAP_PROJECTION_VERSION);
   });
 
+  it("persists graphSpaceId and principal in bootstrap metadata", () => {
+    const record = makeBootstrapCacheRecord(
+      { metaSeq: 1, graphSeq: 3 },
+      { version: 1, nodes: [{ id: "n1", label: "A" }], links: [] },
+      { graphSpaceId: "g1", principal: "alice" }
+    );
+
+    expect(record.graphSpaceId).toBe("g1");
+    expect(record.principal).toBe("alice");
+  });
+
+  it("restores graphSpaceId and principal through storage round-trip", () => {
+    const stored = JSON.stringify(
+      makeBootstrapCacheRecord(
+        { metaSeq: 1, graphSeq: 3 },
+        { version: 1, nodes: [{ id: "n1", label: "A" }], links: [] },
+        { graphSpaceId: "g1", principal: "alice" }
+      )
+    );
+
+    const read = readBootstrapCacheRecord("mesh.bootstrapCache.alice.g1", () => stored);
+    expect(read?.graphSpaceId).toBe("g1");
+    expect(read?.principal).toBe("alice");
+  });
+
 });

--- a/packages/mesh-explorer-ui/test/bootstrapCursor.test.ts
+++ b/packages/mesh-explorer-ui/test/bootstrapCursor.test.ts
@@ -185,6 +185,29 @@ describe("mesh explorer bootstrap cursor", () => {
     expect(decision.invalidateBootstrapCache).toBe(false);
   });
 
+
+  it("transitions from snapshot-only-cache-missing to snapshot-cursor-cache-verified after cache persist", () => {
+    const snapshotCursor = { metaSeq: 0, graphSeq: 2 };
+    const projection = { version: 1 as const, nodes: [{ id: "n1", label: "A" }], links: [] };
+
+    const firstDecision = resolveBootstrapCursorDecision({
+      savedCursor: null,
+      snapshot: { cursor: snapshotCursor },
+      bootstrapCache: null
+    });
+    expect(firstDecision.reason).toBe("snapshot-only-cache-missing");
+
+    const cache = makeBootstrapCacheRecord(snapshotCursor, projection, { graphSpaceId: "g1", principal: "alice" });
+    const secondDecision = resolveBootstrapCursorDecision({
+      savedCursor: snapshotCursor,
+      snapshot: { cursor: snapshotCursor },
+      bootstrapCache: cache
+    });
+
+    expect(secondDecision.reason).toBe("snapshot-cursor-cache-verified");
+    expect(secondDecision.usedSavedCursor).toBe(true);
+  });
+
   it("writes exact storage key format mesh.cursor.<principal>.<graphSpaceId>", () => {
     expect(cursorStorageKey("local-dev", "mesh-explorer-graph-v1")).toBe("mesh.cursor.local-dev.mesh-explorer-graph-v1");
     expect(bootstrapCacheStorageKey("local-dev", "mesh-explorer-graph-v1")).toBe(


### PR DESCRIPTION
### Motivation
- When a snapshot is used on a fresh client (decision `snapshot-only-cache-missing`), the bootstrap completed successfully but no bootstrap cache was persisted, causing repeated expensive replays on subsequent startups. 
- The change ensures that after a successful snapshot-based bootstrap the UI persists a durable bootstrap cache so subsequent startups can take the fast-path `snapshot-cursor-cache-verified` without changing snapshot or projection semantics. 

### Description
- Persist bootstrap cache once after replay completion by calling `persistBootstrapCursor(...)` immediately after `BOOTSTRAP_REPLAY_COMPLETED` and emit `BOOTSTRAP_CACHE_PERSISTED` when the decision reason was `snapshot-only-cache-missing`. 
- Extend the bootstrap cache record to include optional metadata `graphSpaceId` and `principal` and thread those through `makeBootstrapCacheRecord(...)` and `persistDurableBootstrapState(...)`. 
- Add a `forcePersist` flag and boolean return to `persistBootstrapCursor(...)` so the replay-finalize path can request a single forced write while preserving existing monotonicity and replay-completion guards for other paths. 
- Update all durable-write callsites to reuse `persistDurableBootstrapState(...)` (no duplicated persist logic) and add tests that assert metadata round-trips and the transition from `snapshot-only-cache-missing` to `snapshot-cursor-cache-verified`. 
- Files modified: `packages/mesh-explorer-ui/src/index.ts`, `packages/mesh-explorer-ui/src/bootstrapCache.ts`, `packages/mesh-explorer-ui/test/bootstrapCache.test.ts`, and `packages/mesh-explorer-ui/test/bootstrapCursor.test.ts`. 

### Testing
- Ran unit tests with `pnpm vitest --run packages/mesh-explorer-ui/test/bootstrapCursor.test.ts packages/mesh-explorer-ui/test/bootstrapCache.test.ts packages/mesh-explorer-ui/test/bootstrapConvergence.test.ts` and all tests passed (`3 files, 33 tests, 33 passed`). 
- Added tests: one asserting `graphSpaceId`/`principal` are persisted and restored via `makeBootstrapCacheRecord`/`readBootstrapCacheRecord`, and one asserting the decision transitions from `snapshot-only-cache-missing` to `snapshot-cursor-cache-verified` after a persisted cache. 
- No other automated test suites were modified and no failing tests were observed for the changed units.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1ad169e5083218172670349ec153a)