### PR TITLE
Fix normalizedPrincipal scope error in mesh-explorer UI bootstrap persistence

### DIFF
--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -1158,7 +1158,7 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       candidate,
       createProjectionSnapshot(store),
       el.graphSpaceId.value,
-      normalizedPrincipal
+      normalizePrincipal(el.principal.value)
     );
     emitMeshDebugLog("BOOTSTRAP_CACHE_WRITE_COMMITTED", {
       source,


### PR DESCRIPTION
### Motivation
- A TypeScript build error occurred because `normalizedPrincipal` was referenced out of scope in `applyCursorIfAdvanced`, preventing successful compilation while the intent was to persist a normalized principal for bootstrap caching.

### Description
- Updated `packages/mesh-explorer-ui/src/index.ts` to call `normalizePrincipal(el.principal.value)` inline at the `persistDurableBootstrapState(...)` call site, replacing the out-of-scope `normalizedPrincipal` reference and preserving normalization semantics.

### Testing
- Ran `pnpm --filter @mesh/mesh-explorer-ui build`, which completed successfully and removed the TypeScript error (build OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b3f861548321bca344ad527bc7e4)