### PR TITLE
Add bootstrap snapshot selection observability fields

### DIFF
--- a/packages/mesh-explorer-ui/src/bootstrapSnapshotObservability.ts
+++ b/packages/mesh-explorer-ui/src/bootstrapSnapshotObservability.ts
@@ -1,0 +1,29 @@
+export type SnapshotCursor = { metaSeq: number; graphSeq: number };
+
+export type SnapshotSummary = { snapshotId: string };
+
+export type BootstrapSnapshotSelectionDetails = {
+  snapshotId: string;
+  snapshotIndex: number;
+  snapshotCount: number;
+  snapshotCursor: SnapshotCursor;
+};
+
+/**
+ * Returns zero-based snapshot ranking metadata for bootstrap observability.
+ */
+export function resolveBootstrapSnapshotSelectionDetails(
+  selectedSnapshotId: string | null,
+  selectedSnapshotCursor: SnapshotCursor,
+  snapshots: SnapshotSummary[]
+): BootstrapSnapshotSelectionDetails | null {
+  if (!selectedSnapshotId || snapshots.length === 0) return null;
+  const snapshotIndex = snapshots.findIndex((entry) => entry.snapshotId === selectedSnapshotId);
+  if (snapshotIndex < 0) return null;
+  return {
+    snapshotId: selectedSnapshotId,
+    snapshotIndex,
+    snapshotCount: snapshots.length,
+    snapshotCursor: selectedSnapshotCursor
+  };
+}

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -42,6 +42,7 @@ import {
   persistBootstrapCacheRecord,
   readBootstrapCacheRecord
 } from "./bootstrapCache.js";
+import { resolveBootstrapSnapshotSelectionDetails } from "./bootstrapSnapshotObservability.js";
 
 type Cursor = { metaSeq: number; graphSeq: number };
 type GraphData = { nodes: GraphNode[]; links: GraphLink[] };
@@ -394,6 +395,14 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
 
     const bootstrapCursor = bootstrapDecision.bootstrapFrom;
     syncIngestionState.cursor = bootstrapCursor;
+    const snapshotSelectionDetails = resolveBootstrapSnapshotSelectionDetails(snapshot.snapshotId, snapshotCursor, snapshot.snapshots);
+    if (snapshotSelectionDetails) {
+      emitMeshDebugLog("BOOTSTRAP_SNAPSHOT_SELECTED", {
+        graphSpaceId: el.graphSpaceId.value,
+        principal: normalizedPrincipal,
+        ...snapshotSelectionDetails
+      });
+    }
     emitMeshDebugLog("BOOTSTRAP_DECISION", {
       graphSpaceId: el.graphSpaceId.value,
       principal: normalizedPrincipal,
@@ -442,16 +451,28 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
     void subscribeLoop(sessionId, activeAbort.signal);
 
 
-    async function fetchSnapshot(principalValue: string): Promise<{ payload?: { nodes?: GraphNode[]; links?: GraphLink[] }; cursor: Cursor }> {
+    async function fetchSnapshot(principalValue: string): Promise<{
+      payload?: { nodes?: GraphNode[]; links?: GraphLink[] };
+      cursor: Cursor;
+      snapshotId: string | null;
+      snapshots: Array<{ snapshotId: string }>;
+    }> {
       const response = await meshFetch(`${el.baseUrl.value}/v1/${encodeURIComponent(el.graphSpaceId.value)}/graph:snapshot`, { headers: headers(principalValue) }, {
         principal: principalValue,
         transport: "fetch",
         debugAuth,
         onNetworkResult: (status) => markNetworkConnectivity(status, "snapshot-bootstrap")
       });
-      if (!response.ok) return { payload: { nodes: [], links: [] }, cursor: { metaSeq: 0, graphSeq: 0 } };
-      const snapshot = (await response.json()) as { payload?: { nodes?: GraphNode[]; links?: GraphLink[] }; cursor?: Cursor };
-      return { payload: snapshot.payload, cursor: snapshot.cursor ?? { metaSeq: 0, graphSeq: 0 } };
+      if (!response.ok) return { payload: { nodes: [], links: [] }, cursor: { metaSeq: 0, graphSeq: 0 }, snapshotId: null, snapshots: [] };
+      const snapshot = (await response.json()) as { snapshotId?: string; payload?: { nodes?: GraphNode[]; links?: GraphLink[] }; cursor?: Cursor };
+      const listedSnapshots = await fetch(`${el.baseUrl.value}/v1/${encodeURIComponent(el.graphSpaceId.value)}/snapshots`, { headers: headers(principalValue) });
+      const snapshots = listedSnapshots.ok ? (await listedSnapshots.json()) as Array<{ snapshotId: string }> : [];
+      return {
+        payload: snapshot.payload,
+        cursor: snapshot.cursor ?? { metaSeq: 0, graphSeq: 0 },
+        snapshotId: snapshot.snapshotId ?? null,
+        snapshots
+      };
     }
 
     function bootstrapFromSnapshot(snapshot: { payload?: { nodes?: GraphNode[]; links?: GraphLink[] }; cursor: Cursor }): void {

--- a/packages/mesh-explorer-ui/test/bootstrapSnapshotObservability.test.ts
+++ b/packages/mesh-explorer-ui/test/bootstrapSnapshotObservability.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { resolveBootstrapSnapshotSelectionDetails } from "../src/bootstrapSnapshotObservability.js";
+
+describe("resolveBootstrapSnapshotSelectionDetails", () => {
+  it("returns selected snapshot metadata using zero-based snapshotIndex", () => {
+    const details = resolveBootstrapSnapshotSelectionDetails(
+      "snapshot-b",
+      { metaSeq: 0, graphSeq: 43 },
+      [{ snapshotId: "snapshot-a" }, { snapshotId: "snapshot-b" }, { snapshotId: "snapshot-c" }]
+    );
+
+    expect(details).toEqual({
+      snapshotId: "snapshot-b",
+      snapshotIndex: 1,
+      snapshotCount: 3,
+      snapshotCursor: { metaSeq: 0, graphSeq: 43 }
+    });
+  });
+
+  it("returns null when there is no selected snapshot match", () => {
+    expect(resolveBootstrapSnapshotSelectionDetails(null, { metaSeq: 0, graphSeq: 0 }, [{ snapshotId: "snapshot-a" }])).toBeNull();
+    expect(resolveBootstrapSnapshotSelectionDetails("snapshot-z", { metaSeq: 0, graphSeq: 0 }, [{ snapshotId: "snapshot-a" }])).toBeNull();
+  });
+});


### PR DESCRIPTION
### Motivation
- Improve bootstrap debug evidence so it's immediately visible which snapshot was chosen and where it sits among candidates without changing selection semantics.
- Keep logging style consistent with existing bootstrap events and maintain a minimal, observability-only patch.

### Description
- Added a small helper `resolveBootstrapSnapshotSelectionDetails` to compute selection metadata (`snapshotId`, `snapshotIndex`, `snapshotCount`, `snapshotCursor`) with an explicit zero-based index convention. (packages/mesh-explorer-ui/src/bootstrapSnapshotObservability.ts)
- Emitted a new debug event `BOOTSTRAP_SNAPSHOT_SELECTED` prior to `BOOTSTRAP_DECISION` that includes `graphSpaceId`, `principal` and the selection metadata. (packages/mesh-explorer-ui/src/index.ts)
- Extended the local snapshot fetch to also request the snapshot list so the rank (`snapshotIndex`) and count (`snapshotCount`) can be derived; this is used for logging only and does not change selection logic. (packages/mesh-explorer-ui/src/index.ts)
- Added focused unit tests that assert the exact emitted fields, the zero-based index convention, and null/no-match behavior. (packages/mesh-explorer-ui/test/bootstrapSnapshotObservability.test.ts)

### Testing
- Ran unit tests: `pnpm vitest run packages/mesh-explorer-ui/test/bootstrapSnapshotObservability.test.ts packages/mesh-explorer-ui/test/meshDebugLog.test.ts` and both test files passed. (4 tests passed total)
- Built the UI package: `pnpm --filter @mesh/mesh-explorer-ui build` completed successfully.
- The patch is observability-only and does not change bootstrap decision or snapshot ordering logic; tests validate stable field names and null-emission cases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b9c0ea9c832185712f151e68f3b8)