### PR TITLE
Harden bootstrap finalization persistence coherence and restart eligibility

### DIFF
--- a/packages/mesh-explorer-ui/src/bootstrapCache.ts
+++ b/packages/mesh-explorer-ui/src/bootstrapCache.ts
@@ -21,6 +21,11 @@ export type BootstrapCacheRecord = {
   projection: BootstrapProjection;
 };
 
+export type BootstrapPersistenceResult = {
+  committed: boolean;
+  phase: "committed" | "cache-write-failed" | "cursor-write-failed";
+};
+
 export function createProjectionSnapshot(store: GraphStore): BootstrapProjection {
   const state = store.getState();
   return {
@@ -70,14 +75,29 @@ export function persistBootstrapCacheRecord(
   storageKey: string,
   cursorStorageKey: string,
   record: BootstrapCacheRecord,
-  write: (key: string, value: string) => void
-): boolean {
+  write: (key: string, value: string) => void,
+  remove: (key: string) => void
+): BootstrapPersistenceResult {
+  // Finalization contract: restart may trust persisted bootstrap artifacts only when
+  // both cache projection and cursor marker are durably written as one logical unit.
+  // If cursor write fails after cache write, cache is removed best-effort so ambiguous
+  // partial persistence resolves to conservative replay on restart.
   try {
     write(storageKey, JSON.stringify(record));
-    write(cursorStorageKey, JSON.stringify(record.cursor));
-    return true;
   } catch {
-    return false;
+    return { committed: false, phase: "cache-write-failed" };
+  }
+
+  try {
+    write(cursorStorageKey, JSON.stringify(record.cursor));
+    return { committed: true, phase: "committed" };
+  } catch {
+    try {
+      remove(storageKey);
+    } catch {
+      // best effort cleanup to keep ambiguous durable state conservative.
+    }
+    return { committed: false, phase: "cursor-write-failed" };
   }
 }
 

--- a/packages/mesh-explorer-ui/src/bootstrapCursor.ts
+++ b/packages/mesh-explorer-ui/src/bootstrapCursor.ts
@@ -28,6 +28,7 @@ export type BootstrapCursorDecision = {
     | "snapshot-only-schema-version-mismatch"
     | "snapshot-only-projection-version-missing"
     | "snapshot-only-projection-version-mismatch"
+    | "snapshot-only-saved-cursor-mismatch"
     | "snapshot-only-cursor-mismatch"
     | "snapshot-only-digest-mismatch"
     | "snapshot-cursor-cache-verified";
@@ -88,6 +89,15 @@ export function resolveBootstrapCursorDecision(input: BootstrapCursorDecisionInp
       bootstrapFrom: normalizedSnapshot,
       usedSavedCursor: false,
       reason: "snapshot-only-projection-version-mismatch",
+      invalidateBootstrapCache: true
+    };
+  }
+
+  if (compareCursor(normalizedSaved, normalizedSnapshot) !== 0) {
+    return {
+      bootstrapFrom: normalizedSnapshot,
+      usedSavedCursor: false,
+      reason: "snapshot-only-saved-cursor-mismatch",
       invalidateBootstrapCache: true
     };
   }

--- a/packages/mesh-explorer-ui/src/index.ts
+++ b/packages/mesh-explorer-ui/src/index.ts
@@ -40,6 +40,7 @@ import {
   hydrateStoreFromProjection,
   makeBootstrapCacheRecord,
   persistBootstrapCacheRecord,
+  type BootstrapPersistenceResult,
   readBootstrapCacheRecord
 } from "./bootstrapCache.js";
 import { resolveBootstrapSnapshotSelectionDetails } from "./bootstrapSnapshotObservability.js";
@@ -1220,8 +1221,12 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       ? replayComplete && compareCursor(finalCursor, current) >= 0
       : shouldPersistBootstrapCursor(fromCursor, finalCursor, current, replayComplete);
     if (!shouldPersist) return false;
-    store.setCursor(finalCursor);
-    persistDurableBootstrapState(
+    emitMeshDebugLog("BOOTSTRAP_FINALIZE_DURABLE_PERSIST_STARTED", {
+      source: "bootstrap-finalize",
+      fromCursor,
+      finalCursor
+    });
+    const persistResult = persistDurableBootstrapState(
       storageKey,
       bootstrapCacheKey,
       finalCursor,
@@ -1229,6 +1234,24 @@ export function mountMeshExplorerUi(container: HTMLElement): void {
       graphSpaceId,
       principal
     );
+    if (!persistResult.committed) {
+      emitMeshDebugLog("BOOTSTRAP_FINALIZE_DURABLE_PERSIST_FAILED", {
+        source: "bootstrap-finalize",
+        fromCursor,
+        finalCursor,
+        phase: persistResult.phase
+      });
+      return false;
+    }
+    emitMeshDebugLog("BOOTSTRAP_FINALIZE_DURABLE_PERSIST_SUCCEEDED", {
+      source: "bootstrap-finalize",
+      finalCursor
+    });
+    store.setCursor(finalCursor);
+    emitMeshDebugLog("BOOTSTRAP_FINALIZE_CURSOR_EXPOSED", {
+      source: "bootstrap-finalize",
+      finalCursor
+    });
     emitMeshDebugLog("BOOTSTRAP_CACHE_WRITE_COMMITTED", {
       source: "bootstrap-finalize",
       cursor: finalCursor
@@ -1488,9 +1511,15 @@ function persistDurableBootstrapState(
   projection: ReturnType<typeof createProjectionSnapshot>,
   graphSpaceId: string,
   principal: string
-): void {
+): BootstrapPersistenceResult {
   const record = makeBootstrapCacheRecord(cursor, projection, { graphSpaceId, principal });
-  persistBootstrapCacheRecord(cacheStorage, cursorStorage, record, (key, value) => localStorage.setItem(key, value));
+  return persistBootstrapCacheRecord(
+    cacheStorage,
+    cursorStorage,
+    record,
+    (key, value) => localStorage.setItem(key, value),
+    (key) => localStorage.removeItem(key)
+  );
 }
 
 async function *parseSse(body: ReadableStream<Uint8Array>): AsyncIterable<SyncFrame> {

--- a/packages/mesh-explorer-ui/test/bootstrapCache.test.ts
+++ b/packages/mesh-explorer-ui/test/bootstrapCache.test.ts
@@ -5,6 +5,7 @@ import {
   BOOTSTRAP_SNAPSHOT_VERSION,
   computeStateDigest,
   makeBootstrapCacheRecord,
+  persistBootstrapCacheRecord,
   readBootstrapCacheRecord
 } from "../src/bootstrapCache.js";
 
@@ -117,6 +118,75 @@ describe("bootstrap cache digest", () => {
     const read = readBootstrapCacheRecord("mesh.bootstrapCache.alice.g1", () => stored);
     expect(read?.graphSpaceId).toBe("g1");
     expect(read?.principal).toBe("alice");
+  });
+
+  it("fails safe when durable cursor marker write fails after cache write", () => {
+    const record = makeBootstrapCacheRecord(
+      { metaSeq: 1, graphSeq: 3 },
+      { version: 1, nodes: [{ id: "n1", label: "A" }], links: [] }
+    );
+    const writes = new Map<string, string>();
+    const removed: string[] = [];
+    const result = persistBootstrapCacheRecord(
+      "mesh.bootstrapCache.alice.g1",
+      "mesh.cursor.alice.g1",
+      record,
+      (key, value) => {
+        if (key.includes("cursor")) throw new Error("cursor write failed");
+        writes.set(key, value);
+      },
+      (key) => {
+        removed.push(key);
+        writes.delete(key);
+      }
+    );
+
+    expect(result).toEqual({ committed: false, phase: "cursor-write-failed" });
+    expect(writes.has("mesh.bootstrapCache.alice.g1")).toBe(false);
+    expect(removed).toContain("mesh.bootstrapCache.alice.g1");
+  });
+
+  it("reports cache write failure and does not attempt cursor write", () => {
+    const record = makeBootstrapCacheRecord(
+      { metaSeq: 1, graphSeq: 3 },
+      { version: 1, nodes: [{ id: "n1", label: "A" }], links: [] }
+    );
+    let writeCalls = 0;
+    const writtenKeys: string[] = [];
+    const result = persistBootstrapCacheRecord(
+      "mesh.bootstrapCache.alice.g1",
+      "mesh.cursor.alice.g1",
+      record,
+      (key) => {
+        writeCalls += 1;
+        writtenKeys.push(key);
+        throw new Error("cache write failed");
+      },
+      () => undefined
+    );
+
+    expect(result).toEqual({ committed: false, phase: "cache-write-failed" });
+    expect(writeCalls).toBe(1);
+    expect(writtenKeys).toEqual(["mesh.bootstrapCache.alice.g1"]);
+  });
+
+  it("commits only when cache and cursor marker both persist", () => {
+    const record = makeBootstrapCacheRecord(
+      { metaSeq: 1, graphSeq: 3 },
+      { version: 1, nodes: [{ id: "n1", label: "A" }], links: [] }
+    );
+    const writes = new Map<string, string>();
+    const result = persistBootstrapCacheRecord(
+      "mesh.bootstrapCache.alice.g1",
+      "mesh.cursor.alice.g1",
+      record,
+      (key, value) => writes.set(key, value),
+      () => undefined
+    );
+
+    expect(result).toEqual({ committed: true, phase: "committed" });
+    expect(writes.has("mesh.bootstrapCache.alice.g1")).toBe(true);
+    expect(writes.has("mesh.cursor.alice.g1")).toBe(true);
   });
 
 });

--- a/packages/mesh-explorer-ui/test/bootstrapConvergence.test.ts
+++ b/packages/mesh-explorer-ui/test/bootstrapConvergence.test.ts
@@ -117,7 +117,7 @@ describe("bootstrap convergence guards", () => {
       snapshot: { cursor: staleSnapshotCursor },
       bootstrapCache: makeBootstrapCacheRecord(savedCursor, { version: 1, nodes: [], links: [] })
     });
-    expect(decision.reason).toBe("snapshot-only-cursor-mismatch");
+    expect(decision.reason).toBe("snapshot-only-saved-cursor-mismatch");
 
     const store = createGraphStore();
     store.setCursor(decision.bootstrapFrom);

--- a/packages/mesh-explorer-ui/test/bootstrapCursor.test.ts
+++ b/packages/mesh-explorer-ui/test/bootstrapCursor.test.ts
@@ -70,7 +70,25 @@ describe("mesh explorer bootstrap cursor", () => {
 
     expect(decision.bootstrapFrom).toEqual({ metaSeq: 1, graphSeq: 4 });
     expect(decision.usedSavedCursor).toBe(false);
-    expect(decision.reason).toBe("snapshot-only-cursor-mismatch");
+    expect(decision.reason).toBe("snapshot-only-saved-cursor-mismatch");
+    expect(decision.invalidateBootstrapCache).toBe(true);
+  });
+
+  it("rejects cache when saved cursor diverges from snapshot cursor", () => {
+    const cache = makeBootstrapCacheRecord(
+      { metaSeq: 2, graphSeq: 8 },
+      { version: 1, nodes: [{ id: "n1", label: "node-1" }], links: [] }
+    );
+
+    const decision = resolveBootstrapCursorDecision({
+      savedCursor: { metaSeq: 2, graphSeq: 9 },
+      snapshot: { cursor: { metaSeq: 2, graphSeq: 8 } },
+      bootstrapCache: cache
+    });
+
+    expect(decision.bootstrapFrom).toEqual({ metaSeq: 2, graphSeq: 8 });
+    expect(decision.usedSavedCursor).toBe(false);
+    expect(decision.reason).toBe("snapshot-only-saved-cursor-mismatch");
     expect(decision.invalidateBootstrapCache).toBe(true);
   });
 

--- a/tests/e2e/mesh-explorer-sync-materialization.spec.ts
+++ b/tests/e2e/mesh-explorer-sync-materialization.spec.ts
@@ -129,7 +129,7 @@ describe("mesh explorer sync materialization", { timeout: 30_000 }, () => {
 
     const secondSession = await runBootstrapSession(server.url, "alice", firstSession.persisted);
     expect(secondSession.decision.usedSavedCursor).toBe(true);
-    expect(secondSession.decision.reason).toBe("saved-cursor-cache-verified");
+    expect(secondSession.decision.reason).toBe("snapshot-cursor-cache-verified");
     expect(secondSession.replay.graphEventsApplied).toBe(0);
     expect(secondSession.store.getState().cursor.graphSeq).toBeGreaterThanOrEqual(firstSession.store.getState().cursor.graphSeq);
     expect(secondSession.store.getState().nodesById.size).toBe(2);


### PR DESCRIPTION
### Motivation
- Prevent a restart-only divergence where the in-memory cursor is advanced but durable bootstrap artifacts (cache + cursor marker) are incomplete or inconsistent, which could cause unsafe fast-path restarts.
- Make bootstrap finalization explicitly atomic at the logical level so that restart eligibility depends only on provably coherent durable state.
- Add diagnosable instrumentation and focused regression tests for partial/failing persistence scenarios.

### Description
- Introduced a small logical-commit protocol for bootstrap artifacts by adding `BootstrapPersistenceResult` and changing `persistBootstrapCacheRecord` to write the cache first and then the durable cursor marker, returning a phase (`committed`, `cache-write-failed`, `cursor-write-failed`) and performing a best-effort cleanup of the cache if the cursor write fails. (`packages/mesh-explorer-ui/src/bootstrapCache.ts`)
- Reordered bootstrap finalization so durable persistence is attempted and validated before exposing the in-memory cursor; added explicit debug events around finalization (`BOOTSTRAP_FINALIZE_DURABLE_PERSIST_STARTED`, `_SUCCEEDED`, `_FAILED`, `BOOTSTRAP_FINALIZE_CURSOR_EXPOSED`) and only call `store.setCursor` after persistence success. (`packages/mesh-explorer-ui/src/index.ts`)
- Added a restart-eligibility guard to reject saved-cursor reuse when the saved cursor diverges from the snapshot cursor by adding the `snapshot-only-saved-cursor-mismatch` reason; this forces conservative fallback to canonical replay when saved artifacts are ambiguous. (`packages/mesh-explorer-ui/src/bootstrapCursor.ts`)
- Tests and expectations updated/added to cover failure semantics: unit tests that simulate cache write failure, cursor write failure (with cleanup verification), successful commit, and saved-vs-snapshot mismatch were added or extended. Test files updated: `packages/mesh-explorer-ui/test/bootstrapCache.test.ts`, `packages/mesh-explorer-ui/test/bootstrapCursor.test.ts`, `packages/mesh-explorer-ui/test/bootstrapConvergence.test.ts`, and one e2e spec expectation updated. (see changes under `packages/mesh-explorer-ui/test/` and `tests/e2e/`)
- Files touched (key): `packages/mesh-explorer-ui/src/bootstrapCache.ts`, `packages/mesh-explorer-ui/src/index.ts`, `packages/mesh-explorer-ui/src/bootstrapCursor.ts`, plus related tests under `packages/mesh-explorer-ui/test/` and `tests/e2e/mesh-explorer-sync-materialization.spec.ts`.

### Testing
- Ran unit tests for the UI bootstrap logic with `vitest` targeting the modified suites and they passed: `packages/mesh-explorer-ui/test/bootstrapCache.test.ts` — OK, `packages/mesh-explorer-ui/test/bootstrapCursor.test.ts` — OK, `packages/mesh-explorer-ui/test/bootstrapConvergence.test.ts` — OK.
- Attempted to run an e2e-targeted test (`tests/e2e/mesh-explorer-sync-materialization.spec.ts -t "CT-A1 e2e restart reuses valid digest cache and keeps cursor monotonic"`); this run failed to start in the current environment due to a package resolution error for `@mesh/sync-local` before tests executed (environment/package-resolution issue), not because of the new logic.
- The new tests explicitly assert the required failure semantics: cache-write failure returns `cache-write-failed`, cursor-write failure returns `cursor-write-failed` and triggers cache cleanup, and full commit returns `committed`; all assertions passed in unit runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1de6d91088321a8b3e9f6a310f2af)